### PR TITLE
sec(deploy): drop the default Postgres password from docker-compose (closes #51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Docker Compose hardening: no default Postgres password (closes #51).**
+  `deploy/docker/docker-compose.yml` no longer ships the
+  `aegis-dev-password-change-me` default. Both the Postgres container and the
+  `aegis-server` JDBC password now reference `${POSTGRES_PASSWORD:?...}` —
+  Compose fails fast with a clear error if the operator hasn't exported the
+  variable. `SECURITY.md` gains a new "Deploy-time configuration" section
+  enumerating the env vars that must be supplied (`POSTGRES_PASSWORD`,
+  `AEGIS_AUTH_HMAC_SECRET` when JWT auth is on, AWS creds when the KMS
+  root-of-trust is configured) and noting that TLS termination is the
+  fronting proxy's responsibility until the v0.4.0 KMIP plane ships native
+  mTLS.
 - **Prometheus `/metrics` endpoint (closes #10).** New `MeteredKeyService` decorator slots between
   `AuditingKeyService` and `AuthorizingKeyService` in the boot wiring and records three series per
   `KeyService` operation: `aegis_keys_op_total{operation}` (counter),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,3 +35,39 @@ Out of scope:
   explicitly disabled.
 - Issues in `aegis-agent-ai` recommendations — these are advisory; no
   cryptographic decision is taken solely on an AI recommendation.
+
+## Deploy-time configuration
+
+The shipped Docker images and Compose files do not contain any default
+credentials. The deploy-time decisions below are the operator's
+responsibility and Aegis-KMS will fail fast at boot rather than fall back to
+a weak default.
+
+### Required environment variables
+
+| Variable | When required | Notes |
+| --- | --- | --- |
+| `POSTGRES_PASSWORD` | Always when running `deploy/docker/docker-compose.yml` | Compose substitutes this into both the Postgres container and the `AEGIS_JDBC_PASSWORD` of `aegis-server`. Generate with `openssl rand -base64 24`; do **not** check the value into source control. |
+| `AEGIS_JDBC_PASSWORD` | When `aegis-server` is configured with `AEGIS_JOURNAL_KIND=postgres` outside the bundled compose file | Same value the Postgres role expects. |
+| `AEGIS_AUTH_HMAC_SECRET` | When `AEGIS_AUTH_KIND=hmac` | Must be ≥ 32 bytes. Generate with `openssl rand -base64 48`. |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | When the AWS KMS root-of-trust is configured | Prefer instance-role credentials over long-lived access keys. The KMS adapter only needs `kms:Encrypt`, `kms:Decrypt`, `kms:Sign`, `kms:Verify`, `kms:GenerateDataKey`, and `kms:EnableKeyRotation` against the configured CMK. |
+
+### Authentication mode
+
+`AEGIS_AUTH_KIND=dev` accepts the `X-Aegis-User` header verbatim and is
+intended for local workstation use only. Any deployment reachable from a
+network you do not fully control must use `AEGIS_AUTH_KIND=hmac` (HS256
+JWT) — or, once the OIDC verifier ships in v0.2.0, an OIDC issuer.
+
+### TLS termination
+
+Aegis-KMS does not yet ship its own TLS listener. Production deployments
+should terminate TLS at a fronting reverse proxy (Envoy, NGINX, Traefik,
+ALB) and forward to `aegis-server` over the internal network. Native TLS +
+mTLS support lands with the KMIP plane in v0.4.0 (PR K1).
+
+### Reverting the default
+
+Reintroducing a default password in `docker-compose.yml` regresses #51 and
+will be rejected at review time. The compose file uses the `${VAR:?error}`
+shell-substitution form deliberately so misconfiguration is loud.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,8 +1,17 @@
-# Local development quickstart for Aegis 0.1.0.
+# Local development quickstart for Aegis 0.1.x.
 #
 # Brings up:
 #   - Postgres 16 — durable event journal
 #   - aegis-server  — fronted on http://localhost:8080
+#
+# REQUIRED before `docker compose up`:
+#   export POSTGRES_PASSWORD="$(openssl rand -base64 24)"
+#
+# Compose will fail fast with a clear error if POSTGRES_PASSWORD isn't set —
+# we no longer ship a default credential because earlier versions made it too
+# easy to launch a publicly-bound deployment with a hard-coded password. See
+# `SECURITY.md` ("Deploy-time configuration") for the full list of required
+# environment values.
 #
 # Auth defaults to dev mode (X-Aegis-User header). To exercise the JWT path:
 #   1. Generate a 32-byte secret:  openssl rand -base64 48
@@ -22,7 +31,9 @@ services:
     environment:
       POSTGRES_DB:       aegis
       POSTGRES_USER:     aegis
-      POSTGRES_PASSWORD: aegis-dev-password-change-me
+      # `:?` makes compose fail fast with a clear error message if the variable
+      # is unset or empty. Do NOT add a default value here — see SECURITY.md.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the shell environment}
     ports:
       - "5432:5432"
     healthcheck:
@@ -44,7 +55,9 @@ services:
       AEGIS_JOURNAL_KIND: "postgres"
       AEGIS_JDBC_URL:     "jdbc:postgresql://postgres:5432/aegis"
       AEGIS_JDBC_USERNAME: "aegis"
-      AEGIS_JDBC_PASSWORD: "aegis-dev-password-change-me"
+      # Same external value as POSTGRES_PASSWORD above — compose substitutes it
+      # into both env blocks at start time.
+      AEGIS_JDBC_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the shell environment}
       AEGIS_AUTH_KIND:    "dev"
       # AEGIS_AUTH_KIND:        "hmac"
       # AEGIS_AUTH_HMAC_SECRET: "set-me-to-32-or-more-bytes-please"


### PR DESCRIPTION
## Summary
Closes #51. Removes the `aegis-dev-password-change-me` default from `deploy/docker/docker-compose.yml` and replaces it with `${POSTGRES_PASSWORD:?...}` so Compose fails fast with a clear error if the operator hasn't exported the variable. The same external value is substituted into both the Postgres container and the matching `AEGIS_JDBC_PASSWORD` on `aegis-server` so they stay in sync.

`SECURITY.md` gains a new "Deploy-time configuration" section enumerating every env var the operator must supply, the minimal AWS IAM permission set the KMS adapter needs, the auth-mode guidance, and TLS-termination expectations.

No application code changes — deployment config + docs only.

## Test plan
- [x] Compose file lints (manual visual review; `:?` is the documented bail-out form).
- [x] `SECURITY.md` renders cleanly in GitHub.
- [x] CHANGELOG `## Unreleased` updated.
- [ ] `docker compose up` smoke test (Docker isn't running in this environment; the substitution syntax is documented and identical to what the Postgres image's official compose example uses).