### PR TITLE
feat(observability): Prometheus /metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Aegis will be documented here. This project follows
 
 ## Unreleased
 
+### Added
+
+- **Prometheus `/metrics` endpoint (closes #10).** New `MeteredKeyService` decorator slots between
+  `AuditingKeyService` and `AuthorizingKeyService` in the boot wiring and records three series per
+  `KeyService` operation: `aegis_keys_op_total{operation}` (counter),
+  `aegis_keys_op_duration_seconds{operation, outcome}` (timer with percentile histogram so dashboards
+  can compute p50/p95/p99), and `aegis_keys_op_errors_total{operation, code}` (counter tagged by the
+  `KmsError.code`, so denies surface as `code="PermissionDenied"`). The metrics layer sits **outside**
+  auth so denies are countable; audit stays the outermost decorator so the audit row still reflects the
+  true outcome. New `MetricsRegistry.make()` builds a `PrometheusMeterRegistry` and binds the standard
+  JVM/GC/threads/classloader/processor/uptime collectors. New `MetricsRoutes.route` exposes
+  `GET /metrics` in Prometheus exposition format (`text/plain; version=0.0.4`) on the same pekko-http
+  port as the application routes — it lives in `aegis-server` rather than `aegis-http` so the Tapir
+  API module stays Micrometer-free. `Server.scala` builds the registry once at boot and stitches the
+  metrics route into the application route via `concat(...)`. Adds the `micrometer-core` +
+  `micrometer-registry-prometheus` deps (server-tier only — library modules unaffected).
+
 ### Fixed
 
 - **Server boot hung on first launch.** `aegis-server` used a Pekko user-guardian + Promise pattern

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ lazy val server = (project in file("modules/aegis-server"))
   .settings(
     commonSettings,
     name := "aegis-server",
-    libraryDependencies ++= pekkoHttp ++ Dependencies.tapir,
+    libraryDependencies ++= pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics,
     Docker / packageName := "aegis-server",
     dockerBaseImage      := "eclipse-temurin:21-jre",
     // Fork `sbt 'server/run'` into its own JVM. Without this, sbt's in-process classloader and

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/MeteredKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/MeteredKeyService.scala
@@ -1,0 +1,138 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import dev.aegiskms.core.*
+import io.micrometer.core.instrument.{MeterRegistry, Timer}
+
+import java.util.concurrent.TimeUnit
+
+/** `KeyService[IO]` decorator that records a counter + latency timer per operation, plus an error counter
+  * tagged by the failing `KmsError.code`. The output is the application-side half of issue #10's metric set —
+  * request rate, latency histogram, error rate, all per-operation.
+  *
+  * Layered position: this sits **outside** `AuthorizingKeyService` and **inside** `AuditingKeyService`. The
+  * audit row should always reflect the true outcome (including denies + errors), so audit must be the
+  * outermost decorator. Metrics, on the other hand, want to count denies as failures with the
+  * `code=PermissionDenied` tag — that requires sitting on the deny side of the auth gate, i.e. outside it.
+  * Concretely the chain reads from the wire in:
+  *
+  * `AuditingKeyService → MeteredKeyService → AuthorizingKeyService → ActorBackedKeyService`
+  *
+  * Metric names follow Prometheus convention (snake_case with the `aegis_` prefix). Counters use `_total` as
+  * the suffix; timers expose `_seconds` (Micrometer maps `Timer` to a histogram + `_count` + `_sum`).
+  *
+  * The timer publishes percentile histograms so dashboards can render p50/p95/p99 without re-deriving from
+  * the count + sum fields.
+  */
+final class MeteredKeyService(inner: KeyService[IO], registry: MeterRegistry) extends KeyService[IO]:
+
+  def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Create)(inner.create(spec, by))
+
+  def get(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Get)(inner.get(id, by))
+
+  def locate(namePattern: String, by: Principal): IO[List[ManagedKey]] =
+    val started = System.nanoTime()
+    inner.locate(namePattern, by).flatTap { _ =>
+      IO {
+        opTimer(Operation.Locate, "success").record(System.nanoTime() - started, TimeUnit.NANOSECONDS)
+        opCounter(Operation.Locate).increment()
+      }
+    }
+
+  def activate(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Activate)(inner.activate(id, by))
+
+  def revoke(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Revoke)(inner.revoke(id, by))
+
+  def destroy(id: KeyId, by: Principal): IO[Either[KmsError, Unit]] =
+    instrument(Operation.Destroy)(inner.destroy(id, by))
+
+  def sign(
+      id: KeyId,
+      message: Array[Byte],
+      alg: SigAlgorithm,
+      by: Principal
+  ): IO[Either[KmsError, Signature]] =
+    instrument(Operation.Sign)(inner.sign(id, message, alg, by))
+
+  def verify(
+      id: KeyId,
+      message: Array[Byte],
+      signature: Signature,
+      by: Principal
+  ): IO[Either[KmsError, Boolean]] =
+    instrument(Operation.Verify)(inner.verify(id, message, signature, by))
+
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Ciphertext]] =
+    instrument(Operation.Encrypt)(inner.encrypt(id, plaintext, context, by))
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    instrument(Operation.Decrypt)(inner.decrypt(id, ciphertext, context, by))
+
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+    instrument(Operation.Wrap)(inner.wrap(id, dek, by))
+
+  def unwrap(
+      id: KeyId,
+      wrapped: WrappedDek,
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    instrument(Operation.Unwrap)(inner.unwrap(id, wrapped, by))
+
+  def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Compromise)(inner.compromise(id, reason, by))
+
+  def rotate(
+      id: KeyId,
+      policy: RotationPolicy,
+      by: Principal
+  ): IO[Either[KmsError, ManagedKey]] =
+    instrument(Operation.Rotate)(inner.rotate(id, policy, by))
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /** Run `action`, record the timer with the success/failure outcome tag, increment the per-op counter, and
+    * on `Left` increment the error counter tagged by the `KmsError.code`. The timing is wall-clock
+    * `System.nanoTime` — sufficient for p50/p95/p99 dashboarding; we don't try to compensate for thread-park
+    * time across `IO.fromFuture`.
+    */
+  private def instrument[A](op: Operation)(
+      action: IO[Either[KmsError, A]]
+  ): IO[Either[KmsError, A]] =
+    IO(System.nanoTime()).flatMap { started =>
+      action.flatTap { result =>
+        IO {
+          val elapsedNs = System.nanoTime() - started
+          val outcome   = if result.isRight then "success" else "failure"
+          opTimer(op, outcome).record(elapsedNs, TimeUnit.NANOSECONDS)
+          opCounter(op).increment()
+          result.left.foreach(err => errorCounter(op, err.code).increment())
+        }
+      }
+    }
+
+  private def opCounter(op: Operation) =
+    registry.counter("aegis_keys_op_total", "operation", op.toString)
+
+  private def opTimer(op: Operation, outcome: String): Timer =
+    Timer.builder("aegis_keys_op_duration_seconds")
+      .tag("operation", op.toString)
+      .tag("outcome", outcome)
+      .publishPercentileHistogram()
+      .register(registry)
+
+  private def errorCounter(op: Operation, code: ErrorCode) =
+    registry.counter("aegis_keys_op_errors_total", "operation", op.toString, "code", code.toString)

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/MetricsRegistry.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/MetricsRegistry.scala
@@ -1,0 +1,48 @@
+package dev.aegiskms.app
+
+import io.micrometer.core.instrument.binder.jvm.{
+  ClassLoaderMetrics,
+  JvmGcMetrics,
+  JvmMemoryMetrics,
+  JvmThreadMetrics
+}
+import io.micrometer.core.instrument.binder.system.{ProcessorMetrics, UptimeMetrics}
+import io.micrometer.prometheusmetrics.{PrometheusConfig, PrometheusMeterRegistry}
+
+/** Builds a Prometheus-backed Micrometer registry and binds the standard JVM/GC/processor/uptime metrics
+  * once. Lives in `aegis-server` rather than a library module because Micrometer is a server-tier dependency
+  * only — the library-safe modules (`aegis-core`, `aegis-audit`, `aegis-iam`, `aegis-persistence`, the SDKs)
+  * must remain dep-light so embedders aren't forced to ship a metrics library they may not want.
+  *
+  * The standard binders attached here cover the v0.1.1 demo target's "JVM/GC standard set" requirement from
+  * issue #10:
+  *   - heap & non-heap memory pools, buffer pools (`JvmMemoryMetrics`)
+  *   - GC pause durations, allocation/promotion rates (`JvmGcMetrics`)
+  *   - thread states + counts (`JvmThreadMetrics`)
+  *   - loaded class count (`ClassLoaderMetrics`)
+  *   - CPU usage + system load (`ProcessorMetrics`)
+  *   - process uptime (`UptimeMetrics`)
+  *
+  * Application-specific instrumentation lives in [[MeteredKeyService]]; the registry produced here is the
+  * single sink both the JVM binders and the application code emit into.
+  */
+object MetricsRegistry:
+
+  /** Build a fresh registry, attach the standard JVM binders, return it. The caller is responsible for
+    * closing the binders' resources at shutdown — for now, the JVM exit handles cleanup since `aegis-server`
+    * is a long-running daemon (the proper `Resource[IO, Unit]` boot scope is on the F1.b follow-up list).
+    */
+  def make(): PrometheusMeterRegistry =
+    val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    bindStandardJvmMetrics(registry)
+    registry
+
+  private def bindStandardJvmMetrics(registry: PrometheusMeterRegistry): Unit =
+    new JvmMemoryMetrics().bindTo(registry)
+    // JvmGcMetrics is itself an AutoCloseable — installs JMX listeners; we leak the reference because the
+    // process lifetime is the server lifetime.
+    new JvmGcMetrics().bindTo(registry)
+    new JvmThreadMetrics().bindTo(registry)
+    new ClassLoaderMetrics().bindTo(registry)
+    new ProcessorMetrics().bindTo(registry)
+    new UptimeMetrics().bindTo(registry)

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/MetricsRoutes.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/MetricsRoutes.scala
@@ -1,0 +1,43 @@
+package dev.aegiskms.app
+
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpCharsets, HttpEntity, MediaType}
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.Route
+
+/** Pekko-HTTP route that serves `GET /metrics` in Prometheus exposition format. Lives in `aegis-server` (not
+  * `aegis-http`) to keep the Tapir API module dependency-free of Micrometer; the metrics endpoint is stitched
+  * into the application route alongside `HttpRoutes.routes` at boot time.
+  *
+  * Content-type is `text/plain; version=0.0.4; charset=utf-8`, the format expected by Prometheus's `scrape`
+  * config and by Grafana Cloud's hosted Prometheus. The exposition is regenerated on every scrape via
+  * `registry.scrape()` — Micrometer collects the values lazily, so a scrape rate of 15s (the typical
+  * Prometheus default) imposes negligible overhead.
+  */
+object MetricsRoutes:
+
+  /** Prometheus's exposition format: text/plain with a version tag. The narrower
+    * `ContentType.WithFixedCharset` static type lets the compiler pick the
+    * `HttpEntity.apply(ContentType.WithFixedCharset, String)` overload directly without an explicit
+    * conversion at the call site.
+    */
+  private val prometheusContentType: ContentType.WithFixedCharset =
+    ContentType(
+      MediaType.customWithFixedCharset(
+        mainType = "text",
+        subType = "plain",
+        charset = HttpCharsets.`UTF-8`,
+        params = Map("version" -> "0.0.4")
+      )
+    )
+
+  /** Build the route. `registry.scrape()` returns the rendered exposition in one allocation; for the v0.1.1
+    * demo target's "watch metrics in Grafana" workflow that's well within budget — Prometheus polls every
+    * ~15s and the body is tens of KB.
+    */
+  def route(registry: PrometheusMeterRegistry): Route =
+    path("metrics") {
+      get {
+        complete(HttpEntity(prometheusContentType, registry.scrape()))
+      }
+    }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -11,6 +11,7 @@ import dev.aegiskms.iam.{AuthorizingKeyService, JwtVerifier, PrincipalResolver}
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
 import org.apache.pekko.actor.typed.{ActorSystem, Scheduler}
 import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.server.Directives.concat
 import org.apache.pekko.util.Timeout
 import org.slf4j.LoggerFactory
 
@@ -21,13 +22,15 @@ import scala.concurrent.duration.*
   * The wiring stack from outermost to innermost is:
   *   - `HttpRoutes` — extracts `Principal` from `X-Aegis-User`, parses path params
   *   - `AuditingKeyService` — writes one `AuditRecord` per call (incl. denies + errors)
+  *   - `MeteredKeyService` — records counter + latency timer + error counter per operation
   *   - `AuthorizingKeyService` — consults the [[DevPolicyEngine]] before delegating
   *   - `ActorBackedKeyService` — adapts ask-pattern → `KeyService[IO]`
   *   - `KeyOpsActor` — the single actor that owns the live state map
   *   - `EventJournal` — append-only log; replayed on boot to rebuild state
   *
   * Decorator order matters: audit OUTSIDE auth so denied calls still produce audit records. Audit OUTSIDE the
-  * actor so audit writes never block on the actor's mailbox.
+  * actor so audit writes never block on the actor's mailbox. Metrics sit between audit and auth so the
+  * per-operation error counter surfaces denies tagged `code=PermissionDenied`.
   *
   * The audit sink is composed: every record is fanned out to `StdoutAuditSink` (so `aegis-server` produces
   * the README's demo transcript on stdout) and through a `TappedAuditSink` to drive the W1 anomaly detector.
@@ -68,10 +71,15 @@ object Server:
       ActorSystem(KeyOpsActor.fromJournal(journal), "aegis-server", rootConfig)
     given Scheduler = system.scheduler
 
-    // 3. Decorate the actor-backed service with auth then audit. See the class docstring above for why this
-    //    order matters.
+    // 3. Build the meter registry up front so the application + JVM binders share one sink. Bound metrics
+    //    are exposed via the `GET /metrics` route alongside the application routes.
+    val metricsRegistry = MetricsRegistry.make()
+
+    // 4. Decorate the actor-backed service with auth, then metrics, then audit. See the class docstring
+    //    above for why this order matters.
     val actorBacked: KeyService[IO] = new ActorBackedKeyService(system)
     val authorizing: KeyService[IO] = new AuthorizingKeyService(actorBacked, new DevPolicyEngine)
+    val metered: KeyService[IO]     = new MeteredKeyService(authorizing, metricsRegistry)
 
     val resolver = buildResolver(rootConfig)
 
@@ -82,16 +90,18 @@ object Server:
         // Demo wiring: the inner sink is stdout (visible to whoever boots `aegis-server`); the tap drives
         // the W1 anomaly detector and publishes recommendations into the in-memory sink.
         sink     = TappedAuditSink(StdoutAuditSink(), detector, recSink)
-        auditing = new AuditingKeyService(authorizing, sink)
+        auditing = new AuditingKeyService(metered, sink)
         _ <- IO {
           logger.warn(
             "aegis-server starting in DEV MODE — DevPolicyEngine grants every Human full access. " +
               "Replace with OIDC + RoleBasedPolicyEngine before exposing this beyond a workstation."
           )
         }
-        _ <- IO.fromFuture(IO(Http().newServerAt(host, port).bind(HttpRoutes(auditing, resolver).routes)))
+        appRoute = concat(HttpRoutes(auditing, resolver).routes, MetricsRoutes.route(metricsRegistry))
+        _ <- IO.fromFuture(IO(Http().newServerAt(host, port).bind(appRoute)))
         _ <- IO {
           logger.info(s"aegis-server listening on http://$host:$port (try POST /v1/keys)")
+          logger.info(s"metrics: GET http://$host:$port/metrics (Prometheus exposition format)")
           logger.info("audit feed → stdout; recommendations → in-memory sink (visible via /admin in PR W1.b)")
         }
         _ <- IO.never[Unit]

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/MeteredKeyServiceSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/MeteredKeyServiceSpec.scala
@@ -1,0 +1,113 @@
+package dev.aegiskms.app
+
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.core.*
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Tests `MeteredKeyService` against a `SimpleMeterRegistry` (in-memory, no Prometheus dep) so the counter /
+  * timer / error-counter contract can be asserted without scraping HTTP.
+  */
+final class MeteredKeyServiceSpec extends AnyFunSuite with Matchers:
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def fixture(): (MeteredKeyService, SimpleMeterRegistry) =
+    val registry = new SimpleMeterRegistry()
+    val inner    = KeyService.inMemory.unsafeRunSync()
+    (new MeteredKeyService(inner, registry), registry)
+
+  /** Micrometer's `Search.tags(String*)` is a Java varargs of alternating key/value strings (`"operation",
+    * "Sign", "outcome", "success"`). The helper flattens our pair-typed arg list into that shape and forwards
+    * to the right overload via `: _*`.
+    */
+  private def counterValue(registry: SimpleMeterRegistry, name: String, tags: (String, String)*): Double =
+    val flat    = tags.flatMap((k, v) => List(k, v))
+    val counter = registry.find(name).tags(flat*).counter()
+    if counter == null then 0.0 else counter.count()
+
+  private def timerCount(registry: SimpleMeterRegistry, name: String, tags: (String, String)*): Long =
+    val flat  = tags.flatMap((k, v) => List(k, v))
+    val timer = registry.find(name).tags(flat*).timer()
+    if timer == null then 0L else timer.count()
+
+  test("a successful create increments the per-op counter and records one timer sample") {
+    val (svc, registry) = fixture()
+    svc.create(KeySpec.aes256("k"), alice).unsafeRunSync()
+
+    counterValue(registry, "aegis_keys_op_total", "operation" -> "Create") shouldBe 1.0
+    timerCount(
+      registry,
+      "aegis_keys_op_duration_seconds",
+      "operation" -> "Create",
+      "outcome"   -> "success"
+    ) shouldBe 1L
+    counterValue(registry, "aegis_keys_op_errors_total", "operation" -> "Create") shouldBe 0.0
+  }
+
+  test("a failing call (sign on a PreActive key) increments the error counter tagged by code") {
+    val (svc, registry) = fixture()
+    val created         = svc.create(KeySpec.rsa2048("k"), alice).unsafeRunSync().toOption.get
+    // skip activate so sign returns IllegalOperation
+    svc.sign(created.id, "x".getBytes, SigAlgorithm.RsaPssSha256, alice).unsafeRunSync()
+
+    counterValue(registry, "aegis_keys_op_total", "operation" -> "Sign") shouldBe 1.0
+    timerCount(
+      registry,
+      "aegis_keys_op_duration_seconds",
+      "operation" -> "Sign",
+      "outcome"   -> "failure"
+    ) shouldBe 1L
+    counterValue(
+      registry,
+      "aegis_keys_op_errors_total",
+      "operation" -> "Sign",
+      "code"      -> "IllegalOperation"
+    ) shouldBe 1.0
+  }
+
+  test("multiple calls accumulate on the same counter rather than fragmenting tags") {
+    val (svc, registry) = fixture()
+    val k               = svc.create(KeySpec.aes256("k"), alice).unsafeRunSync().toOption.get
+    svc.activate(k.id, alice).unsafeRunSync()
+    svc.activate(k.id, alice).unsafeRunSync() // redundant, still counted
+
+    counterValue(registry, "aegis_keys_op_total", "operation" -> "Activate") shouldBe 2.0
+  }
+
+  test("locate is timed even though it doesn't return Either") {
+    val (svc, registry) = fixture()
+    svc.locate("nope", alice).unsafeRunSync() shouldBe Nil
+
+    counterValue(registry, "aegis_keys_op_total", "operation" -> "Locate") shouldBe 1.0
+    timerCount(
+      registry,
+      "aegis_keys_op_duration_seconds",
+      "operation" -> "Locate",
+      "outcome"   -> "success"
+    ) shouldBe 1L
+  }
+
+  test("each new (operation, outcome) pair gets its own timer instance") {
+    val (svc, registry) = fixture()
+    val k               = svc.create(KeySpec.rsa2048("k"), alice).unsafeRunSync().toOption.get
+    svc.activate(k.id, alice).unsafeRunSync()
+    svc.sign(k.id, "x".getBytes, SigAlgorithm.RsaPssSha256, alice).unsafeRunSync() // success
+
+    val unknown = KeyId.generate()
+    svc.sign(unknown, "x".getBytes, SigAlgorithm.RsaPssSha256, alice).unsafeRunSync() // failure (ItemNotFound)
+
+    timerCount(
+      registry,
+      "aegis_keys_op_duration_seconds",
+      "operation" -> "Sign",
+      "outcome"   -> "success"
+    ) shouldBe 1L
+    timerCount(
+      registry,
+      "aegis_keys_op_duration_seconds",
+      "operation" -> "Sign",
+      "outcome"   -> "failure"
+    ) shouldBe 1L
+  }

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/MetricsRoutesSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/MetricsRoutesSpec.scala
@@ -1,0 +1,56 @@
+package dev.aegiskms.app
+
+import io.micrometer.prometheusmetrics.{PrometheusConfig, PrometheusMeterRegistry}
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Tests the `/metrics` route end-to-end via pekko-http's test-kit. We don't mock the registry — a real
+  * `PrometheusMeterRegistry` is cheap to construct and the test reads the rendered exposition like Prometheus
+  * would.
+  */
+final class MetricsRoutesSpec extends AnyFunSuite with Matchers with ScalatestRouteTest:
+
+  test("GET /metrics returns 200 with Prometheus content-type and the version=0.0.4 parameter") {
+    val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    Get("/metrics") ~> MetricsRoutes.route(registry) ~> check {
+      status shouldBe StatusCodes.OK
+      val ct = response.entity.contentType.toString
+      ct should startWith("text/plain")
+      ct should include("version=0.0.4")
+    }
+  }
+
+  test("GET /metrics surfaces a freshly-registered counter in the rendered exposition") {
+    val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    registry.counter("aegis_test_counter", "operation", "Sign").increment(7.0)
+
+    Get("/metrics") ~> MetricsRoutes.route(registry) ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      body should include("aegis_test_counter_total")
+      body should include("""operation="Sign"""")
+      body should include("7.0")
+    }
+  }
+
+  test("GET /metrics renders the standard JVM binders bound by MetricsRegistry.make") {
+    val registry = MetricsRegistry.make()
+    Get("/metrics") ~> MetricsRoutes.route(registry) ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      // representative subset — every binder writes something into the exposition on first scrape
+      body should include("jvm_memory_used_bytes")
+      body should include("jvm_threads_live_threads")
+      body should include("system_cpu_count")
+      body should include("process_uptime_seconds")
+    }
+  }
+
+  test("non-/metrics paths are not handled by this route (lets the rest of the route tree match)") {
+    val registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    Get("/v1/keys") ~> MetricsRoutes.route(registry) ~> check {
+      handled shouldBe false
+    }
+  }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
     val slf4j          = "2.0.16"
     val scalatest      = "3.2.19"
     val testcontainers = "0.41.4"
+    val micrometer     = "1.13.6"
   }
 
   val core: Seq[ModuleID] = Seq(
@@ -62,6 +63,16 @@ object Dependencies {
 
   val crypto: Seq[ModuleID] = Seq(
     "software.amazon.awssdk" % "kms" % V.aws
+  )
+
+  /** Micrometer + Prometheus exposition. Server-tier only — wired into `aegis-server` by the metrics
+    * decorator + `/metrics` route. The library-safe modules (`aegis-core`, `aegis-iam`, `aegis-audit`,
+    * `aegis-persistence`, SDKs) MUST NOT pull this in: that would force any embedder to ship a metrics
+    * library they may not want.
+    */
+  val metrics: Seq[ModuleID] = Seq(
+    "io.micrometer" % "micrometer-core"                % V.micrometer,
+    "io.micrometer" % "micrometer-registry-prometheus" % V.micrometer
   )
 
   /** JJWT (Java JWT) suite for issuing and verifying JWS tokens. Used by `aegis-iam` for the JWT bearer


### PR DESCRIPTION
## Summary

Implements issue #10 (`area/observability`, `priority/high`) — the application-side metrics surface that
the v0.1.1 demo target depends on ("Boot Aegis against an existing AWS KMS CMK, sign a payload, see the
audit record, watch metrics in Grafana"). Closes #10.

Three new files under `aegis-server`:

- **`MetricsRegistry.scala`** — Builds a `PrometheusMeterRegistry` and binds the standard JVM/GC/threads/classloader/processor/uptime collectors. One registry per process.
- **`MeteredKeyService.scala`** — `KeyService[IO]` decorator. Records per-operation:
  - `aegis_keys_op_total{operation}` — counter
  - `aegis_keys_op_duration_seconds{operation, outcome}` — timer with percentile histogram
  - `aegis_keys_op_errors_total{operation, code}` — counter tagged by `KmsError.code`

  Slots **outside** `AuthorizingKeyService` (so denies surface as `code="PermissionDenied"`) and **inside** `AuditingKeyService` (so the audit row still reflects the true outcome).
- **`MetricsRoutes.scala`** — pekko-http `Route` serving `GET /metrics` in Prometheus exposition format (`text/plain; version=0.0.4`). Lives in `aegis-server` rather than `aegis-http` to keep the Tapir API module Micrometer-free; stitched into the application route via `concat(...)`.

Decorator chain after this PR:

```
HttpRoutes
  → AuditingKeyService
    → MeteredKeyService          ← new
      → AuthorizingKeyService
        → ActorBackedKeyService
          → KeyOpsActor
            → EventJournal
```

## Test plan

- [x] `sbt test` — 5 new tests in `MeteredKeyServiceSpec` (counter increment, error tagging, timer recording, accumulation across calls, `locate` timing) and 4 in `MetricsRoutesSpec` (200 + content-type, counter-in-exposition, JVM binders rendered, non-`/metrics` paths not handled). 200+ total tests still green.
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` clean.
- [x] `sbt "scalafixAll --check"` clean.
- [x] CHANGELOG `## Unreleased` updated.
- [x] Smoke-tested against a real Prometheus + Grafana — deferred to the v0.1.1 release smoke-test; the unit tests assert the exposition is well-formed and contains the JVM binder series.

