### PR TITLE
feat(http): OpenAPI 3.1 spec + Swagger UI on /docs (closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **OpenAPI 3.1 spec + Swagger UI on the REST plane (closes #52).** `HttpRoutes` now generates an
+  OpenAPI document from the live `Endpoints.all` list and mounts the standard Swagger UI bundle at
+  `/docs/`, with the raw YAML at `/docs/docs.yaml`. Because the spec is derived from the same Tapir
+  endpoint definitions the routes interpret, drift between the docs and the wire shape is impossible
+  by construction. The `tapir-openapi-docs` and `tapir-swagger-ui-bundle` deps were already in
+  `Dependencies.scala` `tapir`; this PR is purely the route plumbing + a regression test that asserts
+  every shipped path appears in the rendered spec.
 - **Docker Compose hardening: no default Postgres password (closes #51).**
   `deploy/docker/docker-compose.yml` no longer ships the
   `aegis-dev-password-change-me` default. Both the Postgres container and the

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -6,9 +6,12 @@ import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
 import dev.aegiskms.iam.PrincipalResolver
 import org.apache.pekko.http.scaladsl.server.Route
+import sttp.apispec.openapi.circe.yaml.*
 import sttp.model.StatusCode
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter
+import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -319,5 +322,24 @@ final class HttpRoutes(
       rotateSE
     )
 
-  /** A pekko-http `Route` that mounts every endpoint. */
-  def routes: Route = PekkoHttpServerInterpreter().toRoute(serverEndpoints)
+  /** Render the live endpoint set as an OpenAPI 3.1 document. The build-time guarantee here is the same one
+    * that makes this module valuable: the doc is generated from the same `Endpoints.*` values the routes are
+    * interpreted from, so the docs cannot drift from the wire shape. Title/version pin to `Aegis-KMS v0.1.x`
+    * — the version string is informational only (sbt-dynver computes the real artifact version).
+    */
+  val openApiYaml: String =
+    OpenAPIDocsInterpreter()
+      .toOpenAPI(Endpoints.all, "Aegis-KMS REST API", "0.1.x")
+      .toYaml
+
+  /** Swagger UI server endpoints. Mounted at `/docs` (and the OpenAPI YAML at `/docs/docs.yaml`); this
+    * mirrors the convention `swagger-ui-bundle` defaults to. The interpreter takes the same `AnyEndpoint`
+    * list, so adding a new endpoint above automatically shows up in the UI on next boot.
+    */
+  private val swaggerEndpoints: List[ServerEndpoint[Any, Future]] =
+    SwaggerInterpreter()
+      .fromEndpoints[Future](Endpoints.all, "Aegis-KMS REST API", "0.1.x")
+
+  /** A pekko-http `Route` that mounts every endpoint plus the Swagger UI / OpenAPI surface. */
+  def routes: Route =
+    PekkoHttpServerInterpreter().toRoute(serverEndpoints ++ swaggerEndpoints)

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSpec.scala
@@ -362,6 +362,47 @@ final class HttpRoutesSpec extends AnyFunSuite with Matchers with ScalatestRoute
     }
   }
 
+  test("OpenAPI YAML generated from the endpoint list mentions every advertised path") {
+    val routes  = HttpRoutes(KeyService.inMemory.unsafeRunSync())
+    val openapi = routes.openApiYaml
+
+    openapi should include("openapi: 3.1.0")
+    openapi should include("Aegis-KMS REST API")
+    // every shipped endpoint must appear in the doc (drift guard)
+    List(
+      "/v1/keys",
+      "/v1/keys/{id}",
+      "/v1/keys/{id}/activate",
+      "/v1/keys/{id}/sign",
+      "/v1/keys/{id}/verify",
+      "/v1/keys/{id}/encrypt",
+      "/v1/keys/{id}/decrypt",
+      "/v1/keys/{id}/wrap",
+      "/v1/keys/{id}/unwrap",
+      "/v1/keys/{id}/compromise",
+      "/v1/keys/{id}/rotate"
+    ).foreach(p => openapi should include(p))
+  }
+
+  test("GET /docs/docs.yaml returns the OpenAPI YAML with text/yaml or application/yaml content-type") {
+    Get("/docs/docs.yaml") ~> freshRoute() ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      body should include("openapi: 3.1.0")
+      body should include("/v1/keys/{id}/sign")
+    }
+  }
+
+  test("GET /docs/ serves the Swagger UI HTML shell") {
+    Get("/docs/") ~> freshRoute() ~> check {
+      status shouldBe StatusCodes.OK
+      val body = responseAs[String]
+      // swagger-ui-bundle ships an HTML page that bootstraps the JS app — we just assert the shell
+      // shape rather than pin specific text the bundle's authors might rev later.
+      body.toLowerCase should (include("swagger") or include("<!doctype html"))
+    }
+  }
+
   test("POST /v1/keys/{id}/compromise with a blank reason returns 400 InvalidField") {
     val route = freshRoute()
     var id    = ""


### PR DESCRIPTION
## Summary
Closes #52. The Tapir deps were already wired (`tapir-openapi-docs`, `tapir-swagger-ui-bundle`); this PR is just the route plumbing. The OpenAPI 3.1 doc is generated from the live `Endpoints.all` list at boot, and the standard Swagger UI is mounted at `/docs/` (with the raw YAML at `/docs/docs.yaml`).

Because the spec derives from the same Tapir endpoint values the runtime interprets, drift between docs and wire shape is impossible by construction. A new regression test asserts every shipped path appears in the rendered YAML.

## Test plan
- [x] `sbt test` — 3 new HTTP tests (YAML contains every endpoint; `GET /docs/docs.yaml` returns the spec; `GET /docs/` serves the Swagger UI shell). 200+ tests still green.
- [x] `sbt scalafmtCheckAll "scalafixAll --check"` clean.
- [x] CHANGELOG updated.

