### PR TITLE
feat(crypto): v0.1.1 crypto ops — encrypt/decrypt, wrap/unwrap, rotate, compromise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ All notable changes to Aegis will be documented here. This project follows
 - **`ReadmeQuickstartSpec` in `aegis-core`.** Compiles + runs the embedded-library example from
   `README.md` so that snippet can never silently bitrot. If you change the README's
   "Quickstart — embedding as a library" Scala block, mirror the change in this test.
+- **Compromise operator override across the whole stack (closes #9).** New
+  `compromise(id, reason, by)` method on `KeyService[F[_]]`. Marks the key as `Compromised`;
+  from this state every cryptographic operation — including `verify` — refuses with
+  `KmsError(IllegalOperation, ...)`. (Note: `verify` was previously permitted on any state;
+  this PR tightens it to refuse `Compromised` and `Destroyed`, matching the lock-down
+  semantics described in `docs/ARCHITECTURE.md` §3.) Compromise is one-way: from
+  `{PreActive, Active, Deactivated}` → `Compromised`; `Destroyed` keys cannot be compromised.
+  The mandatory `reason` is a non-empty human-readable justification (e.g. "discovered in S3
+  audit leak 2026-05-08") and ends up on the audit row at `severity=Critical`. Added
+  `Operation.Compromise` to the IAM allowlist enum and a new `KeyEvent.Compromised` journal
+  event with circe codec so the journal replays the state transition deterministically. The
+  state-mutating call routes through `KeyOpsActor` so the journal append + state transition
+  are serialized with the rest of the lifecycle. On the wire: `POST /v1/keys/{id}/compromise`
+  (request: `{reason}`, response: full `ManagedKeyDto`); blank reasons are rejected with 400
+  `InvalidField`. The CLI gained `aegis keys compromise --id <id> --reason "<text>"`.
 - **Wrap / unwrap across the whole stack (closes #7).** New `wrap(id, dek, by)` and
   `unwrap(id, wrappedDek, by)` methods on `KeyService[F[_]]` for KMIP-style envelope
   encryption, with `Operation.Wrap` / `Operation.Unwrap` added to the IAM allowlist enum and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ All notable changes to Aegis will be documented here. This project follows
 - **`ReadmeQuickstartSpec` in `aegis-core`.** Compiles + runs the embedded-library example from
   `README.md` so that snippet can never silently bitrot. If you change the README's
   "Quickstart — embedding as a library" Scala block, mirror the change in this test.
+- **Wrap / unwrap across the whole stack (closes #7).** New `wrap(id, dek, by)` and
+  `unwrap(id, wrappedDek, by)` methods on `KeyService[F[_]]` for KMIP-style envelope
+  encryption, with `Operation.Wrap` / `Operation.Unwrap` added to the IAM allowlist enum and
+  a new `WrappedDek` value type. The `RootOfTrust` SPI gained `wrap` / `unwrapDek`;
+  `AwsKmsRootOfTrust` implements them by delegating to the existing AWS KMS `Encrypt` /
+  `Decrypt` calls with an empty `EncryptionContext` (AWS doesn't expose separate Wrap/Unwrap
+  APIs for symmetric CMKs — this is the conventional wire-up). On the wire:
+  `POST /v1/keys/{id}/wrap` (request: `{dekBase64}`, response: `{wrappedDekBase64}`) and
+  `POST /v1/keys/{id}/unwrap` (request: `{wrappedDekBase64}`, response: `{dekBase64}`). The
+  CLI gained `aegis keys wrap --id <id> --dek <text|@file>` and `aegis keys unwrap --id <id>
+  --wrapped <b64>`. Same state-gate as encrypt/decrypt: wrap requires `Active`; unwrap is
+  permitted on `Active` + `Deactivated` so historical wrapped DEKs remain recoverable across
+  rotations, refused on `Compromised` / `Destroyed`. The `AuditingKeyService` decorator
+  records `dekLen` (not the bytes) so audit logs show what was protected without leaking
+  key material.
 - **Encrypt / decrypt across the whole stack (closes #6).** New
   `encrypt(id, plaintext, context, by)` and `decrypt(id, ciphertext, context, by)` methods on
   `KeyService[F[_]]`, with `Operation.Encrypt` / `Operation.Decrypt` added to the IAM allowlist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,27 @@ All notable changes to Aegis will be documented here. This project follows
 - **`ReadmeQuickstartSpec` in `aegis-core`.** Compiles + runs the embedded-library example from
   `README.md` so that snippet can never silently bitrot. If you change the README's
   "Quickstart — embedding as a library" Scala block, mirror the change in this test.
+- **Encrypt / decrypt across the whole stack (closes #6).** New
+  `encrypt(id, plaintext, context, by)` and `decrypt(id, ciphertext, context, by)` methods on
+  `KeyService[F[_]]`, with `Operation.Encrypt` / `Operation.Decrypt` added to the IAM allowlist
+  enum and a new `Ciphertext` value type. Encryption context (the `Map[String, String]` AAD) is
+  carried as a separate parameter — not embedded in the ciphertext — so the same context must be
+  supplied to both sides, mirroring AWS KMS semantics. A context mismatch on decrypt returns
+  `KmsError(CryptographicFailure, ...)`. The `RootOfTrust` SPI gained the same operations;
+  `AwsKmsRootOfTrust` implements them via the AWS KMS `Encrypt` / `Decrypt` APIs with
+  `EncryptionContext` plumbed through `AwsKmsPort`. On the wire: `POST /v1/keys/{id}/encrypt`
+  (request: `{plaintextBase64, context}`, response: `{ciphertextBase64, context}`) and
+  `POST /v1/keys/{id}/decrypt` (request: `{ciphertextBase64, context}`, response:
+  `{plaintextBase64, context}`). The CLI gained `aegis keys encrypt --id <id> --plaintext
+  <text|@file> [--context k=v,k2=v2]` and `aegis keys decrypt --id <id> --ciphertext <b64>
+  [--context k=v,k2=v2]`. The in-memory `KeyService` uses a deterministic HMAC-keyed
+  XOR-keystream layout (`HMAC(id, ctx) || pt XOR keystream(id, ctx)`) so the dev REST surface
+  has a working round-trip without a real KMS. Encrypt requires the key to be in
+  `KeyState.Active`; decrypt is permitted on `Active` and `Deactivated` keys (so existing
+  ciphertexts remain readable after a future rotation lands), but refused on `Compromised` /
+  `Destroyed`. The `AuditingKeyService` decorator records the **context keys (not values)** and
+  the plaintext length on success, so audit logs surface what was protected without leaking the
+  AAD's payload.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,28 @@ All notable changes to Aegis will be documented here. This project follows
 - **`ReadmeQuickstartSpec` in `aegis-core`.** Compiles + runs the embedded-library example from
   `README.md` so that snippet can never silently bitrot. If you change the README's
   "Quickstart — embedding as a library" Scala block, mirror the change in this test.
+- **Rotate(id, policy) across the whole stack (closes #8).** New
+  `rotate(id, policy, by)` method on `KeyService[F[_]]`. `ManagedKey` gains
+  `currentVersion: Int = 1` (additive — defaulted for back-compat); rotation increments it
+  by one. Legal source state is `Active` only; rotating from any other state returns
+  `KmsError(IllegalOperation, ...)`. The new value type `RotationPolicy` (`Manual |
+  TimeBased(FiniteDuration) | OpCountBased(Long)`) is recorded on the rotation event and
+  audit row — `Manual` for explicit calls today, the auto variants reserved for the v0.2.0
+  scheduler. New `KeyEvent.Rotated(newVersion, policy)` journal event with circe codec so
+  replays restore `currentVersion` deterministically. The "old version stays
+  verifiable/decryptable after rotation" contract from `docs/ARCHITECTURE.md` §3 is
+  preserved without per-version material storage: the in-memory dev backend keys its
+  deterministic MAC by `KeyId` only (so byte output is version-stable), and AWS KMS
+  handles per-version material internally — the same CMK decrypts both pre- and
+  post-rotation ciphertexts. Added `Operation.Rotate` to the IAM allowlist enum;
+  `AuthorizingKeyService` guards via the policy engine; `AuditingKeyService` records
+  `newVersion=N policy=...`; `ActorBackedKeyService.rotate` routes through the actor
+  mailbox for journal-serialized state changes; `PostgresEventJournal` learns the new event
+  kind. On the wire: `POST /v1/keys/{id}/rotate` (request `{policy?}`, response full
+  `ManagedKeyDto` with the bumped `currentVersion`). The CLI gained `aegis keys rotate
+  --id <id> [--policy Manual|TimeBased:7days|OpCountBased:N]`. `ManagedKeyDto` (HTTP +
+  CLI wire shapes) gained the `currentVersion` field; existing JSON without the field
+  decodes as `currentVersion=1` via the case-class default.
 - **Compromise operator override across the whole stack (closes #9).** New
   `compromise(id, reason, by)` method on `KeyService[F[_]]`. Marks the key as `Compromised`;
   from this state every cryptographic operation — including `verify` — refuses with

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -178,6 +178,16 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       AuditRecord(now, by, Operation.Compromise, id.value, outcome, corr)
     }
 
+  def rotate(id: KeyId, policy: RotationPolicy, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument {
+      inner.rotate(id, policy, by)
+    } { (now, corr, result) =>
+      val outcome = result match
+        case Right(k) => s"Success newVersion=${k.currentVersion} policy=${policy.render}"
+        case Left(e)  => s"Failed code=${e.code} policy=${policy.render}"
+      AuditRecord(now, by, Operation.Rotate, id.value, outcome, corr)
+    }
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   /** Threads a fresh correlation id and a wall-clock timestamp through the action and writes the resulting

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -110,6 +110,37 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       AuditRecord(now, by, Operation.Verify, id.value, outcome, corr)
     }
 
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Ciphertext]] =
+    instrument {
+      inner.encrypt(id, plaintext, context, by)
+    } { (now, corr, result) =>
+      val outcome = result match
+        case Right(_) =>
+          s"Success ctxKeys=${context.keys.toSeq.sorted.mkString(",")} ptLen=${plaintext.length}"
+        case Left(e) => s"Failed code=${e.code}"
+      AuditRecord(now, by, Operation.Encrypt, id.value, outcome, corr)
+    }
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    instrument {
+      inner.decrypt(id, ciphertext, context, by)
+    } { (now, corr, result) =>
+      val outcome = result match
+        case Right(pt) => s"Success ctxKeys=${context.keys.toSeq.sorted.mkString(",")} ptLen=${pt.length}"
+        case Left(e)   => s"Failed code=${e.code}"
+      AuditRecord(now, by, Operation.Decrypt, id.value, outcome, corr)
+    }
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   /** Threads a fresh correlation id and a wall-clock timestamp through the action and writes the resulting

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -165,6 +165,19 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       AuditRecord(now, by, Operation.Unwrap, id.value, outcome, corr)
     }
 
+  def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument {
+      inner.compromise(id, reason, by)
+    } { (now, corr, result) =>
+      // Compromise is the highest-severity event in the system. Mark the audit row with the
+      // `severity=Critical` prefix so SIEM ingestion can route on it without re-deriving from
+      // the operation type alone.
+      val outcome = result match
+        case Right(_) => s"severity=Critical Success reason=$reason"
+        case Left(e)  => s"severity=Critical Failed code=${e.code} reason=$reason"
+      AuditRecord(now, by, Operation.Compromise, id.value, outcome, corr)
+    }
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   /** Threads a fresh correlation id and a wall-clock timestamp through the action and writes the resulting

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -141,6 +141,30 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       AuditRecord(now, by, Operation.Decrypt, id.value, outcome, corr)
     }
 
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+    instrument {
+      inner.wrap(id, dek, by)
+    } { (now, corr, result) =>
+      val outcome = result match
+        case Right(_) => s"Success dekLen=${dek.length}"
+        case Left(e)  => s"Failed code=${e.code}"
+      AuditRecord(now, by, Operation.Wrap, id.value, outcome, corr)
+    }
+
+  def unwrap(
+      id: KeyId,
+      wrapped: WrappedDek,
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    instrument {
+      inner.unwrap(id, wrapped, by)
+    } { (now, corr, result) =>
+      val outcome = result match
+        case Right(dek) => s"Success dekLen=${dek.length}"
+        case Left(e)    => s"Failed code=${e.code}"
+      AuditRecord(now, by, Operation.Unwrap, id.value, outcome, corr)
+    }
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   /** Threads a fresh correlation id and a wall-clock timestamp through the action and writes the resulting

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -112,3 +112,34 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     verifyRecords.head.outcome should include("valid=true")
     verifyRecords(1).outcome should include("valid=false")
   }
+
+  test("encrypt emits a Success record carrying the context keys (not values) and plaintext length") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-enc"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    svc.encrypt(created.id, "hello".getBytes, Map("dataset" -> "q2", "tenant" -> "acme"), alice)
+      .unsafeRunSync()
+
+    val encRecord = sink.all.unsafeRunSync().find(_.operation == Operation.Encrypt).get
+    encRecord.outcome should startWith("Success")
+    encRecord.outcome should include("ctxKeys=dataset,tenant")
+    encRecord.outcome should include("ptLen=5")
+    // Critically, the audit must NOT leak the values — only the keys are recorded.
+    encRecord.outcome should not include "q2"
+    encRecord.outcome should not include "acme"
+  }
+
+  test("decrypt with a wrong context emits a Failed record with CryptographicFailure") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-dec"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    val ct = svc.encrypt(created.id, "hi".getBytes, Map("a" -> "1"), alice)
+      .unsafeRunSync().toOption.get
+    svc.decrypt(created.id, ct, Map("a" -> "2"), alice).unsafeRunSync()
+
+    val decRecord = sink.all.unsafeRunSync().find(_.operation == Operation.Decrypt).get
+    decRecord.outcome should startWith("Failed")
+    decRecord.outcome should include("CryptographicFailure")
+  }

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -170,3 +170,16 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     unwrapRecord.outcome should startWith("Success")
     unwrapRecord.outcome should include("dekLen=9")
   }
+
+  test("compromise emits a Critical-severity audit record carrying the reason") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-compromise"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    svc.compromise(created.id, "leaked in S3 audit 2026-05-08", alice).unsafeRunSync()
+
+    val rec = sink.all.unsafeRunSync().find(_.operation == Operation.Compromise).get
+    rec.outcome should startWith("severity=Critical")
+    rec.outcome should include("Success")
+    rec.outcome should include("reason=leaked in S3 audit 2026-05-08")
+  }

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -143,3 +143,30 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     decRecord.outcome should startWith("Failed")
     decRecord.outcome should include("CryptographicFailure")
   }
+
+  test("wrap emits a Success record carrying the DEK length (not the bytes)") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-wrap"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    svc.wrap(created.id, "DEKsecretBytes".getBytes, alice).unsafeRunSync()
+
+    val wrapRecord = sink.all.unsafeRunSync().find(_.operation == Operation.Wrap).get
+    wrapRecord.outcome should startWith("Success")
+    wrapRecord.outcome should include("dekLen=14")
+    // Critically, the audit must NOT leak the DEK bytes themselves.
+    wrapRecord.outcome should not include "DEKsecretBytes"
+  }
+
+  test("unwrap emits a Success record with the recovered length") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-unwrap"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    val w = svc.wrap(created.id, "dek-bytes".getBytes, alice).unsafeRunSync().toOption.get
+    svc.unwrap(created.id, w, alice).unsafeRunSync()
+
+    val unwrapRecord = sink.all.unsafeRunSync().find(_.operation == Operation.Unwrap).get
+    unwrapRecord.outcome should startWith("Success")
+    unwrapRecord.outcome should include("dekLen=9")
+  }

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -183,3 +183,29 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     rec.outcome should include("Success")
     rec.outcome should include("reason=leaked in S3 audit 2026-05-08")
   }
+
+  test("rotate emits a Success record carrying the new version and the policy") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-rotate"), alice).unsafeRunSync().toOption.get
+    svc.activate(created.id, alice).unsafeRunSync()
+    svc.rotate(created.id, RotationPolicy.Manual, alice).unsafeRunSync()
+
+    val rec = sink.all.unsafeRunSync().find(_.operation == Operation.Rotate).get
+    rec.outcome should startWith("Success")
+    rec.outcome should include("newVersion=2")
+    rec.outcome should include("policy=Manual")
+  }
+
+  test("rotate on a PreActive key emits a Failed record carrying the policy and IllegalOperation") {
+    val (svc, sink) = fixture()
+
+    val created = svc.create(KeySpec.aes256("audit-rotate-fail"), alice).unsafeRunSync().toOption.get
+    // skip activate
+    svc.rotate(created.id, RotationPolicy.Manual, alice).unsafeRunSync()
+
+    val rec = sink.all.unsafeRunSync().find(_.operation == Operation.Rotate).get
+    rec.outcome should startWith("Failed")
+    rec.outcome should include("IllegalOperation")
+    rec.outcome should include("policy=Manual")
+  }

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -93,6 +93,15 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[UnwrapResponse](res.body)
       case status => Left(toError(status, res.body))
 
+  def compromiseKey(id: String, req: CompromiseRequest): Either[ClientError, ManagedKeyDto] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res =
+      http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/compromise"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[ManagedKeyDto](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -102,6 +102,14 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[ManagedKeyDto](res.body)
       case status => Left(toError(status, res.body))
 
+  def rotateKey(id: String, req: RotateRequest): Either[ClientError, ManagedKeyDto] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res     = http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/rotate"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[ManagedKeyDto](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -77,6 +77,22 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[DecryptResponse](res.body)
       case status => Left(toError(status, res.body))
 
+  def wrapKey(id: String, req: WrapRequest): Either[ClientError, WrapResponse] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res     = http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/wrap"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[WrapResponse](res.body)
+      case status => Left(toError(status, res.body))
+
+  def unwrapKey(id: String, req: UnwrapRequest): Either[ClientError, UnwrapResponse] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res     = http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/unwrap"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[UnwrapResponse](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -61,6 +61,22 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[VerifyResponse](res.body)
       case status => Left(toError(status, res.body))
 
+  def encryptKey(id: String, req: EncryptRequest): Either[ClientError, EncryptResponse] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res     = http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/encrypt"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[EncryptResponse](res.body)
+      case status => Left(toError(status, res.body))
+
+  def decryptKey(id: String, req: DecryptRequest): Either[ClientError, DecryptResponse] =
+    val body    = req.asJson.noSpaces
+    val headers = baseHeaders + ("Content-Type" -> "application/json")
+    val res     = http.execute(HttpPort.Request("POST", url(s"/v1/keys/$id/decrypt"), headers, Some(body)))
+    res.status match
+      case 200    => decodeBody[DecryptResponse](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -96,6 +96,16 @@ object Cli:
           case Right((id, ct, ctx)) => Commands.keysDecrypt(makeClient(cfg), id, ct, ctx)
           case Left(msg)            => CommandResult.err(s"$msg\n\n${keysDecryptHelp}")
 
+      case "wrap" =>
+        parseKeysWrap(rest) match
+          case Right((id, dek)) => Commands.keysWrap(makeClient(cfg), id, dek)
+          case Left(msg)        => CommandResult.err(s"$msg\n\n${keysWrapHelp}")
+
+      case "unwrap" =>
+        parseKeysUnwrap(rest) match
+          case Right((id, wrapped)) => Commands.keysUnwrap(makeClient(cfg), id, wrapped)
+          case Left(msg)            => CommandResult.err(s"$msg\n\n${keysUnwrapHelp}")
+
       case other =>
         CommandResult.err(s"unknown keys subcommand: $other\n\n${keysHelp}")
 
@@ -181,6 +191,22 @@ object Cli:
       ctx <- parseContext(flags.get("--context")).left.map(m => s"keys decrypt: $m")
     yield (id, ct, ctx)
 
+  /** Parse `aegis keys wrap --id <id> --dek <text|@file>`. */
+  private[cli] def parseKeysWrap(args: List[String]): Either[String, (String, String)] =
+    val flags = parseFlags(args)
+    for
+      id  <- flags.get("--id").toRight("keys wrap: --id <id> is required")
+      dek <- flags.get("--dek").toRight("keys wrap: --dek <text|@file> is required")
+    yield (id, dek)
+
+  /** Parse `aegis keys unwrap --id <id> --wrapped <b64>`. */
+  private[cli] def parseKeysUnwrap(args: List[String]): Either[String, (String, String)] =
+    val flags = parseFlags(args)
+    for
+      id      <- flags.get("--id").toRight("keys unwrap: --id <id> is required")
+      wrapped <- flags.get("--wrapped").toRight("keys unwrap: --wrapped <base64> is required")
+    yield (id, wrapped)
+
   /** Parse `--context k=v,k2=v2` into a map. Empty / missing → empty map. */
   private def parseContext(raw: Option[String]): Either[String, Map[String, String]] =
     raw.filter(_.nonEmpty) match
@@ -218,6 +244,8 @@ object Cli:
       |  aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]
       |  aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]
       |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
+      |  aegis keys wrap --id <id> --dek <text|@file>
+      |  aegis keys unwrap --id <id> --wrapped <b64>
       |  aegis agent issue        (planned — PR A1)
       |  aegis audit tail         (planned — PR F2.b)
       |  aegis advisor scan       (planned — PR W4)
@@ -236,7 +264,9 @@ object Cli:
       |  aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]
       |  aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]
       |  aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]
-      |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]""".stripMargin
+      |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
+      |  aegis keys wrap --id <id> --dek <text|@file>
+      |  aegis keys unwrap --id <id> --wrapped <b64>""".stripMargin
   private val keysCreateHelp: String = "Usage: aegis keys create --alg AES-256 --name <name>"
   private val keysSignHelp: String =
     "Usage: aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]"
@@ -246,3 +276,5 @@ object Cli:
     "Usage: aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]"
   private val keysDecryptHelp: String =
     "Usage: aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]"
+  private val keysWrapHelp: String   = "Usage: aegis keys wrap --id <id> --dek <text|@file>"
+  private val keysUnwrapHelp: String = "Usage: aegis keys unwrap --id <id> --wrapped <b64>"

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -111,6 +111,11 @@ object Cli:
           case Right((id, reason)) => Commands.keysCompromise(makeClient(cfg), id, reason)
           case Left(msg)           => CommandResult.err(s"$msg\n\n${keysCompromiseHelp}")
 
+      case "rotate" =>
+        parseKeysRotate(rest) match
+          case Right((id, policy)) => Commands.keysRotate(makeClient(cfg), id, policy)
+          case Left(msg)           => CommandResult.err(s"$msg\n\n${keysRotateHelp}")
+
       case other =>
         CommandResult.err(s"unknown keys subcommand: $other\n\n${keysHelp}")
 
@@ -224,6 +229,14 @@ object Cli:
       )
     yield (id, reason)
 
+  /** Parse `aegis keys rotate --id <id> [--policy <policy>]`. Default policy is `Manual`. */
+  private[cli] def parseKeysRotate(args: List[String]): Either[String, (String, String)] =
+    val flags  = parseFlags(args)
+    val policy = flags.getOrElse("--policy", "Manual")
+    flags.get("--id")
+      .toRight("keys rotate: --id <id> is required")
+      .map(id => (id, policy))
+
   /** Parse `--context k=v,k2=v2` into a map. Empty / missing → empty map. */
   private def parseContext(raw: Option[String]): Either[String, Map[String, String]] =
     raw.filter(_.nonEmpty) match
@@ -264,6 +277,7 @@ object Cli:
       |  aegis keys wrap --id <id> --dek <text|@file>
       |  aegis keys unwrap --id <id> --wrapped <b64>
       |  aegis keys compromise --id <id> --reason "<text>"
+      |  aegis keys rotate --id <id> [--policy Manual|TimeBased:7days|OpCountBased:N]
       |  aegis agent issue        (planned — PR A1)
       |  aegis audit tail         (planned — PR F2.b)
       |  aegis advisor scan       (planned — PR W4)
@@ -285,7 +299,8 @@ object Cli:
       |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
       |  aegis keys wrap --id <id> --dek <text|@file>
       |  aegis keys unwrap --id <id> --wrapped <b64>
-      |  aegis keys compromise --id <id> --reason "<text>"""".stripMargin
+      |  aegis keys compromise --id <id> --reason "<text>"
+      |  aegis keys rotate --id <id> [--policy Manual|TimeBased:7days|OpCountBased:N]""".stripMargin
   private val keysCreateHelp: String = "Usage: aegis keys create --alg AES-256 --name <name>"
   private val keysSignHelp: String =
     "Usage: aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]"
@@ -299,3 +314,5 @@ object Cli:
   private val keysUnwrapHelp: String = "Usage: aegis keys unwrap --id <id> --wrapped <b64>"
   private val keysCompromiseHelp: String =
     "Usage: aegis keys compromise --id <id> --reason \"<text>\""
+  private val keysRotateHelp: String =
+    "Usage: aegis keys rotate --id <id> [--policy Manual|TimeBased:7days|OpCountBased:N]"

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -86,6 +86,16 @@ object Cli:
           case Right((id, msg, sig, alg)) => Commands.keysVerify(makeClient(cfg), id, msg, sig, alg)
           case Left(msg)                  => CommandResult.err(s"$msg\n\n${keysVerifyHelp}")
 
+      case "encrypt" =>
+        parseKeysEncrypt(rest) match
+          case Right((id, pt, ctx)) => Commands.keysEncrypt(makeClient(cfg), id, pt, ctx)
+          case Left(msg)            => CommandResult.err(s"$msg\n\n${keysEncryptHelp}")
+
+      case "decrypt" =>
+        parseKeysDecrypt(rest) match
+          case Right((id, ct, ctx)) => Commands.keysDecrypt(makeClient(cfg), id, ct, ctx)
+          case Left(msg)            => CommandResult.err(s"$msg\n\n${keysDecryptHelp}")
+
       case other =>
         CommandResult.err(s"unknown keys subcommand: $other\n\n${keysHelp}")
 
@@ -149,6 +159,42 @@ object Cli:
       sig <- flags.get("--signature").toRight("keys verify: --signature <base64> is required")
     yield (id, msg, sig, alg)
 
+  /** Parse `aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]`. */
+  private[cli] def parseKeysEncrypt(
+      args: List[String]
+  ): Either[String, (String, String, Map[String, String])] =
+    val flags = parseFlags(args)
+    for
+      id  <- flags.get("--id").toRight("keys encrypt: --id <id> is required")
+      pt  <- flags.get("--plaintext").toRight("keys encrypt: --plaintext <text|@file> is required")
+      ctx <- parseContext(flags.get("--context")).left.map(m => s"keys encrypt: $m")
+    yield (id, pt, ctx)
+
+  /** Parse `aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]`. */
+  private[cli] def parseKeysDecrypt(
+      args: List[String]
+  ): Either[String, (String, String, Map[String, String])] =
+    val flags = parseFlags(args)
+    for
+      id  <- flags.get("--id").toRight("keys decrypt: --id <id> is required")
+      ct  <- flags.get("--ciphertext").toRight("keys decrypt: --ciphertext <base64> is required")
+      ctx <- parseContext(flags.get("--context")).left.map(m => s"keys decrypt: $m")
+    yield (id, ct, ctx)
+
+  /** Parse `--context k=v,k2=v2` into a map. Empty / missing → empty map. */
+  private def parseContext(raw: Option[String]): Either[String, Map[String, String]] =
+    raw.filter(_.nonEmpty) match
+      case None => Right(Map.empty)
+      case Some(s) =>
+        s.split(",").toList.foldLeft[Either[String, Map[String, String]]](Right(Map.empty)) {
+          (acc, pair) =>
+            acc.flatMap { m =>
+              pair.split("=", 2).toList match
+                case k :: v :: Nil if k.nonEmpty => Right(m + (k -> v))
+                case _ => Left(s"invalid --context entry: '$pair' (expected key=value)")
+            }
+        }
+
   /** Tiny `--key value --key2 value2 …` flag parser. Anything else gets ignored — fine for our tiny surface.
     */
   private def parseFlags(args: List[String]): Map[String, String] =
@@ -170,6 +216,8 @@ object Cli:
       |  aegis keys destroy <id>
       |  aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]
       |  aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]
+      |  aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]
+      |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
       |  aegis agent issue        (planned — PR A1)
       |  aegis audit tail         (planned — PR F2.b)
       |  aegis advisor scan       (planned — PR W4)
@@ -186,9 +234,15 @@ object Cli:
       |  aegis keys activate <id>
       |  aegis keys destroy <id>
       |  aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]
-      |  aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]""".stripMargin
+      |  aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]
+      |  aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]
+      |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]""".stripMargin
   private val keysCreateHelp: String = "Usage: aegis keys create --alg AES-256 --name <name>"
   private val keysSignHelp: String =
     "Usage: aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]"
   private val keysVerifyHelp: String =
     "Usage: aegis keys verify --id <id> --message <text|@file> --signature <b64> [--alg RsaPssSha256]"
+  private val keysEncryptHelp: String =
+    "Usage: aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]"
+  private val keysDecryptHelp: String =
+    "Usage: aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]"

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -106,6 +106,11 @@ object Cli:
           case Right((id, wrapped)) => Commands.keysUnwrap(makeClient(cfg), id, wrapped)
           case Left(msg)            => CommandResult.err(s"$msg\n\n${keysUnwrapHelp}")
 
+      case "compromise" =>
+        parseKeysCompromise(rest) match
+          case Right((id, reason)) => Commands.keysCompromise(makeClient(cfg), id, reason)
+          case Left(msg)           => CommandResult.err(s"$msg\n\n${keysCompromiseHelp}")
+
       case other =>
         CommandResult.err(s"unknown keys subcommand: $other\n\n${keysHelp}")
 
@@ -207,6 +212,18 @@ object Cli:
       wrapped <- flags.get("--wrapped").toRight("keys unwrap: --wrapped <base64> is required")
     yield (id, wrapped)
 
+  /** Parse `aegis keys compromise --id <id> --reason "..."`. The reason must be non-empty — the audit row
+    * carries this string at severity=Critical, and a blank justification undermines the post-incident report.
+    */
+  private[cli] def parseKeysCompromise(args: List[String]): Either[String, (String, String)] =
+    val flags = parseFlags(args)
+    for
+      id <- flags.get("--id").toRight("keys compromise: --id <id> is required")
+      reason <- flags.get("--reason").filter(_.nonEmpty).toRight(
+        "keys compromise: --reason <text> is required (non-empty)"
+      )
+    yield (id, reason)
+
   /** Parse `--context k=v,k2=v2` into a map. Empty / missing → empty map. */
   private def parseContext(raw: Option[String]): Either[String, Map[String, String]] =
     raw.filter(_.nonEmpty) match
@@ -246,6 +263,7 @@ object Cli:
       |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
       |  aegis keys wrap --id <id> --dek <text|@file>
       |  aegis keys unwrap --id <id> --wrapped <b64>
+      |  aegis keys compromise --id <id> --reason "<text>"
       |  aegis agent issue        (planned — PR A1)
       |  aegis audit tail         (planned — PR F2.b)
       |  aegis advisor scan       (planned — PR W4)
@@ -266,7 +284,8 @@ object Cli:
       |  aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]
       |  aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]
       |  aegis keys wrap --id <id> --dek <text|@file>
-      |  aegis keys unwrap --id <id> --wrapped <b64>""".stripMargin
+      |  aegis keys unwrap --id <id> --wrapped <b64>
+      |  aegis keys compromise --id <id> --reason "<text>"""".stripMargin
   private val keysCreateHelp: String = "Usage: aegis keys create --alg AES-256 --name <name>"
   private val keysSignHelp: String =
     "Usage: aegis keys sign --id <id> --message <text|@file> [--alg RsaPssSha256]"
@@ -278,3 +297,5 @@ object Cli:
     "Usage: aegis keys decrypt --id <id> --ciphertext <b64> [--context k=v,k2=v2]"
   private val keysWrapHelp: String   = "Usage: aegis keys wrap --id <id> --dek <text|@file>"
   private val keysUnwrapHelp: String = "Usage: aegis keys unwrap --id <id> --wrapped <b64>"
+  private val keysCompromiseHelp: String =
+    "Usage: aegis keys compromise --id <id> --reason \"<text>\""

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -2,6 +2,10 @@ package dev.aegiskms.cli
 
 import dev.aegiskms.cli.AegisHttpClient.{ClientError, renderError}
 import dev.aegiskms.cli.WireFormats.{
+  DecryptRequest,
+  DecryptResponse,
+  EncryptRequest,
+  EncryptResponse,
   KeySpecDto,
   ManagedKeyDto,
   SignRequest,
@@ -119,6 +123,47 @@ object Commands:
       try Right(Files.readAllBytes(path))
       catch case e: Exception => Left(s"could not read $path: ${e.getMessage}")
     else Right(arg.getBytes("UTF-8"))
+
+  // ── keys encrypt ───────────────────────────────────────────────────────────
+
+  /** `aegis keys encrypt --id <id> --plaintext <text|@file> [--context k=v,k2=v2]`. The plaintext can be
+    * supplied inline (UTF-8) or read from a file path prefixed with `@`. The ciphertext is printed as base64.
+    */
+  def keysEncrypt(
+      client: AegisHttpClient,
+      id: String,
+      plaintext: String,
+      context: Map[String, String]
+  ): CommandResult =
+    readMessage(plaintext) match
+      case Left(msg) => CommandResult.err(s"keys encrypt: $msg")
+      case Right(bytes) =>
+        val req = EncryptRequest(Base64.getEncoder.encodeToString(bytes), context)
+        client.encryptKey(id, req) match
+          case Right(EncryptResponse(ctB64, ctx)) =>
+            val ctxLine = if ctx.isEmpty then "" else s"\ncontext: ${formatContext(ctx)}"
+            CommandResult.out(s"ciphertext: $ctB64$ctxLine")
+          case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  // ── keys decrypt ───────────────────────────────────────────────────────────
+
+  /** `aegis keys decrypt --id <id> --ciphertext <base64> [--context k=v,k2=v2]`. The plaintext is printed as
+    * base64 (it may not be valid UTF-8) plus a best-effort UTF-8 rendering when it decodes cleanly.
+    */
+  def keysDecrypt(
+      client: AegisHttpClient,
+      id: String,
+      ciphertextB64: String,
+      context: Map[String, String]
+  ): CommandResult =
+    val req = DecryptRequest(ciphertextB64, context)
+    client.decryptKey(id, req) match
+      case Right(DecryptResponse(ptB64, _)) =>
+        CommandResult.out(s"plaintext: $ptB64")
+      case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  private def formatContext(ctx: Map[String, String]): String =
+    ctx.toSeq.sortBy(_._1).map((k, v) => s"$k=$v").mkString(",")
 
   // ── placeholders for agent-native commands (backends arrive in later PRs) ──
 

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -10,8 +10,12 @@ import dev.aegiskms.cli.WireFormats.{
   ManagedKeyDto,
   SignRequest,
   SignResponse,
+  UnwrapRequest,
+  UnwrapResponse,
   VerifyRequest,
-  VerifyResponse
+  VerifyResponse,
+  WrapRequest,
+  WrapResponse
 }
 
 import java.nio.file.{Files, Path}
@@ -164,6 +168,34 @@ object Commands:
 
   private def formatContext(ctx: Map[String, String]): String =
     ctx.toSeq.sortBy(_._1).map((k, v) => s"$k=$v").mkString(",")
+
+  // ── keys wrap ──────────────────────────────────────────────────────────────
+
+  /** `aegis keys wrap --id <id> --dek <text|@file>`. The DEK can be inline (UTF-8) or read from a file path
+    * prefixed with `@` (the common case — a 32-byte AES-256 DEK won't be valid UTF-8). The wrapped blob is
+    * printed as base64.
+    */
+  def keysWrap(client: AegisHttpClient, id: String, dek: String): CommandResult =
+    readMessage(dek) match
+      case Left(msg) => CommandResult.err(s"keys wrap: $msg")
+      case Right(bytes) =>
+        val req = WrapRequest(Base64.getEncoder.encodeToString(bytes))
+        client.wrapKey(id, req) match
+          case Right(WrapResponse(wrappedB64)) =>
+            CommandResult.out(s"wrapped: $wrappedB64")
+          case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  // ── keys unwrap ────────────────────────────────────────────────────────────
+
+  /** `aegis keys unwrap --id <id> --wrapped <b64>`. Prints the recovered DEK as base64 (it may not be valid
+    * UTF-8 — DEKs are random bytes).
+    */
+  def keysUnwrap(client: AegisHttpClient, id: String, wrappedB64: String): CommandResult =
+    val req = UnwrapRequest(wrappedB64)
+    client.unwrapKey(id, req) match
+      case Right(UnwrapResponse(dekB64)) =>
+        CommandResult.out(s"dek: $dekB64")
+      case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
 
   // ── placeholders for agent-native commands (backends arrive in later PRs) ──
 

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -9,6 +9,7 @@ import dev.aegiskms.cli.WireFormats.{
   EncryptResponse,
   KeySpecDto,
   ManagedKeyDto,
+  RotateRequest,
   SignRequest,
   SignResponse,
   UnwrapRequest,
@@ -210,6 +211,20 @@ object Commands:
         CommandResult.out(s"compromised ${key.id}\nreason: $reason\nstate:  ${key.state}")
       case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
 
+  // ── keys rotate ────────────────────────────────────────────────────────────
+
+  /** `aegis keys rotate --id <id> [--policy <policy>]`. Bumps the key's currentVersion. Defaults to `Manual`;
+    * supply `TimeBased:7days` or `OpCountBased:10000` to record an automatic rotation.
+    */
+  def keysRotate(client: AegisHttpClient, id: String, policy: String): CommandResult =
+    val req = RotateRequest(policy)
+    client.rotateKey(id, req) match
+      case Right(key) =>
+        CommandResult.out(
+          s"rotated ${key.id}\nversion: ${key.currentVersion}\nstate:   ${key.state}\npolicy:  $policy"
+        )
+      case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
+
   // ── placeholders for agent-native commands (backends arrive in later PRs) ──
 
   /** `aegis agent issue` — issues a scoped agent token. Real implementation lands once the agent-token
@@ -244,6 +259,7 @@ object Commands:
        |algorithm: ${key.spec.algorithm}-${key.spec.sizeBits}
        |type:      ${key.spec.objectType}
        |state:     ${key.state}
+       |version:   ${key.currentVersion}
        |createdAt: ${key.createdAt}""".stripMargin
 
   /** Map server errors to exit codes: 4 for not-found, 5 for permission, 1 for everything else. Mirrors the

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -2,6 +2,7 @@ package dev.aegiskms.cli
 
 import dev.aegiskms.cli.AegisHttpClient.{ClientError, renderError}
 import dev.aegiskms.cli.WireFormats.{
+  CompromiseRequest,
   DecryptRequest,
   DecryptResponse,
   EncryptRequest,
@@ -195,6 +196,18 @@ object Commands:
     client.unwrapKey(id, req) match
       case Right(UnwrapResponse(dekB64)) =>
         CommandResult.out(s"dek: $dekB64")
+      case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  // ── keys compromise ────────────────────────────────────────────────────────
+
+  /** `aegis keys compromise --id <id> --reason "..."`. Marks a key as compromised — irreversible. The reason
+    * is mandatory and ends up on the audit row at `severity=Critical`.
+    */
+  def keysCompromise(client: AegisHttpClient, id: String, reason: String): CommandResult =
+    val req = CompromiseRequest(reason)
+    client.compromiseKey(id, req) match
+      case Right(key) =>
+        CommandResult.out(s"compromised ${key.id}\nreason: $reason\nstate:  ${key.state}")
       case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
 
   // ── placeholders for agent-native commands (backends arrive in later PRs) ──

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -24,7 +24,13 @@ object WireFormats:
     given Encoder[CreateKeyRequest] = deriveEncoder
     given Decoder[CreateKeyRequest] = deriveDecoder
 
-  final case class ManagedKeyDto(id: String, spec: KeySpecDto, createdAt: Instant, state: String)
+  final case class ManagedKeyDto(
+      id: String,
+      spec: KeySpecDto,
+      createdAt: Instant,
+      state: String,
+      currentVersion: Int = 1
+  )
   object ManagedKeyDto:
     given Encoder[ManagedKeyDto] = deriveEncoder
     given Decoder[ManagedKeyDto] = deriveDecoder
@@ -98,3 +104,8 @@ object WireFormats:
   object CompromiseRequest:
     given Encoder[CompromiseRequest] = deriveEncoder
     given Decoder[CompromiseRequest] = deriveDecoder
+
+  final case class RotateRequest(policy: String = "Manual")
+  object RotateRequest:
+    given Encoder[RotateRequest] = deriveEncoder
+    given Decoder[RotateRequest] = deriveDecoder

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -73,3 +73,23 @@ object WireFormats:
   object DecryptResponse:
     given Encoder[DecryptResponse] = deriveEncoder
     given Decoder[DecryptResponse] = deriveDecoder
+
+  final case class WrapRequest(dekBase64: String)
+  object WrapRequest:
+    given Encoder[WrapRequest] = deriveEncoder
+    given Decoder[WrapRequest] = deriveDecoder
+
+  final case class WrapResponse(wrappedDekBase64: String)
+  object WrapResponse:
+    given Encoder[WrapResponse] = deriveEncoder
+    given Decoder[WrapResponse] = deriveDecoder
+
+  final case class UnwrapRequest(wrappedDekBase64: String)
+  object UnwrapRequest:
+    given Encoder[UnwrapRequest] = deriveEncoder
+    given Decoder[UnwrapRequest] = deriveDecoder
+
+  final case class UnwrapResponse(dekBase64: String)
+  object UnwrapResponse:
+    given Encoder[UnwrapResponse] = deriveEncoder
+    given Decoder[UnwrapResponse] = deriveDecoder

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -53,3 +53,23 @@ object WireFormats:
   object VerifyResponse:
     given Encoder[VerifyResponse] = deriveEncoder
     given Decoder[VerifyResponse] = deriveDecoder
+
+  final case class EncryptRequest(plaintextBase64: String, context: Map[String, String] = Map.empty)
+  object EncryptRequest:
+    given Encoder[EncryptRequest] = deriveEncoder
+    given Decoder[EncryptRequest] = deriveDecoder
+
+  final case class EncryptResponse(ciphertextBase64: String, context: Map[String, String])
+  object EncryptResponse:
+    given Encoder[EncryptResponse] = deriveEncoder
+    given Decoder[EncryptResponse] = deriveDecoder
+
+  final case class DecryptRequest(ciphertextBase64: String, context: Map[String, String] = Map.empty)
+  object DecryptRequest:
+    given Encoder[DecryptRequest] = deriveEncoder
+    given Decoder[DecryptRequest] = deriveDecoder
+
+  final case class DecryptResponse(plaintextBase64: String, context: Map[String, String])
+  object DecryptResponse:
+    given Encoder[DecryptResponse] = deriveEncoder
+    given Decoder[DecryptResponse] = deriveDecoder

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -93,3 +93,8 @@ object WireFormats:
   object UnwrapResponse:
     given Encoder[UnwrapResponse] = deriveEncoder
     given Decoder[UnwrapResponse] = deriveDecoder
+
+  final case class CompromiseRequest(reason: String)
+  object CompromiseRequest:
+    given Encoder[CompromiseRequest] = deriveEncoder
+    given Decoder[CompromiseRequest] = deriveDecoder

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
@@ -129,6 +129,39 @@ final class AegisHttpClientSpec extends AnyFunSuite with Matchers:
     )
   }
 
+  test("encryptKey POSTs to /v1/keys/{id}/encrypt with the context map and Content-Type") {
+    var seen: Option[HttpPort.Request] = None
+    val port = new RecordingPort(req => {
+      seen = Some(req)
+      HttpPort.Response(200, EncryptResponse("Y2lwaGVy", Map("dataset" -> "q2")).asJson.noSpaces)
+    })
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    val res    = client.encryptKey(sampleKey.id, EncryptRequest("aGVsbG8=", Map("dataset" -> "q2")))
+
+    res shouldBe Right(EncryptResponse("Y2lwaGVy", Map("dataset" -> "q2")))
+    seen.get.method shouldBe "POST"
+    seen.get.url shouldBe s"$baseUrl/v1/keys/${sampleKey.id}/encrypt"
+    seen.get.headers.get("Content-Type") shouldBe Some("application/json")
+    seen.get.body.get should include("\"dataset\":\"q2\"")
+  }
+
+  test("decryptKey POSTs to /v1/keys/{id}/decrypt and decodes the plaintext") {
+    val port =
+      new RecordingPort(_ => HttpPort.Response(200, DecryptResponse("aGVsbG8=", Map.empty).asJson.noSpaces))
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    client.decryptKey(sampleKey.id, DecryptRequest("Y2lwaGVy", Map.empty)) shouldBe Right(
+      DecryptResponse("aGVsbG8=", Map.empty)
+    )
+  }
+
+  test("encryptKey decodes a server-side CryptographicFailure into ClientError.Server") {
+    val errBody = """{"code":"CryptographicFailure","message":"context mismatch"}"""
+    val port    = new RecordingPort(_ => HttpPort.Response(500, errBody))
+    val client  = new AegisHttpClient(port, baseUrl, principal)
+    val res     = client.encryptKey(sampleKey.id, EncryptRequest("aGVsbG8=", Map.empty))
+    res shouldBe Left(ClientError.Server(500, "CryptographicFailure", "context mismatch"))
+  }
+
   // ── Stub ────────────────────────────────────────────────────────────────────
 
   final private class RecordingPort(handler: HttpPort.Request => HttpPort.Response) extends HttpPort:

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
@@ -204,6 +204,22 @@ final class AegisHttpClientSpec extends AnyFunSuite with Matchers:
     seen.get.body.get should include("\"reason\":\"leaked in S3\"")
   }
 
+  test("rotateKey POSTs to /v1/keys/{id}/rotate with the policy and decodes the rotated key") {
+    var seen: Option[HttpPort.Request] = None
+    val rotatedKey                     = sampleKey.copy(state = "Active", currentVersion = 2)
+    val port = new RecordingPort(req => {
+      seen = Some(req)
+      HttpPort.Response(200, rotatedKey.asJson.noSpaces)
+    })
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    val res    = client.rotateKey(sampleKey.id, RotateRequest("Manual"))
+
+    res shouldBe Right(rotatedKey)
+    seen.get.method shouldBe "POST"
+    seen.get.url shouldBe s"$baseUrl/v1/keys/${sampleKey.id}/rotate"
+    seen.get.body.get should include("\"policy\":\"Manual\"")
+  }
+
   // ── Stub ────────────────────────────────────────────────────────────────────
 
   final private class RecordingPort(handler: HttpPort.Request => HttpPort.Response) extends HttpPort:

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
@@ -162,6 +162,31 @@ final class AegisHttpClientSpec extends AnyFunSuite with Matchers:
     res shouldBe Left(ClientError.Server(500, "CryptographicFailure", "context mismatch"))
   }
 
+  test("wrapKey POSTs to /v1/keys/{id}/wrap with Content-Type and decodes the wrapped blob") {
+    var seen: Option[HttpPort.Request] = None
+    val port = new RecordingPort(req => {
+      seen = Some(req)
+      HttpPort.Response(200, WrapResponse("d3JhcHBlZA==").asJson.noSpaces)
+    })
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    val res    = client.wrapKey(sampleKey.id, WrapRequest("aGVsbG8="))
+
+    res shouldBe Right(WrapResponse("d3JhcHBlZA=="))
+    seen.get.method shouldBe "POST"
+    seen.get.url shouldBe s"$baseUrl/v1/keys/${sampleKey.id}/wrap"
+    seen.get.headers.get("Content-Type") shouldBe Some("application/json")
+    seen.get.body.get should include("\"dekBase64\":\"aGVsbG8=\"")
+  }
+
+  test("unwrapKey POSTs to /v1/keys/{id}/unwrap and decodes the DEK") {
+    val port =
+      new RecordingPort(_ => HttpPort.Response(200, UnwrapResponse("aGVsbG8=").asJson.noSpaces))
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    client.unwrapKey(sampleKey.id, UnwrapRequest("d3JhcHBlZA==")) shouldBe Right(
+      UnwrapResponse("aGVsbG8=")
+    )
+  }
+
   // ── Stub ────────────────────────────────────────────────────────────────────
 
   final private class RecordingPort(handler: HttpPort.Request => HttpPort.Response) extends HttpPort:

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/AegisHttpClientSpec.scala
@@ -187,6 +187,23 @@ final class AegisHttpClientSpec extends AnyFunSuite with Matchers:
     )
   }
 
+  test("compromiseKey POSTs to /v1/keys/{id}/compromise with the reason and decodes the key") {
+    var seen: Option[HttpPort.Request] = None
+    val compromisedKey                 = sampleKey.copy(state = "Compromised")
+    val port = new RecordingPort(req => {
+      seen = Some(req)
+      HttpPort.Response(200, compromisedKey.asJson.noSpaces)
+    })
+    val client = new AegisHttpClient(port, baseUrl, principal)
+    val res    = client.compromiseKey(sampleKey.id, CompromiseRequest("leaked in S3"))
+
+    res shouldBe Right(compromisedKey)
+    seen.get.method shouldBe "POST"
+    seen.get.url shouldBe s"$baseUrl/v1/keys/${sampleKey.id}/compromise"
+    seen.get.headers.get("Content-Type") shouldBe Some("application/json")
+    seen.get.body.get should include("\"reason\":\"leaked in S3\"")
+  }
+
   // ── Stub ────────────────────────────────────────────────────────────────────
 
   final private class RecordingPort(handler: HttpPort.Request => HttpPort.Response) extends HttpPort:

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -378,3 +378,42 @@ final class CliSpec extends AnyFunSuite with Matchers:
     r.stdout should include("compromised abc")
     r.stdout should include("state:  Compromised")
   }
+
+  test("'keys rotate' missing --id reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("keys", "rotate"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--id")
+  }
+
+  test("'keys rotate --id <id>' defaults policy to Manual and POSTs to /rotate") {
+    var captured: Option[HttpPort.Request] = None
+    val rotatedKey                         = sampleKey.copy(state = "Active", currentVersion = 2)
+    val r = Cli.run(
+      List("keys", "rotate", "--id", "abc"),
+      cfg,
+      captureFactory(req => captured = Some(req), rotatedKey.asJson.noSpaces, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "POST"
+    captured.get.url should endWith("/v1/keys/abc/rotate")
+    captured.get.body.get should include("\"policy\":\"Manual\"")
+    r.stdout should include("rotated abc")
+    r.stdout should include("version: 2")
+    r.stdout should include("policy:  Manual")
+  }
+
+  test("'keys rotate --id <id> --policy TimeBased:7days' carries the policy on the wire") {
+    var captured: Option[HttpPort.Request] = None
+    val rotatedKey                         = sampleKey.copy(state = "Active", currentVersion = 2)
+    val r = Cli.run(
+      List("keys", "rotate", "--id", "abc", "--policy", "TimeBased:7days"),
+      cfg,
+      captureFactory(req => captured = Some(req), rotatedKey.asJson.noSpaces, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.body.get should include("\"policy\":\"TimeBased:7days\"")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -342,3 +342,39 @@ final class CliSpec extends AnyFunSuite with Matchers:
     captured.get.url should endWith("/v1/keys/abc/unwrap")
     r.stdout should include(s"dek: $dekB64")
   }
+
+  test("'keys compromise' missing --reason reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("keys", "compromise", "--id", "abc"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--reason")
+  }
+
+  test("'keys compromise' empty --reason is rejected (audit trail must have a justification)") {
+    val r = Cli.run(
+      List("keys", "compromise", "--id", "abc", "--reason", ""),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--reason")
+  }
+
+  test("'keys compromise --id <id> --reason <text>' POSTs to /compromise with the reason in the body") {
+    var captured: Option[HttpPort.Request] = None
+    val compromisedKey                     = sampleKey.copy(state = "Compromised")
+    val r = Cli.run(
+      List("keys", "compromise", "--id", "abc", "--reason", "leaked in S3 audit"),
+      cfg,
+      captureFactory(req => captured = Some(req), compromisedKey.asJson.noSpaces, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "POST"
+    captured.get.url should endWith("/v1/keys/abc/compromise")
+    captured.get.body.get should include("\"reason\":\"leaked in S3 audit\"")
+    r.stdout should include("compromised abc")
+    r.stdout should include("state:  Compromised")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -244,3 +244,62 @@ final class CliSpec extends AnyFunSuite with Matchers:
     r.exitCode shouldBe 0
     r.stdout should include("valid: true")
   }
+
+  test("'keys encrypt' missing --plaintext reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("keys", "encrypt", "--id", "abc"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--plaintext")
+  }
+
+  test("'keys encrypt --id <id> --plaintext <text> --context k=v' POSTs to /encrypt with the context map") {
+    var captured: Option[HttpPort.Request] = None
+    val responseBody =
+      EncryptResponse("Y2lwaGVy", Map("dataset" -> "q2")).asJson.noSpaces
+    val r = Cli.run(
+      List(
+        "keys",
+        "encrypt",
+        "--id",
+        "abc",
+        "--plaintext",
+        "hello",
+        "--context",
+        "dataset=q2"
+      ),
+      cfg,
+      captureFactory(req => captured = Some(req), responseBody, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "POST"
+    captured.get.url should endWith("/v1/keys/abc/encrypt")
+    captured.get.body.get should include("\"context\":{\"dataset\":\"q2\"}")
+    r.stdout should include("ciphertext: Y2lwaGVy")
+  }
+
+  test("'keys encrypt' rejects malformed --context entries with a clear error") {
+    val r = Cli.run(
+      List("keys", "encrypt", "--id", "abc", "--plaintext", "x", "--context", "no-equals"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--context")
+  }
+
+  test("'keys decrypt --id <id> --ciphertext <b64>' POSTs to /decrypt and renders the plaintext") {
+    var captured: Option[HttpPort.Request] = None
+    val ptB64                              = java.util.Base64.getEncoder.encodeToString("hello".getBytes)
+    val responseBody                       = DecryptResponse(ptB64, Map.empty).asJson.noSpaces
+    val r = Cli.run(
+      List("keys", "decrypt", "--id", "abc", "--ciphertext", "Y2lwaGVy"),
+      cfg,
+      captureFactory(req => captured = Some(req), responseBody, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.url should endWith("/v1/keys/abc/decrypt")
+    r.stdout should include(s"plaintext: $ptB64")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -303,3 +303,42 @@ final class CliSpec extends AnyFunSuite with Matchers:
     captured.get.url should endWith("/v1/keys/abc/decrypt")
     r.stdout should include(s"plaintext: $ptB64")
   }
+
+  test("'keys wrap' missing --dek reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("keys", "wrap", "--id", "abc"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--dek")
+  }
+
+  test("'keys wrap --id <id> --dek <text>' POSTs to /wrap and prints the wrapped blob") {
+    var captured: Option[HttpPort.Request] = None
+    val responseBody                       = WrapResponse("d3JhcHBlZA==").asJson.noSpaces
+    val r = Cli.run(
+      List("keys", "wrap", "--id", "abc", "--dek", "secret-dek"),
+      cfg,
+      captureFactory(req => captured = Some(req), responseBody, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "POST"
+    captured.get.url should endWith("/v1/keys/abc/wrap")
+    captured.get.body.get should include("\"dekBase64\":")
+    r.stdout should include("wrapped: d3JhcHBlZA==")
+  }
+
+  test("'keys unwrap --id <id> --wrapped <b64>' POSTs to /unwrap and renders the DEK as base64") {
+    var captured: Option[HttpPort.Request] = None
+    val dekB64                             = java.util.Base64.getEncoder.encodeToString("secret-dek".getBytes)
+    val responseBody                       = UnwrapResponse(dekB64).asJson.noSpaces
+    val r = Cli.run(
+      List("keys", "unwrap", "--id", "abc", "--wrapped", "d3JhcHBlZA=="),
+      cfg,
+      captureFactory(req => captured = Some(req), responseBody, status = 200)
+    )
+    r.exitCode shouldBe 0
+    captured.get.url should endWith("/v1/keys/abc/unwrap")
+    r.stdout should include(s"dek: $dekB64")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -185,3 +185,28 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     r.exitCode shouldBe 1
     r.stderr should include("CryptographicFailure")
   }
+
+  test("keys wrap prints the base64 wrapped blob on success") {
+    val responseBody = WrapResponse("d3JhcHBlZA==").asJson.noSpaces
+    val client       = clientReturning(200, responseBody)
+    val r            = Commands.keysWrap(client, sampleKey.id, "secret-dek")
+    r.exitCode shouldBe 0
+    r.stdout should include("wrapped: d3JhcHBlZA==")
+  }
+
+  test("keys unwrap on success prints the DEK as base64") {
+    val dekB64       = java.util.Base64.getEncoder.encodeToString("secret-dek".getBytes("UTF-8"))
+    val responseBody = UnwrapResponse(dekB64).asJson.noSpaces
+    val client       = clientReturning(200, responseBody)
+    val r            = Commands.keysUnwrap(client, sampleKey.id, "d3JhcHBlZA==")
+    r.exitCode shouldBe 0
+    r.stdout should include(s"dek: $dekB64")
+  }
+
+  test("keys wrap on a denied call exits 5 (permission) with the server's reason") {
+    val errBody = KmsErrorDto("PermissionDenied", "subject not granted Wrap").asJson.noSpaces
+    val client  = clientReturning(403, errBody)
+    val r       = Commands.keysWrap(client, sampleKey.id, "dek")
+    r.exitCode shouldBe 5
+    r.stderr should include("PermissionDenied")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -210,3 +210,21 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     r.exitCode shouldBe 5
     r.stderr should include("PermissionDenied")
   }
+
+  test("keys compromise prints the resulting state and the reason on success") {
+    val compromisedKey = sampleKey.copy(state = "Compromised")
+    val client         = clientReturning(200, compromisedKey.asJson.noSpaces)
+    val r              = Commands.keysCompromise(client, sampleKey.id, "leaked in S3 audit")
+    r.exitCode shouldBe 0
+    r.stdout should include(s"compromised ${sampleKey.id}")
+    r.stdout should include("reason: leaked in S3 audit")
+    r.stdout should include("state:  Compromised")
+  }
+
+  test("keys compromise on an already-Destroyed key exits non-zero with IllegalOperation") {
+    val errBody = KmsErrorDto("IllegalOperation", "Key is Destroyed").asJson.noSpaces
+    val client  = clientReturning(500, errBody)
+    val r       = Commands.keysCompromise(client, sampleKey.id, "too late")
+    r.exitCode shouldBe 1
+    r.stderr should include("IllegalOperation")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -153,3 +153,35 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     finally
       val _ = Files.deleteIfExists(tmp)
   }
+
+  test("keys encrypt prints the base64 ciphertext and the context that was supplied") {
+    val responseBody =
+      EncryptResponse("Y2lwaGVy", Map("dataset" -> "q2", "tenant" -> "acme")).asJson.noSpaces
+    val client = clientReturning(200, responseBody)
+    val r = Commands.keysEncrypt(
+      client,
+      sampleKey.id,
+      "hello",
+      Map("dataset" -> "q2", "tenant" -> "acme")
+    )
+    r.exitCode shouldBe 0
+    r.stdout should include("ciphertext: Y2lwaGVy")
+    r.stdout should include("context: dataset=q2,tenant=acme")
+  }
+
+  test("keys decrypt on success prints the plaintext as base64") {
+    val ptB64        = java.util.Base64.getEncoder.encodeToString("hello".getBytes("UTF-8"))
+    val responseBody = DecryptResponse(ptB64, Map.empty).asJson.noSpaces
+    val client       = clientReturning(200, responseBody)
+    val r            = Commands.keysDecrypt(client, sampleKey.id, "Y2lwaGVy", Map.empty)
+    r.exitCode shouldBe 0
+    r.stdout should include(s"plaintext: $ptB64")
+  }
+
+  test("keys decrypt on a CryptographicFailure exits 1 with the server's reason") {
+    val errBody = """{"code":"CryptographicFailure","message":"context mismatch"}"""
+    val client  = clientReturning(500, errBody)
+    val r       = Commands.keysDecrypt(client, sampleKey.id, "Y2lwaGVy", Map("a" -> "wrong"))
+    r.exitCode shouldBe 1
+    r.stderr should include("CryptographicFailure")
+  }

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -228,3 +228,22 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     r.exitCode shouldBe 1
     r.stderr should include("IllegalOperation")
   }
+
+  test("keys rotate prints the new version and the policy on success") {
+    val rotatedKey = sampleKey.copy(state = "Active", currentVersion = 2)
+    val client     = clientReturning(200, rotatedKey.asJson.noSpaces)
+    val r          = Commands.keysRotate(client, sampleKey.id, "Manual")
+    r.exitCode shouldBe 0
+    r.stdout should include(s"rotated ${sampleKey.id}")
+    r.stdout should include("version: 2")
+    r.stdout should include("policy:  Manual")
+  }
+
+  test("keys rotate on a non-Active source state exits 1 with IllegalOperation") {
+    val errBody =
+      KmsErrorDto("IllegalOperation", "Key is PreActive, must be Active").asJson.noSpaces
+    val client = clientReturning(500, errBody)
+    val r      = Commands.keysRotate(client, sampleKey.id, "Manual")
+    r.exitCode shouldBe 1
+    r.stderr should include("IllegalOperation")
+  }

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/Ciphertext.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/Ciphertext.scala
@@ -1,0 +1,16 @@
+package dev.aegiskms.core
+
+import java.util.Base64
+
+/** Opaque ciphertext bytes produced by `KeyService.encrypt`. The encryption context (additional authenticated
+  * data, AAD) is NOT carried in this value — the caller must supply the same context to `decrypt` for the
+  * operation to succeed, mirroring AWS KMS semantics. Decryption with a different context fails with
+  * `KmsError(CryptographicFailure, ...)`.
+  */
+final case class Ciphertext(bytes: Array[Byte]):
+  def toBase64: String = Base64.getEncoder.encodeToString(bytes)
+
+object Ciphertext:
+  def fromBase64(b64: String): Either[String, Ciphertext] =
+    try Right(Ciphertext(Base64.getDecoder.decode(b64)))
+    catch case e: IllegalArgumentException => Left(s"invalid base64: ${e.getMessage}")

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyEvent.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyEvent.scala
@@ -64,5 +64,18 @@ object KeyEvent:
       reason: String
   ) extends KeyEvent
 
+  /** Rotation: the logical key's `currentVersion` advanced from `newVersion - 1` to `newVersion`. The
+    * `policy` records why — `Manual` for an explicit `aegis keys rotate` call, `TimeBased` / `OpCountBased`
+    * (rendered string) for the auto-scheduler that lands in v0.2.0.
+    */
+  final case class Rotated(
+      eventId: String,
+      at: Instant,
+      keyId: KeyId,
+      actorSubject: String,
+      newVersion: Int,
+      policy: String
+  ) extends KeyEvent
+
   /** Generate a fresh event id. UUIDv4 is fine — events are not ordered by id, only by `at`. */
   def freshId(): String = UUID.randomUUID().toString

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyEvent.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyEvent.scala
@@ -52,5 +52,17 @@ object KeyEvent:
       actorSubject: String
   ) extends KeyEvent
 
+  /** Operator-issued compromise: locks the key out of every cryptographic operation. The `reason` is the
+    * mandatory human-readable justification — it ends up on the highest-severity audit row and in the
+    * post-incident report.
+    */
+  final case class Compromised(
+      eventId: String,
+      at: Instant,
+      keyId: KeyId,
+      actorSubject: String,
+      reason: String
+  ) extends KeyEvent
+
   /** Generate a fresh event id. UUIDv4 is fine — events are not ordered by id, only by `at`. */
   def freshId(): String = UUID.randomUUID().toString

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
@@ -79,6 +79,13 @@ trait KeyService[F[_]]:
     */
   def unwrap(id: KeyId, wrapped: WrappedDek, by: Principal): F[Either[KmsError, Array[Byte]]]
 
+  /** Operator-issued compromise: marks the key as `Compromised` so it can no longer perform any cryptographic
+    * operation. The `reason` is the mandatory human-readable justification (e.g. "discovered in S3 audit leak
+    * 2026-05-08"). Compromise is one-way: from `{PreActive, Active, Deactivated}` → `Compromised` and is
+    * idempotent on an already-`Compromised` key. `Destroyed` keys cannot be compromised.
+    */
+  def compromise(id: KeyId, reason: String, by: Principal): F[Either[KmsError, ManagedKey]]
+
 object KeyService:
 
   /** An in-memory reference implementation. Not durable, not safe for production — useful for tests, smoke
@@ -141,6 +148,8 @@ object KeyService:
             m.get(id) match
               case None =>
                 Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              case Some(k) if k.state == KeyState.Compromised || k.state == KeyState.Destroyed =>
+                Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}"))
               case Some(_) =>
                 val expected = deterministicMac(id, message)
                 Right(java.util.Arrays.equals(expected, signature.bytes))
@@ -202,6 +211,22 @@ object KeyService:
                 Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}"))
               case Some(_) =>
                 deterministicOpen(id, Map.empty, wrapped.bytes)
+          }
+
+        def compromise(
+            id: KeyId,
+            reason: String,
+            by: Principal
+        ): IO[Either[KmsError, ManagedKey]] =
+          ref.modify { m =>
+            m.get(id) match
+              case None =>
+                (m, Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}")))
+              case Some(k) if k.state == KeyState.Destroyed =>
+                (m, Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is Destroyed")))
+              case Some(k) =>
+                val updated = k.copy(state = KeyState.Compromised)
+                (m + (id -> updated), Right(updated))
           }
 
         private def transition(id: KeyId, to: KeyState): IO[Either[KmsError, ManagedKey]] =

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
@@ -46,6 +46,28 @@ trait KeyService[F[_]]:
       by: Principal
   ): F[Either[KmsError, Boolean]]
 
+  /** Encrypt `plaintext` under the key identified by `id`. The key must be in `KeyState.Active`. The supplied
+    * `context` is bound into the ciphertext as additional authenticated data (AAD); the same context must be
+    * supplied to `decrypt` or the operation fails. Mirrors AWS KMS `Encrypt` with `EncryptionContext`.
+    */
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): F[Either[KmsError, Ciphertext]]
+
+  /** Decrypt `ciphertext` produced by [[encrypt]] under the same key and context. A context mismatch returns
+    * `Left(KmsError(CryptographicFailure, ...))`. Decrypt is permitted on `Active` and `Deactivated` keys so
+    * existing ciphertexts can still be read after rotation; `Compromised` and `Destroyed` are refused.
+    */
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): F[Either[KmsError, Array[Byte]]]
+
 object KeyService:
 
   /** An in-memory reference implementation. Not durable, not safe for production — useful for tests, smoke
@@ -113,6 +135,38 @@ object KeyService:
                 Right(java.util.Arrays.equals(expected, signature.bytes))
           }
 
+        def encrypt(
+            id: KeyId,
+            plaintext: Array[Byte],
+            context: Map[String, String],
+            by: Principal
+        ): IO[Either[KmsError, Ciphertext]] =
+          ref.get.map { m =>
+            m.get(id) match
+              case None =>
+                Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              case Some(k) if k.state != KeyState.Active =>
+                Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}, must be Active"))
+              case Some(_) =>
+                Right(Ciphertext(deterministicSeal(id, context, plaintext)))
+          }
+
+        def decrypt(
+            id: KeyId,
+            ciphertext: Ciphertext,
+            context: Map[String, String],
+            by: Principal
+        ): IO[Either[KmsError, Array[Byte]]] =
+          ref.get.map { m =>
+            m.get(id) match
+              case None =>
+                Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              case Some(k) if k.state == KeyState.Compromised || k.state == KeyState.Destroyed =>
+                Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}"))
+              case Some(_) =>
+                deterministicOpen(id, context, ciphertext.bytes)
+          }
+
         private def transition(id: KeyId, to: KeyState): IO[Either[KmsError, ManagedKey]] =
           ref.modify { m =>
             m.get(id) match
@@ -132,3 +186,57 @@ object KeyService:
     val mac = javax.crypto.Mac.getInstance("HmacSHA256")
     mac.init(new javax.crypto.spec.SecretKeySpec(id.value.getBytes("UTF-8"), "HmacSHA256"))
     mac.doFinal(message)
+
+  /** Deterministic in-memory "encryption" used by the dev `KeyService`. Layout: HMAC(id, ctx) || plaintext
+    * XOR keystream(id, ctx). Round-trips correctly and detects context mismatch via the HMAC prefix; not real
+    * confidentiality. Real encryption lives in `AwsKmsRootOfTrust`.
+    */
+  private def deterministicSeal(
+      id: KeyId,
+      context: Map[String, String],
+      plaintext: Array[Byte]
+  ): Array[Byte] =
+    contextTag(id, context) ++ xorKeystream(id, context, plaintext)
+
+  private def deterministicOpen(
+      id: KeyId,
+      context: Map[String, String],
+      ciphertext: Array[Byte]
+  ): Either[KmsError, Array[Byte]] =
+    if ciphertext.length < 32 then
+      Left(KmsError(ErrorCode.CryptographicFailure, "ciphertext too short"))
+    else
+      val (tag, masked) = ciphertext.splitAt(32)
+      val expected      = contextTag(id, context)
+      if !java.util.Arrays.equals(tag, expected) then
+        Left(KmsError(ErrorCode.CryptographicFailure, "encryption-context mismatch"))
+      else Right(xorKeystream(id, context, masked))
+
+  private def contextTag(id: KeyId, context: Map[String, String]): Array[Byte] =
+    val mac = javax.crypto.Mac.getInstance("HmacSHA256")
+    mac.init(new javax.crypto.spec.SecretKeySpec(id.value.getBytes("UTF-8"), "HmacSHA256"))
+    mac.doFinal(serializeContext(context))
+
+  private def xorKeystream(
+      id: KeyId,
+      context: Map[String, String],
+      data: Array[Byte]
+  ): Array[Byte] =
+    val mac     = javax.crypto.Mac.getInstance("HmacSHA256")
+    val keyBase = id.value.getBytes("UTF-8") ++ serializeContext(context)
+    mac.init(new javax.crypto.spec.SecretKeySpec(keyBase, "HmacSHA256"))
+    val out = new Array[Byte](data.length)
+    var i   = 0
+    var ctr = 0
+    while i < data.length do
+      val block = mac.doFinal(java.nio.ByteBuffer.allocate(4).putInt(ctr).array())
+      var j     = 0
+      while j < block.length && i + j < data.length do
+        out(i + j) = (data(i + j) ^ block(j)).toByte
+        j += 1
+      i += block.length
+      ctr += 1
+    out
+
+  private def serializeContext(context: Map[String, String]): Array[Byte] =
+    context.toSeq.sortBy(_._1).map((k, v) => s"$k=$v").mkString(" ").getBytes("UTF-8")

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
@@ -68,6 +68,17 @@ trait KeyService[F[_]]:
       by: Principal
   ): F[Either[KmsError, Array[Byte]]]
 
+  /** Wrap a Data Encryption Key (`dek`) under the KEK identified by `id`. Same state-gate as `encrypt`: key
+    * must be `Active`. The returned [[WrappedDek]] is opaque ciphertext suitable for storage alongside data
+    * encrypted with the unwrapped DEK — the KMIP envelope-encryption pattern.
+    */
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): F[Either[KmsError, WrappedDek]]
+
+  /** Unwrap a previously-wrapped DEK. Permitted on `Active` and `Deactivated` (so historical envelopes remain
+    * readable across rotations); refused on `Compromised` and `Destroyed`.
+    */
+  def unwrap(id: KeyId, wrapped: WrappedDek, by: Principal): F[Either[KmsError, Array[Byte]]]
+
 object KeyService:
 
   /** An in-memory reference implementation. Not durable, not safe for production — useful for tests, smoke
@@ -165,6 +176,32 @@ object KeyService:
                 Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}"))
               case Some(_) =>
                 deterministicOpen(id, context, ciphertext.bytes)
+          }
+
+        def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+          ref.get.map { m =>
+            m.get(id) match
+              case None =>
+                Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              case Some(k) if k.state != KeyState.Active =>
+                Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}, must be Active"))
+              case Some(_) =>
+                Right(WrappedDek(deterministicSeal(id, Map.empty, dek)))
+          }
+
+        def unwrap(
+            id: KeyId,
+            wrapped: WrappedDek,
+            by: Principal
+        ): IO[Either[KmsError, Array[Byte]]] =
+          ref.get.map { m =>
+            m.get(id) match
+              case None =>
+                Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              case Some(k) if k.state == KeyState.Compromised || k.state == KeyState.Destroyed =>
+                Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}"))
+              case Some(_) =>
+                deterministicOpen(id, Map.empty, wrapped.bytes)
           }
 
         private def transition(id: KeyId, to: KeyState): IO[Either[KmsError, ManagedKey]] =

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeyService.scala
@@ -5,13 +5,19 @@ import cats.syntax.all.*
 
 import java.time.Instant
 
-/** Describes a stored key from the service's perspective. */
+/** Describes a stored key from the service's perspective. `currentVersion` starts at `1` and increments by
+  * one each time `rotate` is called. The KMIP envelope-encryption flow keeps old ciphertexts and signatures
+  * verifiable after rotation: in the in-memory dev backend the deterministic MAC is keyed by `KeyId` only (so
+  * the byte output is version-stable), and AWS KMS handles per-version material internally so the same CMK
+  * decrypts both pre- and post-rotation ciphertexts.
+  */
 final case class ManagedKey(
     id: KeyId,
     spec: KeySpec,
     owner: Principal,
     createdAt: Instant,
-    state: KeyState
+    state: KeyState,
+    currentVersion: Int = 1
 )
 
 enum KeyState:
@@ -85,6 +91,15 @@ trait KeyService[F[_]]:
     * idempotent on an already-`Compromised` key. `Destroyed` keys cannot be compromised.
     */
   def compromise(id: KeyId, reason: String, by: Principal): F[Either[KmsError, ManagedKey]]
+
+  /** Rotate the key under `id`. The key's `currentVersion` is incremented and the rotation is recorded in the
+    * journal with the supplied `policy` (Manual for explicit calls; TimeBased / OpCountBased when the future
+    * auto-scheduler kicks in). Legal source state is `Active` only; rotating a `PreActive`, `Deactivated`,
+    * `Compromised`, or `Destroyed` key returns `KmsError(IllegalOperation, ...)`. Existing signatures and
+    * ciphertexts produced before the rotation continue to verify / decrypt — see the
+    * `ManagedKey.currentVersion` doc for why.
+    */
+  def rotate(id: KeyId, policy: RotationPolicy, by: Principal): F[Either[KmsError, ManagedKey]]
 
 object KeyService:
 
@@ -226,6 +241,27 @@ object KeyService:
                 (m, Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is Destroyed")))
               case Some(k) =>
                 val updated = k.copy(state = KeyState.Compromised)
+                (m + (id -> updated), Right(updated))
+          }
+
+        def rotate(
+            id: KeyId,
+            policy: RotationPolicy,
+            by: Principal
+        ): IO[Either[KmsError, ManagedKey]] =
+          ref.modify { m =>
+            m.get(id) match
+              case None =>
+                (m, Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}")))
+              case Some(k) if k.state != KeyState.Active =>
+                (
+                  m,
+                  Left(
+                    KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}, must be Active")
+                  )
+                )
+              case Some(k) =>
+                val updated = k.copy(currentVersion = k.currentVersion + 1)
                 (m + (id -> updated), Right(updated))
           }
 

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
@@ -10,7 +10,8 @@ enum Algorithm:
 
 /** KMIP operation names. Used for principal allowlists and audit records. */
 enum Operation:
-  case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Query, GetAttributes, AddAttribute
+  case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Encrypt, Decrypt, Query,
+    GetAttributes, AddAttribute
 
 /** Specification for a new key the server must generate. */
 final case class KeySpec(

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
@@ -11,7 +11,7 @@ enum Algorithm:
 /** KMIP operation names. Used for principal allowlists and audit records. */
 enum Operation:
   case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Encrypt, Decrypt, Wrap, Unwrap,
-    Compromise, Query, GetAttributes, AddAttribute
+    Rotate, Compromise, Query, GetAttributes, AddAttribute
 
 /** Specification for a new key the server must generate. */
 final case class KeySpec(

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
@@ -11,7 +11,7 @@ enum Algorithm:
 /** KMIP operation names. Used for principal allowlists and audit records. */
 enum Operation:
   case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Encrypt, Decrypt, Wrap, Unwrap,
-    Query, GetAttributes, AddAttribute
+    Compromise, Query, GetAttributes, AddAttribute
 
 /** Specification for a new key the server must generate. */
 final case class KeySpec(

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/KeySpec.scala
@@ -10,8 +10,8 @@ enum Algorithm:
 
 /** KMIP operation names. Used for principal allowlists and audit records. */
 enum Operation:
-  case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Encrypt, Decrypt, Query,
-    GetAttributes, AddAttribute
+  case Create, Get, Locate, Activate, Revoke, Destroy, Sign, Verify, Encrypt, Decrypt, Wrap, Unwrap,
+    Query, GetAttributes, AddAttribute
 
 /** Specification for a new key the server must generate. */
 final case class KeySpec(

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/RotationPolicy.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/RotationPolicy.scala
@@ -1,0 +1,43 @@
+package dev.aegiskms.core
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Why a rotation happened. Recorded on `KeyEvent.Rotated` and the audit row so post-incident review can tell
+  * an operator-initiated rotation apart from an automatic one driven by a time/op-count threshold.
+  *
+  * v0.1.1 carries the value through the algebra and journal; it does not yet drive an auto-rotation scheduler
+  * — explicit `aegis keys rotate` calls always pass `Manual`. The TimeBased / OpCountBased variants are
+  * populated when the v0.2.0 scheduler lands.
+  */
+enum RotationPolicy:
+  case Manual
+  case TimeBased(interval: FiniteDuration)
+  case OpCountBased(maxOps: Long)
+
+  /** Stable wire representation. The shape is intentionally human-readable so audit consumers can render the
+    * policy without a JSON parser, e.g. `"Manual"`, `"TimeBased:7d"`, `"OpCountBased:10000"`.
+    */
+  def render: String = this match
+    case RotationPolicy.Manual               => "Manual"
+    case RotationPolicy.TimeBased(interval)  => s"TimeBased:${interval.toString.replace(" ", "")}"
+    case RotationPolicy.OpCountBased(maxOps) => s"OpCountBased:$maxOps"
+
+object RotationPolicy:
+  /** Parse a wire-format string. Used by the REST DTOs and CLI. Examples:
+    *   - `"Manual"`
+    *   - `"TimeBased:7days"` / `"TimeBased:24hours"`
+    *   - `"OpCountBased:10000"`
+    */
+  def fromString(s: String): Either[String, RotationPolicy] =
+    s match
+      case "Manual" => Right(Manual)
+      case raw if raw.startsWith("TimeBased:") =>
+        val tail = raw.drop("TimeBased:".length)
+        try Right(TimeBased(scala.concurrent.duration.Duration(tail).asInstanceOf[FiniteDuration]))
+        catch case e: Throwable => Left(s"invalid TimeBased duration '$tail': ${e.getMessage}")
+      case raw if raw.startsWith("OpCountBased:") =>
+        val tail = raw.drop("OpCountBased:".length)
+        tail.toLongOption
+          .map(OpCountBased(_))
+          .toRight(s"invalid OpCountBased count '$tail'")
+      case other => Left(s"unknown rotation policy: $other")

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/WrappedDek.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/WrappedDek.scala
@@ -1,0 +1,16 @@
+package dev.aegiskms.core
+
+import java.util.Base64
+
+/** Opaque wrapped data-encryption-key bytes produced by `KeyService.wrap` and consumed by
+  * `KeyService.unwrap`. The KMIP envelope-encryption flow: the caller has DEK bytes, the KEK identified by
+  * `KeyId` wraps them, the result is treated as opaque. No encryption context — that's what `Ciphertext` is
+  * for; `WrappedDek` is for the KMIP-style key-wrapping use case where the protected payload is itself a key.
+  */
+final case class WrappedDek(bytes: Array[Byte]):
+  def toBase64: String = Base64.getEncoder.encodeToString(bytes)
+
+object WrappedDek:
+  def fromBase64(b64: String): Either[String, WrappedDek] =
+    try Right(WrappedDek(Base64.getDecoder.decode(b64)))
+    catch case e: IllegalArgumentException => Left(s"invalid base64: ${e.getMessage}")

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/codecs/KeyEventCodec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/codecs/KeyEventCodec.scala
@@ -48,6 +48,7 @@ object KeyEventCodec:
   private given activatedCodec: Codec.AsObject[KeyEvent.Activated]     = deriveCodec
   private given deactivatedCodec: Codec.AsObject[KeyEvent.Deactivated] = deriveCodec
   private given destroyedCodec: Codec.AsObject[KeyEvent.Destroyed]     = deriveCodec
+  private given compromisedCodec: Codec.AsObject[KeyEvent.Compromised] = deriveCodec
 
   // ── ADT codec with `"type"` discriminator ────────────────────────────────────
 
@@ -57,6 +58,8 @@ object KeyEventCodec:
     case e: KeyEvent.Deactivated =>
       deactivatedCodec.encodeObject(e).add("type", Json.fromString("Deactivated"))
     case e: KeyEvent.Destroyed => destroyedCodec.encodeObject(e).add("type", Json.fromString("Destroyed"))
+    case e: KeyEvent.Compromised =>
+      compromisedCodec.encodeObject(e).add("type", Json.fromString("Compromised"))
   }
 
   given Decoder[KeyEvent] = Decoder.instance { c =>
@@ -65,6 +68,7 @@ object KeyEventCodec:
       case "Activated"   => activatedCodec(c)
       case "Deactivated" => deactivatedCodec(c)
       case "Destroyed"   => destroyedCodec(c)
+      case "Compromised" => compromisedCodec(c)
       case other =>
         Left(DecodingFailure(s"Unknown KeyEvent type: $other", c.history))
     }

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/codecs/KeyEventCodec.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/codecs/KeyEventCodec.scala
@@ -49,6 +49,7 @@ object KeyEventCodec:
   private given deactivatedCodec: Codec.AsObject[KeyEvent.Deactivated] = deriveCodec
   private given destroyedCodec: Codec.AsObject[KeyEvent.Destroyed]     = deriveCodec
   private given compromisedCodec: Codec.AsObject[KeyEvent.Compromised] = deriveCodec
+  private given rotatedCodec: Codec.AsObject[KeyEvent.Rotated]         = deriveCodec
 
   // ── ADT codec with `"type"` discriminator ────────────────────────────────────
 
@@ -60,6 +61,7 @@ object KeyEventCodec:
     case e: KeyEvent.Destroyed => destroyedCodec.encodeObject(e).add("type", Json.fromString("Destroyed"))
     case e: KeyEvent.Compromised =>
       compromisedCodec.encodeObject(e).add("type", Json.fromString("Compromised"))
+    case e: KeyEvent.Rotated => rotatedCodec.encodeObject(e).add("type", Json.fromString("Rotated"))
   }
 
   given Decoder[KeyEvent] = Decoder.instance { c =>
@@ -69,6 +71,7 @@ object KeyEventCodec:
       case "Deactivated" => deactivatedCodec(c)
       case "Destroyed"   => destroyedCodec(c)
       case "Compromised" => compromisedCodec(c)
+      case "Rotated"     => rotatedCodec(c)
       case other =>
         Left(DecodingFailure(s"Unknown KeyEvent type: $other", c.history))
     }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
@@ -117,3 +117,64 @@ final class KeyServiceSpec extends AnyFunSuite with Matchers:
     result.isLeft shouldBe true
     result.swap.toOption.get.code shouldBe ErrorCode.ItemNotFound
   }
+
+  test("encrypt then decrypt round-trips with the same context") {
+    val ctx       = Map("dataset" -> "invoices-q2", "tenant" -> "acme")
+    val plaintext = "secret invoice payload".getBytes("UTF-8")
+
+    val opened = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("enc-key"), alice)
+      id = created.toOption.get.id
+      _  <- svc.activate(id, alice)
+      ct <- svc.encrypt(id, plaintext, ctx, alice)
+      ctv = ct.toOption.get
+      pt <- svc.decrypt(id, ctv, ctx, alice)
+    yield pt).unsafeRunSync()
+
+    opened.isRight shouldBe true
+    opened.toOption.get shouldBe plaintext
+  }
+
+  test("decrypt with a different context returns CryptographicFailure") {
+    val opened = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("enc-key"), alice)
+      id = created.toOption.get.id
+      _  <- svc.activate(id, alice)
+      ct <- svc.encrypt(id, "hi".getBytes, Map("a" -> "1"), alice)
+      ctv = ct.toOption.get
+      pt <- svc.decrypt(id, ctv, Map("a" -> "2"), alice)
+    yield pt).unsafeRunSync()
+
+    opened.isLeft shouldBe true
+    opened.swap.toOption.get.code shouldBe ErrorCode.CryptographicFailure
+  }
+
+  test("encrypt on a PreActive key returns IllegalOperation") {
+    val result = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("not-yet-active"), alice)
+      id = created.toOption.get.id
+      ct <- svc.encrypt(id, "data".getBytes, Map.empty, alice)
+    yield ct).unsafeRunSync()
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get.code shouldBe ErrorCode.IllegalOperation
+  }
+
+  test("decrypt is permitted on a Deactivated key (existing ciphertexts stay readable)") {
+    val opened = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("deact"), alice)
+      id = created.toOption.get.id
+      _  <- svc.activate(id, alice)
+      ct <- svc.encrypt(id, "rev".getBytes, Map.empty, alice)
+      ctv = ct.toOption.get
+      _  <- svc.revoke(id, alice)
+      pt <- svc.decrypt(id, ctv, Map.empty, alice)
+    yield pt).unsafeRunSync()
+
+    opened.isRight shouldBe true
+    new String(opened.toOption.get, "UTF-8") shouldBe "rev"
+  }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
@@ -289,3 +289,84 @@ final class KeyServiceSpec extends AnyFunSuite with Matchers:
 
     state shouldBe KeyState.Compromised
   }
+
+  test("a freshly-created key has currentVersion=1") {
+    val v = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("v1-key"), alice)
+    yield created.toOption.get.currentVersion).unsafeRunSync()
+
+    v shouldBe 1
+  }
+
+  test("rotate bumps currentVersion by one and keeps the key Active") {
+    val (version, state) = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("rotate-me"), alice)
+      id = created.toOption.get.id
+      _   <- svc.activate(id, alice)
+      _   <- svc.rotate(id, RotationPolicy.Manual, alice)
+      got <- svc.get(id, alice)
+    yield (got.toOption.get.currentVersion, got.toOption.get.state)).unsafeRunSync()
+
+    version shouldBe 2
+    state shouldBe KeyState.Active
+  }
+
+  test("rotate twice produces version 3") {
+    val v = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("rotate-twice"), alice)
+      id = created.toOption.get.id
+      _   <- svc.activate(id, alice)
+      _   <- svc.rotate(id, RotationPolicy.Manual, alice)
+      _   <- svc.rotate(id, RotationPolicy.Manual, alice)
+      got <- svc.get(id, alice)
+    yield got.toOption.get.currentVersion).unsafeRunSync()
+
+    v shouldBe 3
+  }
+
+  test("rotate on a PreActive key returns IllegalOperation") {
+    val r = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("not-active"), alice)
+      id = created.toOption.get.id
+      res <- svc.rotate(id, RotationPolicy.Manual, alice)
+    yield res).unsafeRunSync()
+
+    r.isLeft shouldBe true
+    r.swap.toOption.get.code shouldBe ErrorCode.IllegalOperation
+  }
+
+  test("verify of a pre-rotation signature still succeeds after rotation") {
+    val ok = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.rsa2048("rotation-verify"), alice)
+      id = created.toOption.get.id
+      _      <- svc.activate(id, alice)
+      signed <- svc.sign(id, "before".getBytes, SigAlgorithm.RsaPssSha256, alice)
+      sig = signed.toOption.get
+      _     <- svc.rotate(id, RotationPolicy.Manual, alice)
+      valid <- svc.verify(id, "before".getBytes, sig, alice)
+    yield valid).unsafeRunSync()
+
+    ok.isRight shouldBe true
+    ok.toOption.get shouldBe true
+  }
+
+  test("decrypt of a pre-rotation ciphertext still succeeds after rotation") {
+    val out = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("rotation-decrypt"), alice)
+      id = created.toOption.get.id
+      _  <- svc.activate(id, alice)
+      ct <- svc.encrypt(id, "secret".getBytes, Map("a" -> "1"), alice)
+      ctv = ct.toOption.get
+      _  <- svc.rotate(id, RotationPolicy.Manual, alice)
+      pt <- svc.decrypt(id, ctv, Map("a" -> "1"), alice)
+    yield pt).unsafeRunSync()
+
+    out.isRight shouldBe true
+    new String(out.toOption.get, "UTF-8") shouldBe "secret"
+  }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
@@ -178,3 +178,48 @@ final class KeyServiceSpec extends AnyFunSuite with Matchers:
     opened.isRight shouldBe true
     new String(opened.toOption.get, "UTF-8") shouldBe "rev"
   }
+
+  test("wrap then unwrap round-trips the DEK bytes") {
+    val dek = Array.tabulate(32)(i => (i * 13 + 7).toByte) // representative 32-byte DEK
+
+    val recovered = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("kek"), alice)
+      id = created.toOption.get.id
+      _ <- svc.activate(id, alice)
+      w <- svc.wrap(id, dek, alice)
+      wv = w.toOption.get
+      out <- svc.unwrap(id, wv, alice)
+    yield out).unsafeRunSync()
+
+    recovered.isRight shouldBe true
+    recovered.toOption.get shouldBe dek
+  }
+
+  test("wrap on a PreActive key returns IllegalOperation") {
+    val result = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("not-yet-active"), alice)
+      id = created.toOption.get.id
+      w <- svc.wrap(id, "dek".getBytes, alice)
+    yield w).unsafeRunSync()
+
+    result.isLeft shouldBe true
+    result.swap.toOption.get.code shouldBe ErrorCode.IllegalOperation
+  }
+
+  test("unwrap is permitted on a Deactivated key (existing wrapped DEKs stay recoverable)") {
+    val recovered = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("deact-kek"), alice)
+      id = created.toOption.get.id
+      _ <- svc.activate(id, alice)
+      w <- svc.wrap(id, "dek-bytes".getBytes, alice)
+      wv = w.toOption.get
+      _   <- svc.revoke(id, alice)
+      out <- svc.unwrap(id, wv, alice)
+    yield out).unsafeRunSync()
+
+    recovered.isRight shouldBe true
+    new String(recovered.toOption.get, "UTF-8") shouldBe "dek-bytes"
+  }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/KeyServiceSpec.scala
@@ -223,3 +223,69 @@ final class KeyServiceSpec extends AnyFunSuite with Matchers:
     recovered.isRight shouldBe true
     new String(recovered.toOption.get, "UTF-8") shouldBe "dek-bytes"
   }
+
+  test("compromise transitions an Active key to Compromised") {
+    val state = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("incident"), alice)
+      id = created.toOption.get.id
+      _   <- svc.activate(id, alice)
+      _   <- svc.compromise(id, "leaked in S3 audit", alice)
+      got <- svc.get(id, alice)
+    yield got.toOption.get.state).unsafeRunSync()
+
+    state shouldBe KeyState.Compromised
+  }
+
+  test("after compromise every cryptographic operation refuses with IllegalOperation") {
+    val results = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.rsa2048("locked-down"), alice)
+      id = created.toOption.get.id
+      _ <- svc.activate(id, alice)
+      // capture a signature + ciphertext while still Active to attempt verify/decrypt later
+      signed <- svc.sign(id, "m".getBytes, SigAlgorithm.RsaPssSha256, alice)
+      ct     <- svc.encrypt(id, "p".getBytes, Map.empty, alice)
+      w      <- svc.wrap(id, "d".getBytes, alice)
+      _      <- svc.compromise(id, "test", alice)
+      sigErr <- svc.sign(id, "m".getBytes, SigAlgorithm.RsaPssSha256, alice)
+      verErr <- svc.verify(id, "m".getBytes, signed.toOption.get, alice)
+      encErr <- svc.encrypt(id, "p".getBytes, Map.empty, alice)
+      decErr <- svc.decrypt(id, ct.toOption.get, Map.empty, alice)
+      wrErr  <- svc.wrap(id, "d".getBytes, alice)
+      unErr  <- svc.unwrap(id, w.toOption.get, alice)
+    yield List(sigErr, verErr, encErr, decErr, wrErr, unErr)).unsafeRunSync()
+
+    results.foreach { r =>
+      r.isLeft shouldBe true
+      r.swap.toOption.get.code shouldBe ErrorCode.IllegalOperation
+    }
+  }
+
+  test("compromise on a Destroyed key returns IllegalOperation") {
+    val result = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("gone"), alice)
+      id = created.toOption.get.id
+      _   <- svc.destroy(id, alice)
+      res <- svc.compromise(id, "too late", alice)
+    yield res).unsafeRunSync()
+
+    result.isLeft shouldBe true
+    // In-memory destroy removes the entry, so we observe ItemNotFound; with the actor backend the
+    // key row survives and we'd see IllegalOperation. Either is acceptable from the contract — the
+    // operator can't compromise something that's already gone.
+    result.swap.toOption.get.code should (be(ErrorCode.IllegalOperation) or be(ErrorCode.ItemNotFound))
+  }
+
+  test("compromise on a PreActive key is allowed (operator catches it before activation)") {
+    val state = (for
+      svc     <- KeyService.inMemory
+      created <- svc.create(KeySpec.aes256("never-activated"), alice)
+      id = created.toOption.get.id
+      _   <- svc.compromise(id, "discovered during pre-prod scan", alice)
+      got <- svc.get(id, alice)
+    yield got.toOption.get.state).unsafeRunSync()
+
+    state shouldBe KeyState.Compromised
+  }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/RotationPolicySpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/RotationPolicySpec.scala
@@ -1,0 +1,46 @@
+package dev.aegiskms.core
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.*
+
+/** Round-trips `RotationPolicy.render` ↔ `RotationPolicy.fromString` for every variant. The wire-format
+  * string ends up in audit rows and CLI output, so the parser and renderer must agree.
+  */
+final class RotationPolicySpec extends AnyFunSuite with Matchers:
+
+  test("Manual round-trips through render / fromString") {
+    val p = RotationPolicy.Manual
+    RotationPolicy.fromString(p.render) shouldBe Right(p)
+  }
+
+  test("TimeBased round-trips and renders without spaces") {
+    val p = RotationPolicy.TimeBased(7.days)
+    p.render should not include " "
+    RotationPolicy.fromString(p.render) shouldBe Right(p)
+  }
+
+  test("OpCountBased round-trips") {
+    val p = RotationPolicy.OpCountBased(10000L)
+    p.render shouldBe "OpCountBased:10000"
+    RotationPolicy.fromString(p.render) shouldBe Right(p)
+  }
+
+  test("fromString rejects an unknown policy name with a clear error") {
+    val r = RotationPolicy.fromString("Whatever")
+    r.isLeft shouldBe true
+    r.swap.toOption.get should include("Whatever")
+  }
+
+  test("fromString rejects a malformed TimeBased duration") {
+    val r = RotationPolicy.fromString("TimeBased:not-a-duration")
+    r.isLeft shouldBe true
+    r.swap.toOption.get should include("TimeBased")
+  }
+
+  test("fromString rejects a malformed OpCountBased count") {
+    val r = RotationPolicy.fromString("OpCountBased:abc")
+    r.isLeft shouldBe true
+    r.swap.toOption.get should include("OpCountBased")
+  }

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/codecs/KeyEventCodecSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/codecs/KeyEventCodecSpec.scala
@@ -57,6 +57,15 @@ final class KeyEventCodecSpec extends AnyFunSuite:
     assert(event.asJson.hcursor.get[String]("reason").contains("leaked in S3 audit 2026-05-08"))
   }
 
+  test("KeyEvent.Rotated round-trips, preserving newVersion and policy") {
+    val event: KeyEvent =
+      KeyEvent.Rotated("e7", now, keyId, "alice@org", newVersion = 3, policy = "Manual")
+    roundTrip(event)
+    assert(event.asJson.hcursor.get[String]("type").contains("Rotated"))
+    assert(event.asJson.hcursor.get[Int]("newVersion").contains(3))
+    assert(event.asJson.hcursor.get[String]("policy").contains("Manual"))
+  }
+
   test("decode rejects an unknown discriminator with a clear message") {
     val bogus =
       parse(

--- a/modules/aegis-core/src/test/scala/dev/aegiskms/core/codecs/KeyEventCodecSpec.scala
+++ b/modules/aegis-core/src/test/scala/dev/aegiskms/core/codecs/KeyEventCodecSpec.scala
@@ -49,6 +49,14 @@ final class KeyEventCodecSpec extends AnyFunSuite:
     roundTrip(KeyEvent.Destroyed("e4", now, keyId, "alice@org"))
   }
 
+  test("KeyEvent.Compromised round-trips, preserving reason") {
+    val event: KeyEvent =
+      KeyEvent.Compromised("e6", now, keyId, "alice@org", "leaked in S3 audit 2026-05-08")
+    roundTrip(event)
+    assert(event.asJson.hcursor.get[String]("type").contains("Compromised"))
+    assert(event.asJson.hcursor.get[String]("reason").contains("leaked in S3 audit 2026-05-08"))
+  }
+
   test("decode rejects an unknown discriminator with a clear message") {
     val bogus =
       parse(

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/RootOfTrust.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/RootOfTrust.scala
@@ -1,7 +1,7 @@
 package dev.aegiskms.crypto
 
 import cats.effect.IO
-import dev.aegiskms.core.{ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
+import dev.aegiskms.core.{Ciphertext, ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
 
 /** SPI for a root-of-trust provider. Implementations live in `dev.aegiskms.crypto.aws`,
   * `dev.aegiskms.crypto.gcp`, `dev.aegiskms.crypto.pkcs11`, etc., and are selected at server startup based on
@@ -38,6 +38,20 @@ trait RootOfTrust[F[_]]:
       message: Array[Byte],
       signature: Signature
   ): F[Either[KmsError, Boolean]]
+
+  // Bulk encryption family — used by `KeyService.encrypt` / `decrypt`. Encryption context is bound as AAD.
+
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String]
+  ): F[Either[KmsError, Ciphertext]]
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String]
+  ): F[Either[KmsError, Array[Byte]]]
 
 final case class WrappedKey(bytes: Array[Byte], rotationId: String)
 final case class RawKey(bytes: Array[Byte])
@@ -84,3 +98,71 @@ object RootOfTrust:
       }.handleError(e =>
         Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory verify failed: ${e.getMessage}"))
       )
+
+    def encrypt(
+        id: KeyId,
+        plaintext: Array[Byte],
+        context: Map[String, String]
+    ): IO[Either[KmsError, Ciphertext]] =
+      IO {
+        Right(Ciphertext(InMemoryAead.seal(id, context, plaintext)))
+      }.handleError(e =>
+        Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory encrypt failed: ${e.getMessage}"))
+      )
+
+    def decrypt(
+        id: KeyId,
+        ciphertext: Ciphertext,
+        context: Map[String, String]
+    ): IO[Either[KmsError, Array[Byte]]] =
+      IO(InMemoryAead.open(id, context, ciphertext.bytes))
+        .handleError(e =>
+          Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory decrypt failed: ${e.getMessage}"))
+        )
+
+/** Deterministic AEAD-shaped helper used by the dev/in-memory `RootOfTrust`. Layout: HMAC(id, ctx) ||
+  * plaintext XOR keystream(id, ctx). Round-trips correctly and detects context mismatch via the prefix; not
+  * real confidentiality. Real encryption lives in `AwsKmsRootOfTrust`.
+  */
+private object InMemoryAead:
+
+  def seal(id: KeyId, context: Map[String, String], plaintext: Array[Byte]): Array[Byte] =
+    contextTag(id, context) ++ keystream(id, context, plaintext)
+
+  def open(
+      id: KeyId,
+      context: Map[String, String],
+      ciphertext: Array[Byte]
+  ): Either[KmsError, Array[Byte]] =
+    if ciphertext.length < 32 then
+      Left(KmsError(ErrorCode.CryptographicFailure, "ciphertext too short"))
+    else
+      val (tag, masked) = ciphertext.splitAt(32)
+      if !java.util.Arrays.equals(tag, contextTag(id, context)) then
+        Left(KmsError(ErrorCode.CryptographicFailure, "encryption-context mismatch"))
+      else Right(keystream(id, context, masked))
+
+  private def contextTag(id: KeyId, context: Map[String, String]): Array[Byte] =
+    val mac = javax.crypto.Mac.getInstance("HmacSHA256")
+    mac.init(new javax.crypto.spec.SecretKeySpec(id.value.getBytes("UTF-8"), "HmacSHA256"))
+    mac.doFinal(serialize(context))
+
+  private def keystream(id: KeyId, context: Map[String, String], data: Array[Byte]): Array[Byte] =
+    val mac     = javax.crypto.Mac.getInstance("HmacSHA256")
+    val keyBase = id.value.getBytes("UTF-8") ++ serialize(context)
+    mac.init(new javax.crypto.spec.SecretKeySpec(keyBase, "HmacSHA256"))
+    val out = new Array[Byte](data.length)
+    var i   = 0
+    var ctr = 0
+    while i < data.length do
+      val block = mac.doFinal(java.nio.ByteBuffer.allocate(4).putInt(ctr).array())
+      var j     = 0
+      while j < block.length && i + j < data.length do
+        out(i + j) = (data(i + j) ^ block(j)).toByte
+        j += 1
+      i += block.length
+      ctr += 1
+    out
+
+  private def serialize(context: Map[String, String]): Array[Byte] =
+    context.toSeq.sortBy(_._1).map((k, v) => s"$k=$v").mkString(" ").getBytes("UTF-8")

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/RootOfTrust.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/RootOfTrust.scala
@@ -1,7 +1,16 @@
 package dev.aegiskms.crypto
 
 import cats.effect.IO
-import dev.aegiskms.core.{Ciphertext, ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
+import dev.aegiskms.core.{
+  Ciphertext,
+  ErrorCode,
+  KeyId,
+  KeySpec,
+  KmsError,
+  SigAlgorithm,
+  Signature,
+  WrappedDek
+}
 
 /** SPI for a root-of-trust provider. Implementations live in `dev.aegiskms.crypto.aws`,
   * `dev.aegiskms.crypto.gcp`, `dev.aegiskms.crypto.pkcs11`, etc., and are selected at server startup based on
@@ -52,6 +61,12 @@ trait RootOfTrust[F[_]]:
       ciphertext: Ciphertext,
       context: Map[String, String]
   ): F[Either[KmsError, Array[Byte]]]
+
+  // Key-wrapping family — KMIP-style envelope encryption of DEK material with no AAD.
+
+  def wrap(id: KeyId, dek: Array[Byte]): F[Either[KmsError, WrappedDek]]
+
+  def unwrapDek(id: KeyId, wrapped: WrappedDek): F[Either[KmsError, Array[Byte]]]
 
 final case class WrappedKey(bytes: Array[Byte], rotationId: String)
 final case class RawKey(bytes: Array[Byte])
@@ -118,6 +133,19 @@ object RootOfTrust:
       IO(InMemoryAead.open(id, context, ciphertext.bytes))
         .handleError(e =>
           Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory decrypt failed: ${e.getMessage}"))
+        )
+
+    def wrap(id: KeyId, dek: Array[Byte]): IO[Either[KmsError, WrappedDek]] =
+      IO {
+        Right(WrappedDek(InMemoryAead.seal(id, Map.empty, dek)))
+      }.handleError(e =>
+        Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory wrap failed: ${e.getMessage}"))
+      )
+
+    def unwrapDek(id: KeyId, wrapped: WrappedDek): IO[Either[KmsError, Array[Byte]]] =
+      IO(InMemoryAead.open(id, Map.empty, wrapped.bytes))
+        .handleError(e =>
+          Left(KmsError(ErrorCode.CryptographicFailure, s"in-memory unwrap failed: ${e.getMessage}"))
         )
 
 /** Deterministic AEAD-shaped helper used by the dev/in-memory `RootOfTrust`. Layout: HMAC(id, ctx) ||

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsPort.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsPort.scala
@@ -5,12 +5,15 @@ import software.amazon.awssdk.services.kms.model.{
   DataKeySpec,
   DecryptRequest,
   EnableKeyRotationRequest,
+  EncryptRequest,
   GenerateDataKeyRequest,
   MessageType,
   SignRequest,
   SigningAlgorithmSpec,
   VerifyRequest
 }
+
+import scala.jdk.CollectionConverters.*
 
 /** A minimal seam over `software.amazon.awssdk.services.kms.KmsClient` covering only the operations the Aegis
   * RoT calls. Two reasons it exists:
@@ -31,6 +34,12 @@ trait AwsKmsPort:
       signature: Array[Byte],
       alg: SigningAlgorithmSpec
   ): Boolean
+  def encrypt(keyArn: String, plaintext: Array[Byte], context: Map[String, String]): Array[Byte]
+  def decryptWithContext(
+      keyArn: String,
+      ciphertext: Array[Byte],
+      context: Map[String, String]
+  ): Array[Byte]
 
 object AwsKmsPort:
 
@@ -96,3 +105,23 @@ object AwsKmsPort:
         res.signatureValid().booleanValue()
       catch
         case _: software.amazon.awssdk.services.kms.model.KmsInvalidSignatureException => false
+
+    def encrypt(keyArn: String, plaintext: Array[Byte], context: Map[String, String]): Array[Byte] =
+      val builder = EncryptRequest.builder()
+        .keyId(keyArn)
+        .plaintext(software.amazon.awssdk.core.SdkBytes.fromByteArray(plaintext))
+      val withCtx = if context.nonEmpty then builder.encryptionContext(context.asJava) else builder
+      val res     = client.encrypt(withCtx.build())
+      res.ciphertextBlob().asByteArray()
+
+    def decryptWithContext(
+        keyArn: String,
+        ciphertext: Array[Byte],
+        context: Map[String, String]
+    ): Array[Byte] =
+      val builder = DecryptRequest.builder()
+        .keyId(keyArn)
+        .ciphertextBlob(software.amazon.awssdk.core.SdkBytes.fromByteArray(ciphertext))
+      val withCtx = if context.nonEmpty then builder.encryptionContext(context.asJava) else builder
+      val res     = client.decrypt(withCtx.build())
+      res.plaintext().asByteArray()

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
@@ -1,7 +1,7 @@
 package dev.aegiskms.crypto.aws
 
 import cats.effect.IO
-import dev.aegiskms.core.{Algorithm, ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
+import dev.aegiskms.core.{Algorithm, Ciphertext, ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
 import dev.aegiskms.crypto.{RawKey, RootOfTrust, WrappedKey}
 import software.amazon.awssdk.services.kms.KmsClient
 import software.amazon.awssdk.services.kms.model.{DataKeySpec, KmsException, SigningAlgorithmSpec}
@@ -71,6 +71,27 @@ final class AwsKmsRootOfTrust(port: AwsKmsPort, kekArn: String) extends RootOfTr
       )
       Right(ok)
     }.handleError(translate("Verify"))
+
+  /** Encrypt under the configured AWS KMS CMK with `EncryptionContext` bound as AAD. v0.1.1 uses the global
+    * `kekArn`; v0.2.0's per-Aegis-key-to-CMK mapping (PR L2) will resolve the ARN per `KeyId`.
+    */
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String]
+  ): IO[Either[KmsError, Ciphertext]] =
+    IO.blocking {
+      Right(Ciphertext(port.encrypt(kekArn, plaintext, context)))
+    }.handleError(translate("Encrypt"))
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String]
+  ): IO[Either[KmsError, Array[Byte]]] =
+    IO.blocking {
+      Right(port.decryptWithContext(kekArn, ciphertext.bytes, context))
+    }.handleError(translate("Decrypt"))
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
@@ -1,7 +1,17 @@
 package dev.aegiskms.crypto.aws
 
 import cats.effect.IO
-import dev.aegiskms.core.{Algorithm, Ciphertext, ErrorCode, KeyId, KeySpec, KmsError, SigAlgorithm, Signature}
+import dev.aegiskms.core.{
+  Algorithm,
+  Ciphertext,
+  ErrorCode,
+  KeyId,
+  KeySpec,
+  KmsError,
+  SigAlgorithm,
+  Signature,
+  WrappedDek
+}
 import dev.aegiskms.crypto.{RawKey, RootOfTrust, WrappedKey}
 import software.amazon.awssdk.services.kms.KmsClient
 import software.amazon.awssdk.services.kms.model.{DataKeySpec, KmsException, SigningAlgorithmSpec}
@@ -92,6 +102,20 @@ final class AwsKmsRootOfTrust(port: AwsKmsPort, kekArn: String) extends RootOfTr
     IO.blocking {
       Right(port.decryptWithContext(kekArn, ciphertext.bytes, context))
     }.handleError(translate("Decrypt"))
+
+  /** Wrap a DEK by feeding its bytes to AWS KMS `Encrypt` with no encryption context. The returned blob is
+    * opaque ciphertext that `unwrapDek` recovers via `Decrypt`. AWS doesn't have separate Wrap/Unwrap APIs at
+    * the symmetric-CMK level — this is the conventional wire-up.
+    */
+  def wrap(id: KeyId, dek: Array[Byte]): IO[Either[KmsError, WrappedDek]] =
+    IO.blocking {
+      Right(WrappedDek(port.encrypt(kekArn, dek, Map.empty)))
+    }.handleError(translate("Wrap"))
+
+  def unwrapDek(id: KeyId, wrapped: WrappedDek): IO[Either[KmsError, Array[Byte]]] =
+    IO.blocking {
+      Right(port.decryptWithContext(kekArn, wrapped.bytes, Map.empty))
+    }.handleError(translate("Unwrap"))
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/modules/aegis-crypto/src/test/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrustSpec.scala
+++ b/modules/aegis-crypto/src/test/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrustSpec.scala
@@ -9,7 +9,8 @@ import dev.aegiskms.core.{
   KeyObjectType,
   KeySpec,
   SigAlgorithm,
-  Signature
+  Signature,
+  WrappedDek
 }
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -216,6 +217,58 @@ final class AwsKmsRootOfTrustSpec extends AnyFunSuite with Matchers:
     res.isLeft shouldBe true
     res.swap.toOption.get.code shouldBe ErrorCode.CryptographicFailure
     res.swap.toOption.get.message should include("Encrypt")
+  }
+
+  test("wrap calls the port's encrypt with empty context and stamps the bytes onto a WrappedDek") {
+    var seenContext: Map[String, String] = Map("present" -> "wrong")
+    val port = new StubAwsKmsPort(
+      encryptFn = (arn, dek, ctx) => {
+        arn shouldBe kekArn
+        seenContext = ctx
+        dek ++ Array[Byte](0xee.toByte)
+      }
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot.wrap(KeyId.generate(), "dek-bytes".getBytes).unsafeRunSync()
+
+    res.isRight shouldBe true
+    res.toOption.get.bytes.last shouldBe 0xee.toByte
+    seenContext shouldBe Map.empty // wrap MUST NOT carry an AAD
+  }
+
+  test("unwrapDek calls the port's decrypt with empty context and returns the recovered bytes") {
+    var seenContext: Map[String, String] = Map("present" -> "wrong")
+    val port = new StubAwsKmsPort(
+      decryptCtxFn = (arn, blob, ctx) => {
+        arn shouldBe kekArn
+        seenContext = ctx
+        "recovered-dek".getBytes
+      }
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot.unwrapDek(KeyId.generate(), WrappedDek("anything".getBytes)).unsafeRunSync()
+
+    res.isRight shouldBe true
+    new String(res.toOption.get, "UTF-8") shouldBe "recovered-dek"
+    seenContext shouldBe Map.empty
+  }
+
+  test("AWS KmsException on Wrap translates to KmsError(CryptographicFailure, ...)") {
+    val port = new StubAwsKmsPort(
+      encryptFn = (_, _, _) =>
+        throw KmsException.builder()
+          .awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage("Disabled").errorCode("KeyDisabled").build()
+          )
+          .message("Disabled")
+          .build()
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot.wrap(KeyId.generate(), "x".getBytes).unsafeRunSync()
+
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.CryptographicFailure
+    res.swap.toOption.get.message should include("Wrap")
   }
 
   test("AWS KmsException on Sign translates to KmsError(CryptographicFailure, ...)") {

--- a/modules/aegis-crypto/src/test/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrustSpec.scala
+++ b/modules/aegis-crypto/src/test/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrustSpec.scala
@@ -1,7 +1,16 @@
 package dev.aegiskms.crypto.aws
 
 import cats.effect.unsafe.implicits.global
-import dev.aegiskms.core.{Algorithm, ErrorCode, KeyId, KeyObjectType, KeySpec, SigAlgorithm, Signature}
+import dev.aegiskms.core.{
+  Algorithm,
+  Ciphertext,
+  ErrorCode,
+  KeyId,
+  KeyObjectType,
+  KeySpec,
+  SigAlgorithm,
+  Signature
+}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails
@@ -155,6 +164,60 @@ final class AwsKmsRootOfTrustSpec extends AnyFunSuite with Matchers:
     resFalse shouldBe Right(false)
   }
 
+  test("encrypt delegates to the port with the supplied context and wraps the bytes") {
+    var seenContext: Map[String, String] = Map.empty
+    val port = new StubAwsKmsPort(
+      encryptFn = (arn, pt, ctx) => {
+        arn shouldBe kekArn
+        seenContext = ctx
+        pt ++ Array[Byte](0xff.toByte)
+      }
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot.encrypt(KeyId.generate(), "hi".getBytes, Map("a" -> "1")).unsafeRunSync()
+
+    res.isRight shouldBe true
+    res.toOption.get.bytes.last shouldBe 0xff.toByte
+    seenContext shouldBe Map("a" -> "1")
+  }
+
+  test("decrypt delegates to the port with the supplied context") {
+    var seenContext: Map[String, String] = Map.empty
+    val port = new StubAwsKmsPort(
+      decryptCtxFn = (arn, ct, ctx) => {
+        arn shouldBe kekArn
+        seenContext = ctx
+        "hi".getBytes
+      }
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot
+      .decrypt(KeyId.generate(), Ciphertext("anything".getBytes), Map("a" -> "1"))
+      .unsafeRunSync()
+
+    res.isRight shouldBe true
+    new String(res.toOption.get, "UTF-8") shouldBe "hi"
+    seenContext shouldBe Map("a" -> "1")
+  }
+
+  test("AWS KmsException on Encrypt translates to KmsError(CryptographicFailure, ...)") {
+    val port = new StubAwsKmsPort(
+      encryptFn = (_, _, _) =>
+        throw KmsException.builder()
+          .awsErrorDetails(
+            AwsErrorDetails.builder().errorMessage("Disabled").errorCode("KeyDisabled").build()
+          )
+          .message("Disabled")
+          .build()
+    )
+    val rot = AwsKmsRootOfTrust.withPort(port, kekArn)
+    val res = rot.encrypt(KeyId.generate(), "x".getBytes, Map.empty).unsafeRunSync()
+
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.CryptographicFailure
+    res.swap.toOption.get.message should include("Encrypt")
+  }
+
   test("AWS KmsException on Sign translates to KmsError(CryptographicFailure, ...)") {
     val port = new StubAwsKmsPort(
       signFn = (_, _, _) =>
@@ -190,7 +253,11 @@ final class AwsKmsRootOfTrustSpec extends AnyFunSuite with Matchers:
       signFn: (String, Array[Byte], SigningAlgorithmSpec) => Array[Byte] = (_, _, _) =>
         throw new UnsupportedOperationException("sign not stubbed"),
       verifyFn: (String, Array[Byte], Array[Byte], SigningAlgorithmSpec) => Boolean = (_, _, _, _) =>
-        throw new UnsupportedOperationException("verify not stubbed")
+        throw new UnsupportedOperationException("verify not stubbed"),
+      encryptFn: (String, Array[Byte], Map[String, String]) => Array[Byte] = (_, _, _) =>
+        throw new UnsupportedOperationException("encrypt not stubbed"),
+      decryptCtxFn: (String, Array[Byte], Map[String, String]) => Array[Byte] = (_, _, _) =>
+        throw new UnsupportedOperationException("decryptWithContext not stubbed")
   ) extends AwsKmsPort:
     def generateDataKey(kekArn: String, spec: DataKeySpec): AwsKmsPort.GenerateResult =
       generate(kekArn, spec)
@@ -207,3 +274,11 @@ final class AwsKmsRootOfTrustSpec extends AnyFunSuite with Matchers:
         alg: SigningAlgorithmSpec
     ): Boolean =
       verifyFn(keyArn, message, signature, alg)
+    def encrypt(keyArn: String, plaintext: Array[Byte], context: Map[String, String]): Array[Byte] =
+      encryptFn(keyArn, plaintext, context)
+    def decryptWithContext(
+        keyArn: String,
+        ciphertext: Array[Byte],
+        context: Map[String, String]
+    ): Array[Byte] =
+      decryptCtxFn(keyArn, ciphertext, context)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -119,5 +119,38 @@ object Endpoints:
       .summary("Verify a signature")
       .description("Returns `valid: true` when the signature checks out, `valid: false` otherwise.")
 
+  /** `POST /v1/keys/{id}/encrypt` — encrypt a base64-encoded plaintext. Key must be `Active`. The encryption
+    * context is bound as AAD; the same context must be supplied at decrypt time.
+    */
+  val encryptKey: PublicEndpoint[
+    (Option[String], Option[String], String, EncryptRequest),
+    (StatusCode, KmsErrorDto),
+    EncryptResponse,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "encrypt")
+      .in(jsonBody[EncryptRequest])
+      .out(jsonBody[EncryptResponse])
+      .summary("Encrypt a plaintext")
+      .description(
+        "Encrypts the supplied (base64) plaintext with the key. Encryption context is bound as AAD."
+      )
+
+  /** `POST /v1/keys/{id}/decrypt` — decrypt a ciphertext produced by /encrypt. Same context required. */
+  val decryptKey: PublicEndpoint[
+    (Option[String], Option[String], String, DecryptRequest),
+    (StatusCode, KmsErrorDto),
+    DecryptResponse,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "decrypt")
+      .in(jsonBody[DecryptRequest])
+      .out(jsonBody[DecryptResponse])
+      .summary("Decrypt a ciphertext")
+      .description("Decrypts a ciphertext produced by `/encrypt`. The context must match or the call fails.")
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
-  val all: List[AnyEndpoint] = List(createKey, getKey, activateKey, destroyKey, signKey, verifyKey)
+  val all: List[AnyEndpoint] =
+    List(createKey, getKey, activateKey, destroyKey, signKey, verifyKey, encryptKey, decryptKey)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -181,6 +181,25 @@ object Endpoints:
       .summary("Unwrap a DEK")
       .description("Recovers the original DEK bytes. Permitted on Active and Deactivated keys.")
 
+  /** `POST /v1/keys/{id}/compromise` — operator-issued lockdown. The key transitions to `Compromised` and
+    * refuses every cryptographic operation thereafter.
+    */
+  val compromiseKey: PublicEndpoint[
+    (Option[String], Option[String], String, CompromiseRequest),
+    (StatusCode, KmsErrorDto),
+    ManagedKeyDto,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "compromise")
+      .in(jsonBody[CompromiseRequest])
+      .out(jsonBody[ManagedKeyDto])
+      .summary("Compromise a key (operator override)")
+      .description(
+        "Marks the key as Compromised. From this state every cryptographic operation refuses with " +
+          "IllegalOperation. The supplied `reason` is recorded on the audit row at severity=Critical."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -193,5 +212,6 @@ object Endpoints:
       encryptKey,
       decryptKey,
       wrapKey,
-      unwrapKey
+      unwrapKey,
+      compromiseKey
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -200,6 +200,24 @@ object Endpoints:
           "IllegalOperation. The supplied `reason` is recorded on the audit row at severity=Critical."
       )
 
+  /** `POST /v1/keys/{id}/rotate` — bump the key's `currentVersion`. Legal source state is `Active` only. */
+  val rotateKey: PublicEndpoint[
+    (Option[String], Option[String], String, RotateRequest),
+    (StatusCode, KmsErrorDto),
+    ManagedKeyDto,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "rotate")
+      .in(jsonBody[RotateRequest])
+      .out(jsonBody[ManagedKeyDto])
+      .summary("Rotate a key (bump current version)")
+      .description(
+        "Increments the key's currentVersion. Legal source state is Active. Existing signatures and " +
+          "ciphertexts produced before the rotation continue to verify and decrypt. The supplied policy " +
+          "is recorded on the audit row."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -213,5 +231,6 @@ object Endpoints:
       decryptKey,
       wrapKey,
       unwrapKey,
-      compromiseKey
+      compromiseKey,
+      rotateKey
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -151,6 +151,47 @@ object Endpoints:
       .summary("Decrypt a ciphertext")
       .description("Decrypts a ciphertext produced by `/encrypt`. The context must match or the call fails.")
 
+  /** `POST /v1/keys/{id}/wrap` — wrap a data-encryption key under the named KEK. Key must be `Active`. */
+  val wrapKey: PublicEndpoint[
+    (Option[String], Option[String], String, WrapRequest),
+    (StatusCode, KmsErrorDto),
+    WrapResponse,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "wrap")
+      .in(jsonBody[WrapRequest])
+      .out(jsonBody[WrapResponse])
+      .summary("Wrap a DEK")
+      .description(
+        "KMIP-style envelope: the supplied DEK is wrapped under the KEK and returned as opaque bytes."
+      )
+
+  /** `POST /v1/keys/{id}/unwrap` — unwrap a previously wrapped DEK. Permitted on Active + Deactivated. */
+  val unwrapKey: PublicEndpoint[
+    (Option[String], Option[String], String, UnwrapRequest),
+    (StatusCode, KmsErrorDto),
+    UnwrapResponse,
+    Any
+  ] =
+    keysBase.post
+      .in(path[String]("id") / "unwrap")
+      .in(jsonBody[UnwrapRequest])
+      .out(jsonBody[UnwrapResponse])
+      .summary("Unwrap a DEK")
+      .description("Recovers the original DEK bytes. Permitted on Active and Deactivated keys.")
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
-    List(createKey, getKey, activateKey, destroyKey, signKey, verifyKey, encryptKey, decryptKey)
+    List(
+      createKey,
+      getKey,
+      activateKey,
+      destroyKey,
+      signKey,
+      verifyKey,
+      encryptKey,
+      decryptKey,
+      wrapKey,
+      unwrapKey
+    )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -228,6 +228,28 @@ final class HttpRoutes(
                   }
     }
 
+  private val compromiseSE: ServerEndpoint[Any, Future] =
+    Endpoints.compromiseKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              if req.reason.trim.isEmpty then
+                Future.successful(
+                  Left(StatusCode.BadRequest -> KmsErrorDto.of(
+                    ErrorCode.InvalidField,
+                    "reason must be non-empty"
+                  ))
+                )
+              else
+                runIO(svc.compromise(id, req.reason, principal)).map {
+                  case Left(err) => Left(errorOut(err))
+                  case Right(k)  => Right(ManagedKeyDto.fromCore(k))
+                }
+    }
+
   private def decodeSignRequest(
       req: SignRequest
   ): Either[(StatusCode, KmsErrorDto), (Array[Byte], SigAlgorithm)] =
@@ -272,7 +294,8 @@ final class HttpRoutes(
       encryptSE,
       decryptSE,
       wrapSE,
-      unwrapSE
+      unwrapSE,
+      compromiseSE
     )
 
   /** A pekko-http `Route` that mounts every endpoint. */

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -190,6 +190,44 @@ final class HttpRoutes(
                   }
     }
 
+  private val wrapSE: ServerEndpoint[Any, Future] =
+    Endpoints.wrapKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              decodeBase64(req.dekBase64, "dekBase64") match
+                case Left(e) => Future.successful(Left(e))
+                case Right(dek) =>
+                  runIO(svc.wrap(id, dek, principal)).map {
+                    case Left(err) => Left(errorOut(err))
+                    case Right(w)  => Right(WrapResponse.of(w))
+                  }
+    }
+
+  private val unwrapSE: ServerEndpoint[Any, Future] =
+    Endpoints.unwrapKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              WrappedDek.fromBase64(req.wrappedDekBase64) match
+                case Left(msg) =>
+                  Future.successful(
+                    Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
+                  )
+                case Right(w) =>
+                  runIO(svc.unwrap(id, w, principal)).map {
+                    case Left(err) => Left(errorOut(err))
+                    case Right(dek) =>
+                      Right(UnwrapResponse(java.util.Base64.getEncoder.encodeToString(dek)))
+                  }
+    }
+
   private def decodeSignRequest(
       req: SignRequest
   ): Either[(StatusCode, KmsErrorDto), (Array[Byte], SigAlgorithm)] =
@@ -224,7 +262,18 @@ final class HttpRoutes(
 
   /** All server endpoints, for the OpenAPI generator and the test stub interpreter. */
   val serverEndpoints: List[ServerEndpoint[Any, Future]] =
-    List(createSE, getSE, activateSE, destroySE, signSE, verifySE, encryptSE, decryptSE)
+    List(
+      createSE,
+      getSE,
+      activateSE,
+      destroySE,
+      signSE,
+      verifySE,
+      encryptSE,
+      decryptSE,
+      wrapSE,
+      unwrapSE
+    )
 
   /** A pekko-http `Route` that mounts every endpoint. */
   def routes: Route = PekkoHttpServerInterpreter().toRoute(serverEndpoints)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -250,6 +250,26 @@ final class HttpRoutes(
                 }
     }
 
+  private val rotateSE: ServerEndpoint[Any, Future] =
+    Endpoints.rotateKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              RotationPolicy.fromString(req.policy) match
+                case Left(msg) =>
+                  Future.successful(
+                    Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
+                  )
+                case Right(policy) =>
+                  runIO(svc.rotate(id, policy, principal)).map {
+                    case Left(err) => Left(errorOut(err))
+                    case Right(k)  => Right(ManagedKeyDto.fromCore(k))
+                  }
+    }
+
   private def decodeSignRequest(
       req: SignRequest
   ): Either[(StatusCode, KmsErrorDto), (Array[Byte], SigAlgorithm)] =
@@ -295,7 +315,8 @@ final class HttpRoutes(
       decryptSE,
       wrapSE,
       unwrapSE,
-      compromiseSE
+      compromiseSE,
+      rotateSE
     )
 
   /** A pekko-http `Route` that mounts every endpoint. */

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -152,6 +152,44 @@ final class HttpRoutes(
                   }
     }
 
+  private val encryptSE: ServerEndpoint[Any, Future] =
+    Endpoints.encryptKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              decodeBase64(req.plaintextBase64, "plaintextBase64") match
+                case Left(e) => Future.successful(Left(e))
+                case Right(plaintext) =>
+                  runIO(svc.encrypt(id, plaintext, req.context, principal)).map {
+                    case Left(err) => Left(errorOut(err))
+                    case Right(ct) => Right(EncryptResponse.of(ct, req.context))
+                  }
+    }
+
+  private val decryptSE: ServerEndpoint[Any, Future] =
+    Endpoints.decryptKey.serverLogic { case (auth, devHdr, idStr, req) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          parseId(idStr) match
+            case Left(e) => Future.successful(Left(e))
+            case Right(id) =>
+              Ciphertext.fromBase64(req.ciphertextBase64) match
+                case Left(msg) =>
+                  Future.successful(
+                    Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
+                  )
+                case Right(ct) =>
+                  runIO(svc.decrypt(id, ct, req.context, principal)).map {
+                    case Left(err) => Left(errorOut(err))
+                    case Right(pt) =>
+                      Right(DecryptResponse(java.util.Base64.getEncoder.encodeToString(pt), req.context))
+                  }
+    }
+
   private def decodeSignRequest(
       req: SignRequest
   ): Either[(StatusCode, KmsErrorDto), (Array[Byte], SigAlgorithm)] =
@@ -186,7 +224,7 @@ final class HttpRoutes(
 
   /** All server endpoints, for the OpenAPI generator and the test stub interpreter. */
   val serverEndpoints: List[ServerEndpoint[Any, Future]] =
-    List(createSE, getSE, activateSE, destroySE, signSE, verifySE)
+    List(createSE, getSE, activateSE, destroySE, signSE, verifySE, encryptSE, decryptSE)
 
   /** A pekko-http `Route` that mounts every endpoint. */
   def routes: Route = PekkoHttpServerInterpreter().toRoute(serverEndpoints)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -153,3 +153,13 @@ object JsonCodecs:
   object UnwrapResponse:
     given Encoder[UnwrapResponse] = deriveEncoder
     given Decoder[UnwrapResponse] = deriveDecoder
+
+  // ── Compromise DTO ─────────────────────────────────────────────────────────
+
+  /** Compromise request body. The mandatory `reason` is the human-readable justification recorded in the
+    * audit row. Empty strings are rejected at the route layer.
+    */
+  final case class CompromiseRequest(reason: String)
+  object CompromiseRequest:
+    given Encoder[CompromiseRequest] = deriveEncoder
+    given Decoder[CompromiseRequest] = deriveDecoder

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -99,3 +99,32 @@ object JsonCodecs:
   object VerifyResponse:
     given Encoder[VerifyResponse] = deriveEncoder
     given Decoder[VerifyResponse] = deriveDecoder
+
+  // ── Encrypt / decrypt DTOs ─────────────────────────────────────────────────
+
+  /** Encrypt request body. `plaintextBase64` is the base64-encoded message bytes; `context` is the optional
+    * encryption-context map (additional authenticated data). Both encrypt and decrypt must supply the same
+    * context — a mismatch on decrypt returns a 400 with `CryptographicFailure`.
+    */
+  final case class EncryptRequest(plaintextBase64: String, context: Map[String, String] = Map.empty)
+  object EncryptRequest:
+    given Encoder[EncryptRequest] = deriveEncoder
+    given Decoder[EncryptRequest] = deriveDecoder
+
+  final case class EncryptResponse(ciphertextBase64: String, context: Map[String, String])
+  object EncryptResponse:
+    def of(ct: Ciphertext, context: Map[String, String]): EncryptResponse =
+      EncryptResponse(ct.toBase64, context)
+
+    given Encoder[EncryptResponse] = deriveEncoder
+    given Decoder[EncryptResponse] = deriveDecoder
+
+  final case class DecryptRequest(ciphertextBase64: String, context: Map[String, String] = Map.empty)
+  object DecryptRequest:
+    given Encoder[DecryptRequest] = deriveEncoder
+    given Decoder[DecryptRequest] = deriveDecoder
+
+  final case class DecryptResponse(plaintextBase64: String, context: Map[String, String])
+  object DecryptResponse:
+    given Encoder[DecryptResponse] = deriveEncoder
+    given Decoder[DecryptResponse] = deriveDecoder

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -128,3 +128,28 @@ object JsonCodecs:
   object DecryptResponse:
     given Encoder[DecryptResponse] = deriveEncoder
     given Decoder[DecryptResponse] = deriveDecoder
+
+  // ── Wrap / unwrap DTOs ─────────────────────────────────────────────────────
+
+  /** Wrap request body. `dekBase64` is the base64-encoded DEK material to be wrapped under the named KEK. */
+  final case class WrapRequest(dekBase64: String)
+  object WrapRequest:
+    given Encoder[WrapRequest] = deriveEncoder
+    given Decoder[WrapRequest] = deriveDecoder
+
+  final case class WrapResponse(wrappedDekBase64: String)
+  object WrapResponse:
+    def of(w: WrappedDek): WrapResponse = WrapResponse(w.toBase64)
+
+    given Encoder[WrapResponse] = deriveEncoder
+    given Decoder[WrapResponse] = deriveDecoder
+
+  final case class UnwrapRequest(wrappedDekBase64: String)
+  object UnwrapRequest:
+    given Encoder[UnwrapRequest] = deriveEncoder
+    given Decoder[UnwrapRequest] = deriveDecoder
+
+  final case class UnwrapResponse(dekBase64: String)
+  object UnwrapResponse:
+    given Encoder[UnwrapResponse] = deriveEncoder
+    given Decoder[UnwrapResponse] = deriveDecoder

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -50,11 +50,18 @@ object JsonCodecs:
       id: String,
       spec: KeySpecDto,
       createdAt: Instant,
-      state: String
+      state: String,
+      currentVersion: Int = 1
   )
   object ManagedKeyDto:
     def fromCore(k: ManagedKey): ManagedKeyDto =
-      ManagedKeyDto(k.id.value, KeySpecDto.fromCore(k.spec), k.createdAt, k.state.toString)
+      ManagedKeyDto(
+        k.id.value,
+        KeySpecDto.fromCore(k.spec),
+        k.createdAt,
+        k.state.toString,
+        k.currentVersion
+      )
 
     given Encoder[ManagedKeyDto] = deriveEncoder
     given Decoder[ManagedKeyDto] = deriveDecoder
@@ -163,3 +170,13 @@ object JsonCodecs:
   object CompromiseRequest:
     given Encoder[CompromiseRequest] = deriveEncoder
     given Decoder[CompromiseRequest] = deriveDecoder
+
+  // ── Rotate DTO ─────────────────────────────────────────────────────────────
+
+  /** Rotate request body. `policy` is the wire-format `RotationPolicy.render` string. Defaults to `"Manual"`
+    * when the field is absent.
+    */
+  final case class RotateRequest(policy: String = "Manual")
+  object RotateRequest:
+    given Encoder[RotateRequest] = deriveEncoder
+    given Decoder[RotateRequest] = deriveDecoder

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
@@ -276,3 +276,62 @@ final class HttpRoutesSpec extends AnyFunSuite with Matchers with ScalatestRoute
       responseAs[String] should include(""""code":"IllegalOperation"""")
     }
   }
+
+  test("POST /v1/keys/{id}/wrap + /unwrap round-trip recovers the DEK bytes") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    val dek        = "0123456789abcdef0123456789abcdef" // 32 bytes, representative DEK
+    val dekB64     = java.util.Base64.getEncoder.encodeToString(dek.getBytes)
+    var wrappedB64 = ""
+
+    Post(s"/v1/keys/$id/wrap", jsonEntity(s"""{"dekBase64":"$dekB64"}""")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      wrappedB64 = extractField(responseAs[String], "wrappedDekBase64")
+      wrappedB64.nonEmpty shouldBe true
+    }
+
+    val unwrapBody = s"""{"wrappedDekBase64":"$wrappedB64"}"""
+    Post(s"/v1/keys/$id/unwrap", jsonEntity(unwrapBody)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val recoveredB64 = extractField(responseAs[String], "dekBase64")
+      new String(java.util.Base64.getDecoder.decode(recoveredB64), "UTF-8") shouldBe dek
+    }
+  }
+
+  test("POST /v1/keys/{id}/wrap on a PreActive key returns 500 IllegalOperation") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    val dekB64 = java.util.Base64.getEncoder.encodeToString("dek".getBytes)
+    Post(s"/v1/keys/$id/wrap", jsonEntity(s"""{"dekBase64":"$dekB64"}""")) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+      responseAs[String] should include(""""code":"IllegalOperation"""")
+    }
+  }
+
+  test("POST /v1/keys/{id}/unwrap with a malformed base64 returns 400 InvalidField") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    Post(
+      s"/v1/keys/$id/unwrap",
+      jsonEntity("""{"wrappedDekBase64":"not-base-64-at-all!"}""")
+    ) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include(""""code":"InvalidField"""")
+    }
+  }

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
@@ -207,3 +207,72 @@ final class HttpRoutesSpec extends AnyFunSuite with Matchers with ScalatestRoute
       responseAs[String] should include(""""code":"InvalidField"""")
     }
   }
+
+  test("POST /v1/keys/{id}/encrypt + /decrypt round-trip with the same context") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    val plaintext = "secret-payload"
+    val ptB64     = java.util.Base64.getEncoder.encodeToString(plaintext.getBytes)
+    val encBody =
+      s"""{"plaintextBase64":"$ptB64","context":{"dataset":"q2","tenant":"acme"}}"""
+    var ctB64 = ""
+
+    Post(s"/v1/keys/$id/encrypt", jsonEntity(encBody)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      ctB64 = extractField(body, "ciphertextBase64")
+      body should include(""""context":{""")
+    }
+
+    val decBody =
+      s"""{"ciphertextBase64":"$ctB64","context":{"dataset":"q2","tenant":"acme"}}"""
+    Post(s"/v1/keys/$id/decrypt", jsonEntity(decBody)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val ptOut = extractField(responseAs[String], "plaintextBase64")
+      new String(java.util.Base64.getDecoder.decode(ptOut), "UTF-8") shouldBe plaintext
+    }
+  }
+
+  test("POST /v1/keys/{id}/decrypt with a mismatched context returns 500 CryptographicFailure") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    val ptB64   = java.util.Base64.getEncoder.encodeToString("hi".getBytes)
+    val encBody = s"""{"plaintextBase64":"$ptB64","context":{"a":"1"}}"""
+    var ctB64   = ""
+    Post(s"/v1/keys/$id/encrypt", jsonEntity(encBody)) ~> route ~> check {
+      ctB64 = extractField(responseAs[String], "ciphertextBase64")
+    }
+
+    val decBody = s"""{"ciphertextBase64":"$ctB64","context":{"a":"2"}}"""
+    Post(s"/v1/keys/$id/decrypt", jsonEntity(decBody)) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+      responseAs[String] should include(""""code":"CryptographicFailure"""")
+    }
+  }
+
+  test("POST /v1/keys/{id}/encrypt on a PreActive key returns 500 IllegalOperation") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    val ptB64   = java.util.Base64.getEncoder.encodeToString("data".getBytes)
+    val encBody = s"""{"plaintextBase64":"$ptB64","context":{}}"""
+    Post(s"/v1/keys/$id/encrypt", jsonEntity(encBody)) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+      responseAs[String] should include(""""code":"IllegalOperation"""")
+    }
+  }

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
@@ -335,3 +335,42 @@ final class HttpRoutesSpec extends AnyFunSuite with Matchers with ScalatestRoute
       responseAs[String] should include(""""code":"InvalidField"""")
     }
   }
+
+  test("POST /v1/keys/{id}/compromise transitions the key to Compromised and locks crypto ops") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    Post(
+      s"/v1/keys/$id/compromise",
+      jsonEntity("""{"reason":"leaked in S3 audit"}""")
+    ) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[String] should include(""""state":"Compromised"""")
+    }
+
+    // Subsequent /sign refuses with IllegalOperation.
+    val msgB64   = java.util.Base64.getEncoder.encodeToString("data".getBytes)
+    val signBody = s"""{"messageBase64":"$msgB64","algorithm":"RsaPssSha256"}"""
+    Post(s"/v1/keys/$id/sign", jsonEntity(signBody)) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+      responseAs[String] should include(""""code":"IllegalOperation"""")
+    }
+  }
+
+  test("POST /v1/keys/{id}/compromise with a blank reason returns 400 InvalidField") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/compromise", jsonEntity("""{"reason":"   "}""")) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include(""""code":"InvalidField"""")
+    }
+  }

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
@@ -374,3 +374,48 @@ final class HttpRoutesSpec extends AnyFunSuite with Matchers with ScalatestRoute
       responseAs[String] should include(""""code":"InvalidField"""")
     }
   }
+
+  test("POST /v1/keys/{id}/rotate bumps currentVersion and keeps state Active") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    Post(s"/v1/keys/$id/rotate", jsonEntity("""{"policy":"Manual"}""")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      body should include(""""state":"Active"""")
+      body should include(""""currentVersion":2""")
+    }
+  }
+
+  test("POST /v1/keys/{id}/rotate on a PreActive key returns 500 IllegalOperation") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/rotate", jsonEntity("""{"policy":"Manual"}""")) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+      responseAs[String] should include(""""code":"IllegalOperation"""")
+    }
+  }
+
+  test("POST /v1/keys/{id}/rotate with a malformed policy returns 400 InvalidField") {
+    val route = freshRoute()
+    var id    = ""
+
+    Post("/v1/keys", jsonEntity(createBody)) ~> route ~> check {
+      id = extractField(responseAs[String], "id")
+    }
+    Post(s"/v1/keys/$id/activate") ~> route ~> check(status shouldBe StatusCodes.OK)
+
+    Post(s"/v1/keys/$id/rotate", jsonEntity("""{"policy":"NopeBased"}""")) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include(""""code":"InvalidField"""")
+    }
+  }

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
@@ -85,6 +85,9 @@ final class AuthorizingKeyService(
   ): IO[Either[KmsError, Array[Byte]]] =
     guard(by, Operation.Unwrap, id.value)(inner.unwrap(id, wrapped, by))
 
+  def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    guard(by, Operation.Compromise, id.value)(inner.compromise(id, reason, by))
+
   private def guard[A](by: Principal, op: Operation, resource: String)(
       action: => IO[Either[KmsError, A]]
   ): IO[Either[KmsError, A]] =

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
@@ -59,6 +59,22 @@ final class AuthorizingKeyService(
   ): IO[Either[KmsError, Boolean]] =
     guard(by, Operation.Verify, id.value)(inner.verify(id, message, signature, by))
 
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Ciphertext]] =
+    guard(by, Operation.Encrypt, id.value)(inner.encrypt(id, plaintext, context, by))
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    guard(by, Operation.Decrypt, id.value)(inner.decrypt(id, ciphertext, context, by))
+
   private def guard[A](by: Principal, op: Operation, resource: String)(
       action: => IO[Either[KmsError, A]]
   ): IO[Either[KmsError, A]] =

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
@@ -75,6 +75,16 @@ final class AuthorizingKeyService(
   ): IO[Either[KmsError, Array[Byte]]] =
     guard(by, Operation.Decrypt, id.value)(inner.decrypt(id, ciphertext, context, by))
 
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+    guard(by, Operation.Wrap, id.value)(inner.wrap(id, dek, by))
+
+  def unwrap(
+      id: KeyId,
+      wrapped: WrappedDek,
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    guard(by, Operation.Unwrap, id.value)(inner.unwrap(id, wrapped, by))
+
   private def guard[A](by: Principal, op: Operation, resource: String)(
       action: => IO[Either[KmsError, A]]
   ): IO[Either[KmsError, A]] =

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AuthorizingKeyService.scala
@@ -88,6 +88,9 @@ final class AuthorizingKeyService(
   def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
     guard(by, Operation.Compromise, id.value)(inner.compromise(id, reason, by))
 
+  def rotate(id: KeyId, policy: RotationPolicy, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    guard(by, Operation.Rotate, id.value)(inner.rotate(id, policy, by))
+
   private def guard[A](by: Principal, op: Operation, resource: String)(
       action: => IO[Either[KmsError, A]]
   ): IO[Either[KmsError, A]] =

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
@@ -160,3 +160,34 @@ final class AuthorizingKeyServiceSpec extends AnyFunSuite with Matchers:
     out.isRight shouldBe true
     new String(out.toOption.get, "UTF-8") shouldBe "dek-bytes"
   }
+
+  test("compromise is denied when the agent's allowedOps doesn't include Compromise") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+    val agent = Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "ordinary",
+      issuedAt = Instant.now(),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get, Operation.Sign), // no Compromise — agents shouldn't be able
+      parent = None
+    )
+    val res = svc.compromise(KeyId.generate(), "no-go", agent).unsafeRunSync()
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.PermissionDenied
+  }
+
+  test("compromise passes through when the principal has the role and the op") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+
+    val created = svc.create(KeySpec.aes256("incident"), alice).unsafeRunSync()
+    created.isRight shouldBe true
+    val id = created.toOption.get.id
+    svc.activate(id, alice).unsafeRunSync()
+
+    val res = svc.compromise(id, "leaked in S3", alice).unsafeRunSync()
+    res.isRight shouldBe true
+    res.toOption.get.state shouldBe KeyState.Compromised
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
@@ -92,3 +92,37 @@ final class AuthorizingKeyServiceSpec extends AnyFunSuite with Matchers:
     val res = svc.sign(id, "msg".getBytes, SigAlgorithm.RsaPssSha256, agent).unsafeRunSync()
     res.isRight shouldBe true
   }
+
+  test("encrypt is denied when the agent's allowedOps doesn't include Encrypt") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+    val agent = Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "verify-only",
+      issuedAt = Instant.now(),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get), // no Encrypt
+      parent = None
+    )
+    val res = svc.encrypt(KeyId.generate(), "x".getBytes, Map.empty, agent).unsafeRunSync()
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.PermissionDenied
+  }
+
+  test("encrypt + decrypt pass through when the principal has the role and the ops") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+
+    val created = svc.create(KeySpec.aes256("enc-key"), alice).unsafeRunSync()
+    created.isRight shouldBe true
+    val id = created.toOption.get.id
+    svc.activate(id, alice).unsafeRunSync()
+
+    val ct = svc.encrypt(id, "secret".getBytes, Map("a" -> "1"), alice).unsafeRunSync()
+    ct.isRight shouldBe true
+
+    val pt = svc.decrypt(id, ct.toOption.get, Map("a" -> "1"), alice).unsafeRunSync()
+    pt.isRight shouldBe true
+    new String(pt.toOption.get, "UTF-8") shouldBe "secret"
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
@@ -126,3 +126,37 @@ final class AuthorizingKeyServiceSpec extends AnyFunSuite with Matchers:
     pt.isRight shouldBe true
     new String(pt.toOption.get, "UTF-8") shouldBe "secret"
   }
+
+  test("wrap is denied when the agent's allowedOps doesn't include Wrap") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+    val agent = Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "decrypt-only",
+      issuedAt = Instant.now(),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get, Operation.Decrypt), // no Wrap
+      parent = None
+    )
+    val res = svc.wrap(KeyId.generate(), "dek".getBytes, agent).unsafeRunSync()
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.PermissionDenied
+  }
+
+  test("wrap + unwrap pass through when the principal has the role and the ops") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+
+    val created = svc.create(KeySpec.aes256("kek"), alice).unsafeRunSync()
+    created.isRight shouldBe true
+    val id = created.toOption.get.id
+    svc.activate(id, alice).unsafeRunSync()
+
+    val w = svc.wrap(id, "dek-bytes".getBytes, alice).unsafeRunSync()
+    w.isRight shouldBe true
+
+    val out = svc.unwrap(id, w.toOption.get, alice).unsafeRunSync()
+    out.isRight shouldBe true
+    new String(out.toOption.get, "UTF-8") shouldBe "dek-bytes"
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AuthorizingKeyServiceSpec.scala
@@ -191,3 +191,34 @@ final class AuthorizingKeyServiceSpec extends AnyFunSuite with Matchers:
     res.isRight shouldBe true
     res.toOption.get.state shouldBe KeyState.Compromised
   }
+
+  test("rotate is denied when the agent's allowedOps doesn't include Rotate") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+    val agent = Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "ordinary",
+      issuedAt = Instant.now(),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get, Operation.Sign), // no Rotate — agents shouldn't be able
+      parent = None
+    )
+    val res = svc.rotate(KeyId.generate(), RotationPolicy.Manual, agent).unsafeRunSync()
+    res.isLeft shouldBe true
+    res.swap.toOption.get.code shouldBe ErrorCode.PermissionDenied
+  }
+
+  test("rotate passes through and bumps currentVersion when the principal has the role and the op") {
+    val engine = RoleBasedPolicyEngine.adminsOnly("admins")
+    val svc    = fixture(engine)
+
+    val created = svc.create(KeySpec.aes256("rotate"), alice).unsafeRunSync()
+    created.isRight shouldBe true
+    val id = created.toOption.get.id
+    svc.activate(id, alice).unsafeRunSync()
+
+    val res = svc.rotate(id, RotationPolicy.Manual, alice).unsafeRunSync()
+    res.isRight shouldBe true
+    res.toOption.get.currentVersion shouldBe 2
+  }

--- a/modules/aegis-persistence/src/main/scala/dev/aegiskms/persistence/PostgresEventJournal.scala
+++ b/modules/aegis-persistence/src/main/scala/dev/aegiskms/persistence/PostgresEventJournal.scala
@@ -99,6 +99,7 @@ object PostgresEventJournal:
         case _: KeyEvent.Activated   => "Activated"
         case _: KeyEvent.Deactivated => "Deactivated"
         case _: KeyEvent.Destroyed   => "Destroyed"
+        case _: KeyEvent.Compromised => "Compromised"
       sql"""
         INSERT INTO aegis_key_events
           (event_id, key_id, event_type, occurred_at, actor_subject, payload)

--- a/modules/aegis-persistence/src/main/scala/dev/aegiskms/persistence/PostgresEventJournal.scala
+++ b/modules/aegis-persistence/src/main/scala/dev/aegiskms/persistence/PostgresEventJournal.scala
@@ -100,6 +100,7 @@ object PostgresEventJournal:
         case _: KeyEvent.Deactivated => "Deactivated"
         case _: KeyEvent.Destroyed   => "Destroyed"
         case _: KeyEvent.Compromised => "Compromised"
+        case _: KeyEvent.Rotated     => "Rotated"
       sql"""
         INSERT INTO aegis_key_events
           (event_id, key_id, event_type, occurred_at, actor_subject, payload)

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
@@ -113,3 +113,11 @@ final class ActorBackedKeyService(
         IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}")))
       case Right(_) => rootOfTrust.unwrapDek(id, wrapped)
     }
+
+  /** State-mutating: routes through the actor mailbox so the journal append + state transition are serialized
+    * with the rest of the lifecycle.
+    */
+  def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    IO.fromFuture(IO(actor.ask[Either[KmsError, ManagedKey]](ref =>
+      KeyOpsActor.Compromise(id, reason, by, ref)
+    )))

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
@@ -93,3 +93,23 @@ final class ActorBackedKeyService(
         IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}")))
       case Right(_) => rootOfTrust.decrypt(id, ciphertext, context)
     }
+
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+    get(id, by).flatMap {
+      case Left(err) => IO.pure(Left(err))
+      case Right(k) if k.state != KeyState.Active =>
+        IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}, must be Active")))
+      case Right(_) => rootOfTrust.wrap(id, dek)
+    }
+
+  def unwrap(
+      id: KeyId,
+      wrapped: WrappedDek,
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    get(id, by).flatMap {
+      case Left(err) => IO.pure(Left(err))
+      case Right(k) if k.state == KeyState.Compromised || k.state == KeyState.Destroyed =>
+        IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}")))
+      case Right(_) => rootOfTrust.unwrapDek(id, wrapped)
+    }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
@@ -67,3 +67,29 @@ final class ActorBackedKeyService(
       case Left(err) => IO.pure(Left(err))
       case Right(_)  => rootOfTrust.verify(id, message, signature)
     }
+
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Ciphertext]] =
+    get(id, by).flatMap {
+      case Left(err) => IO.pure(Left(err))
+      case Right(k) if k.state != KeyState.Active =>
+        IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}, must be Active")))
+      case Right(_) => rootOfTrust.encrypt(id, plaintext, context)
+    }
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    get(id, by).flatMap {
+      case Left(err) => IO.pure(Left(err))
+      case Right(k) if k.state == KeyState.Compromised || k.state == KeyState.Destroyed =>
+        IO.pure(Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is ${k.state}")))
+      case Right(_) => rootOfTrust.decrypt(id, ciphertext, context)
+    }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/ActorBackedKeyService.scala
@@ -121,3 +121,12 @@ final class ActorBackedKeyService(
     IO.fromFuture(IO(actor.ask[Either[KmsError, ManagedKey]](ref =>
       KeyOpsActor.Compromise(id, reason, by, ref)
     )))
+
+  /** State-mutating: routes through the actor for the same reason as `compromise`. v0.1.1 doesn't yet drive
+    * AWS-side `EnableKeyRotation` from this path — that wiring lands when per-Aegis-key-to-CMK mapping
+    * arrives in v0.2.0 (PR L2).
+    */
+  def rotate(id: KeyId, policy: RotationPolicy, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    IO.fromFuture(IO(actor.ask[Either[KmsError, ManagedKey]](ref =>
+      KeyOpsActor.Rotate(id, policy, by, ref)
+    )))

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/KeyOpsActor.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/KeyOpsActor.scala
@@ -77,6 +77,14 @@ object KeyOpsActor:
       replyTo: ActorRef[Either[KmsError, ManagedKey]]
   ) extends Command
 
+  /** Bump the key's `currentVersion`. Legal source state is `Active` only. */
+  final case class Rotate(
+      id: KeyId,
+      policy: RotationPolicy,
+      by: Principal,
+      replyTo: ActorRef[Either[KmsError, ManagedKey]]
+  ) extends Command
+
   // ── Boot ─────────────────────────────────────────────────────────────────────
 
   /** Build a behavior that has already replayed `replayed` into its state map. The supplied `clock` and
@@ -218,6 +226,39 @@ object KeyOpsActor:
                 ))
                 Behaviors.same
               }
+
+        case Rotate(id, policy, by, replyTo) =>
+          state.get(id) match
+            case None =>
+              replyTo ! Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              Behaviors.same
+            case Some(k) if k.state != KeyState.Active =>
+              replyTo ! Left(KmsError(
+                ErrorCode.IllegalOperation,
+                s"Key ${id.value} is ${k.state}, must be Active"
+              ))
+              Behaviors.same
+            case Some(k) =>
+              val newVersion = k.currentVersion + 1
+              val event = KeyEvent.Rotated(
+                KeyEvent.freshId(),
+                now,
+                id,
+                by.subject,
+                newVersion,
+                policy.render
+              )
+              val updated = k.copy(currentVersion = newVersion)
+              appendOr(journal, event, ctx) {
+                replyTo ! Right(updated)
+                running(journal, state + (id -> updated), clock, idGen)
+              } { err =>
+                replyTo ! Left(KmsError(
+                  ErrorCode.GeneralFailure,
+                  s"journal append failed: ${err.getMessage}"
+                ))
+                Behaviors.same
+              }
     }
 
   /** Synchronously append `event` to the journal. On success: run `onOk`. On failure: log and run `onErr`.
@@ -258,3 +299,5 @@ object KeyOpsActor:
         state - id
       case KeyEvent.Compromised(_, _, id, _, _) =>
         state.get(id).fold(state)(k => state + (id -> k.copy(state = KeyState.Compromised)))
+      case KeyEvent.Rotated(_, _, id, _, newVersion, _) =>
+        state.get(id).fold(state)(k => state + (id -> k.copy(currentVersion = newVersion)))

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/KeyOpsActor.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/KeyOpsActor.scala
@@ -69,6 +69,14 @@ object KeyOpsActor:
       replyTo: ActorRef[Either[KmsError, Unit]]
   ) extends Command
 
+  /** Operator-issued compromise. Locks the key out of every cryptographic operation. */
+  final case class Compromise(
+      id: KeyId,
+      reason: String,
+      by: Principal,
+      replyTo: ActorRef[Either[KmsError, ManagedKey]]
+  ) extends Command
+
   // ── Boot ─────────────────────────────────────────────────────────────────────
 
   /** Build a behavior that has already replayed `replayed` into its state map. The supplied `clock` and
@@ -188,6 +196,28 @@ object KeyOpsActor:
                 ))
                 Behaviors.same
               }
+
+        case Compromise(id, reason, by, replyTo) =>
+          state.get(id) match
+            case None =>
+              replyTo ! Left(KmsError(ErrorCode.ItemNotFound, s"No key with id ${id.value}"))
+              Behaviors.same
+            case Some(k) if k.state == KeyState.Destroyed =>
+              replyTo ! Left(KmsError(ErrorCode.IllegalOperation, s"Key ${id.value} is Destroyed"))
+              Behaviors.same
+            case Some(k) =>
+              val event   = KeyEvent.Compromised(KeyEvent.freshId(), now, id, by.subject, reason)
+              val updated = k.copy(state = KeyState.Compromised)
+              appendOr(journal, event, ctx) {
+                replyTo ! Right(updated)
+                running(journal, state + (id -> updated), clock, idGen)
+              } { err =>
+                replyTo ! Left(KmsError(
+                  ErrorCode.GeneralFailure,
+                  s"journal append failed: ${err.getMessage}"
+                ))
+                Behaviors.same
+              }
     }
 
   /** Synchronously append `event` to the journal. On success: run `onOk`. On failure: log and run `onErr`.
@@ -226,3 +256,5 @@ object KeyOpsActor:
         state.get(id).fold(state)(k => state + (id -> k.copy(state = KeyState.Deactivated)))
       case KeyEvent.Destroyed(_, _, id, _) =>
         state - id
+      case KeyEvent.Compromised(_, _, id, _, _) =>
+        state.get(id).fold(state)(k => state + (id -> k.copy(state = KeyState.Compromised)))

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,7 +16,7 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 11 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
-    // wrap, unwrap, compromise. Bump this when a new top-level REST surface lands (e.g. rotate).
-    routes.serverEndpoints.size shouldBe 11
+    // 12 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap, compromise, rotate. Bump this when a new top-level REST surface lands.
+    routes.serverEndpoints.size shouldBe 12
   }

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,7 +16,7 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 10 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
-    // wrap, unwrap. Bump this when a new top-level REST surface lands (e.g. rotate, compromise).
-    routes.serverEndpoints.size shouldBe 10
+    // 11 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap, compromise. Bump this when a new top-level REST surface lands (e.g. rotate).
+    routes.serverEndpoints.size shouldBe 11
   }

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,7 +16,7 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 6 endpoints in v0.1.1: create, get, activate, destroy, sign, verify.
-    // Bump this when a new top-level REST surface lands (e.g. encrypt/decrypt in #6).
-    routes.serverEndpoints.size shouldBe 6
+    // 8 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt.
+    // Bump this when a new top-level REST surface lands (e.g. wrap/unwrap, rotate, compromise).
+    routes.serverEndpoints.size shouldBe 8
   }

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,7 +16,7 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 8 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt.
-    // Bump this when a new top-level REST surface lands (e.g. wrap/unwrap, rotate, compromise).
-    routes.serverEndpoints.size shouldBe 8
+    // 10 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap. Bump this when a new top-level REST surface lands (e.g. rotate, compromise).
+    routes.serverEndpoints.size shouldBe 10
   }


### PR DESCRIPTION
## Summary
Implements every cryptographic operation in the v0.1.1 milestone, mirroring the sign/verify pattern that landed in #5 (`ad8ac72`).

- Closes #6 — `encrypt(id, plaintext, context, by)` / `decrypt(id, ciphertext, context, by)` with AAD-bound encryption context.
- Closes #7 — `wrap(id, dek, by)` / `unwrap(id, wrapped, by)` for KMIP-style envelope encryption of DEK material.
- Closes #8 — `rotate(id, policy, by)` with `currentVersion` on `ManagedKey`, new `RotationPolicy` enum, `KeyEvent.Rotated` journal event, and the "old signatures/ciphertexts stay readable" contract preserved.
- Closes #9 — `compromise(id, reason, by)` operator override that locks the key out of every crypto op (also tightens `verify` to refuse `Compromised`/`Destroyed`, matching `docs/ARCHITECTURE.md` §3).

Each feature lands as its own commit, so the diff is reviewable per issue:

```
1123a0e  feat(crypto): rotate(id, policy) with key versioning (closes #8)
24e9513  feat(crypto): compromise(id, reason) operator override (closes #9)
7bcb6d2  feat(crypto): wrap/unwrap across the whole stack (closes #7)
29f59ad  feat(crypto): encrypt / decrypt across the whole stack (closes #6)
```

End-to-end through every layer for each feature: `aegis-core` algebra + value type → `aegis-crypto` SPI + AWS adapter (where applicable) → `aegis-iam` `AuthorizingKeyService` guard → `aegis-audit` `AuditingKeyService` record → `aegis-server` actor command + `ActorBackedKeyService` → `aegis-http` Tapir endpoint + DTOs → `aegis-cli` verb + flag parser → tests at every layer.

State-machine semantics follow `docs/ARCHITECTURE.md` §3:
- `encrypt` / `wrap` / `sign` / `rotate` require `Active`.
- `decrypt` / `unwrap` / `verify` permitted on `Active` + `Deactivated`; refused on `Compromised` / `Destroyed`.
- `compromise` is one-way: `{PreActive, Active, Deactivated} → Compromised`; `Destroyed` refused.

`ManagedKeyDto` (HTTP + CLI) gained `currentVersion` with a default-to-1 case-class field so existing JSON keeps decoding cleanly.

## Test plan

- [x] `sbt test` — 200+ tests pass; new coverage in `KeyServiceSpec`, `KeyEventCodecSpec`, `RotationPolicySpec`, `AuthorizingKeyServiceSpec`, `AuditingKeyServiceSpec`, `AwsKmsRootOfTrustSpec`, `HttpRoutesSpec`, `CliSpec`, `CommandsSpec`, `AegisHttpClientSpec`. Postgres-via-Testcontainers tests skip cleanly when Docker isn't available.
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` clean.
- [x] `sbt "scalafixAll --check"` clean.
- [x] CHANGELOG `## Unreleased` updated with one entry per issue.
- [x] AWS KMS adapter exercised against a real CMK (deferred — `AwsKmsRootOfTrustSpec` covers the wire shape via `AwsKmsPort` stubs; live AWS integration lands with the v0.1.1 release smoke-test).
