### PR TITLE
release(maven): per-module descriptions + maintainer runbook (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Maven Central publishing — POM metadata + operator runbook (closes #14).**
+  Each library module (`aegis-core`, `aegis-persistence`, `aegis-crypto`,
+  `aegis-iam`, `aegis-audit`, `aegis-sdk-scala`, `aegis-sdk-java`,
+  `aegis-kmip`, `aegis-http`, `aegis-agent-ai`, `aegis-mcp-server`) now
+  declares its own one-line `description` so Sonatype's POM-validation
+  staging gate accepts the artifact. `aegis-server` and `aegis-cli` keep
+  `publish / skip := true` since they ship as a Docker image and a
+  Universal tarball respectively. A `ThisBuild / description` fallback
+  prevents an unnamed jar from regressing the gate. New `RELEASING.md`
+  documents the one-time maintainer setup (Sonatype OSSRH account, GPG
+  key generation + keyserver publication, the four GitHub Action secrets
+  `PGP_SECRET` / `PGP_PASSPHRASE` / `SONATYPE_USERNAME` / `SONATYPE_PASSWORD`)
+  plus the per-release workflow (CHANGELOG bump, `git tag v0.1.1 && git push
+  origin v0.1.1`, what to expect on the Actions page) and a
+  troubleshooting matrix. The existing `release.yml` workflow already
+  gates the Maven publish step on `PGP_SECRET != ''`, so a release
+  without secrets ships Docker + CLI only with a clear `::notice`.
 - **OpenTelemetry tracing — application-level spans + autoconfigured SDK (closes #11).** New
   `TracingKeyService` decorator wraps each `KeyService[IO]` call in an OTel span named
   `kms.<operation>` with attributes `aegis.operation`, `aegis.key.id` (when applicable),

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,124 @@
+# Releasing Aegis-KMS
+
+This is the operator runbook for cutting a tagged release. The `release.yml`
+GitHub Actions workflow does the heavy lifting on every `v*` tag push:
+
+1. CI gate (compile, scalafmt, scalafix, test) — same checks as the main
+   branch CI.
+2. Publish library jars to Maven Central (`dev.aegiskms %% aegis-core` and
+   friends) via `sbt-ci-release`. Skipped automatically if the signing
+   secrets aren't configured.
+3. Publish the `aegis-server` Docker image to
+   `ghcr.io/<owner>/aegis-server:<version>` using the built-in `GITHUB_TOKEN`.
+4. Build the `aegis-cli` universal tarball and attach it to a GitHub Release.
+
+The version number is derived by `sbt-dynver` from the tag — `v0.1.1` →
+`0.1.1` for the artifacts. Don't add a `version :=` line to `build.sbt`;
+that would override the derived value and ship every tag as
+`0.1.0-SNAPSHOT`.
+
+## One-time setup (you, the maintainer, must do this once)
+
+The Docker + GitHub Release path runs out of the box on a fresh repository.
+The Maven Central path requires four secrets that only you can set up.
+
+### 1. Sonatype OSSRH account on `s01.oss.sonatype.org`
+
+If `dev.aegiskms` is already provisioned, skip to step 2. If not:
+
+1. Sign up at https://central.sonatype.com (or https://issues.sonatype.org
+   for the legacy OSSRH JIRA flow if your namespace is on the older host).
+2. Open a "New Project" ticket claiming the `dev.aegiskms` group ID. The
+   reviewer will check that you control `aegiskms.dev` (DNS TXT verification)
+   or the GitHub `sharma-bhaskar` namespace.
+3. Once approved, generate a **user token** (NOT your account password) at
+   https://central.sonatype.com/account → Tokens. The token's username and
+   password are the values you'll set as GitHub Action secrets below.
+
+### 2. GPG signing key
+
+Maven Central rejects unsigned artifacts. `sbt-ci-release` expects the
+private key as a base64-encoded blob in an env var.
+
+```bash
+# Generate a 4096-bit RSA key. Pick a passphrase you'll remember.
+gpg --full-generate-key
+
+# Find the key id (the long hex string) and publish the public half to a
+# keyserver so verifiers can fetch it.
+gpg --list-secret-keys --keyid-format LONG
+gpg --keyserver keyserver.ubuntu.com   --send-keys <KEY_ID>
+gpg --keyserver keys.openpgp.org       --send-keys <KEY_ID>
+gpg --keyserver pgp.mit.edu            --send-keys <KEY_ID>
+
+# Export the private key and base64-encode it (no line wrapping).
+gpg --armor --export-secret-keys <KEY_ID> | base64 | pbcopy
+```
+
+Save the base64 blob; it goes into `PGP_SECRET` below.
+
+### 3. GitHub Action secrets
+
+In the GitHub repo, go to **Settings → Secrets and variables → Actions →
+New repository secret** and add:
+
+| Secret name | Value |
+| --- | --- |
+| `PGP_SECRET` | The base64 blob from step 2. |
+| `PGP_PASSPHRASE` | The passphrase you chose for the GPG key. |
+| `SONATYPE_USERNAME` | The user-token name from step 1. |
+| `SONATYPE_PASSWORD` | The user-token value from step 1. |
+
+The release workflow gates the Maven publish step on `PGP_SECRET != ''`; if
+any of these are missing the workflow ships the Docker image + CLI tarball
+only and adds a `::notice` to the run output instead of failing.
+
+## Cutting a release
+
+Once setup is done, releasing is one command per tag:
+
+```bash
+# 1. Update CHANGELOG: rename the `## Unreleased` section to `## 0.1.1 — YYYY-MM-DD`,
+#    open a fresh `## Unreleased` block above it. Commit the change to main.
+
+# 2. Tag and push. sbt-dynver reads the tag verbatim, minus the `v` prefix.
+git tag v0.1.1
+git push origin v0.1.1
+```
+
+That's it. Watch the workflow at
+https://github.com/sharma-bhaskar/aegis-kms/actions/workflows/release.yml. On
+success:
+
+- `aegis-core_3` etc. appear at https://central.sonatype.com/artifact/dev.aegiskms/aegis-core_3
+  (allow ~10 min for staging → release sync).
+- The Docker image is at `ghcr.io/sharma-bhaskar/aegis-server:0.1.1`.
+- A `0.1.1` release page on GitHub carries the CLI tarball and
+  auto-generated changelog notes.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to do |
+| --- | --- | --- |
+| Workflow's "Publish to Maven Central" step is skipped with a `::notice` | One of the four secrets above is unset | Set them in repo settings; subsequent tags will publish |
+| Sonatype rejects with "Missing: gpg signature for ..." | GPG key not propagated to the keyserver yet | Re-run `gpg --keyserver ... --send-keys` against multiple servers; wait 10 min and retry the workflow |
+| Sonatype rejects with "Invalid POM: missing description" | One of the modules lost its `description :=` line | Restore in `build.sbt`; the `ThisBuild / description` fallback should also catch this |
+| Tag pushed but workflow didn't fire | Branch protection or workflow `on:` filter | Verify the tag matches `v*`; check the Actions tab for queued runs |
+| Docker tag missing the `v` prefix | Intentional — the workflow strips `v` so `v0.1.1 → ghcr.io/...:0.1.1` | This is the documented format |
+
+For deeper diagnostics, the workflow run page captures the full sbt output
+including the staged Sonatype URL.
+
+## Pre-release / SNAPSHOT versions
+
+Pushes to `main` (without a tag) automatically produce
+`0.1.1+<n>-<sha>-SNAPSHOT` artifacts via `sbt-dynver`. These are useful for
+internal smoke tests but are not published anywhere by default. To publish a
+SNAPSHOT manually from your laptop:
+
+```bash
+# Set the same env vars the workflow sets (PGP_SECRET, etc.).
+sbt ci-release
+```
+
+The Sonatype snapshot repo accepts these without manual staging.

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,12 @@ ThisBuild / organization     := "dev.aegiskms"
 ThisBuild / organizationName := "Aegis-KMS"
 ThisBuild / homepage         := Some(url("https://aegiskms.dev"))
 ThisBuild / licenses         := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
+// Maven Central staging requires a non-empty description on every published artifact. Each module
+// overrides this in its own `.settings(...)` block with its specific summary; this `ThisBuild`
+// fallback prevents an unnamed jar from failing the staging gate if a per-module override is ever
+// removed by accident.
+ThisBuild / description :=
+  "Aegis-KMS — agent-native key management. Identity, intelligence, and real-time control in front of your existing KMS."
 ThisBuild / developers := List(
   Developer("bhaskar", "Bhaskar Sharma", "sharma.b6@gmail.com", url("https://github.com/sharma-bhaskar"))
 )
@@ -54,56 +60,110 @@ lazy val commonSettings = Seq(
 
 // ── Library-safe tier: no Pekko, usable as a dependency by anyone ──
 lazy val core = (project in file("modules/aegis-core"))
-  .settings(commonSettings, name := "aegis-core", libraryDependencies ++= Dependencies.core)
+  .settings(
+    commonSettings,
+    name := "aegis-core",
+    description :=
+      "Pure-Scala domain layer: KeyService[F[_]] algebra, ManagedKey, KmsError, Principal, KeyEvent.",
+    libraryDependencies ++= Dependencies.core
+  )
 
 lazy val persistence = (project in file("modules/aegis-persistence"))
   .dependsOn(core)
   .settings(
     commonSettings,
     name := "aegis-persistence",
+    description :=
+      "Doobie-backed event journal for Aegis-KMS. Postgres impl + an in-memory variant for tests.",
     libraryDependencies ++= Dependencies.persistence ++ Dependencies.testcontainersPostgres
   )
 
 lazy val crypto = (project in file("modules/aegis-crypto"))
   .dependsOn(core)
-  .settings(commonSettings, name := "aegis-crypto", libraryDependencies ++= Dependencies.crypto)
+  .settings(
+    commonSettings,
+    name := "aegis-crypto",
+    description :=
+      "Root-of-Trust SPI for Aegis-KMS plus the AWS KMS adapter (layered-mode key generation, sign / verify, encrypt / decrypt, wrap / unwrap).",
+    libraryDependencies ++= Dependencies.crypto
+  )
 
 lazy val iam = (project in file("modules/aegis-iam"))
   .dependsOn(core, persistence)
-  .settings(commonSettings, name := "aegis-iam", libraryDependencies ++= Dependencies.jwt)
+  .settings(
+    commonSettings,
+    name := "aegis-iam",
+    description :=
+      "Identity + authorization for Aegis-KMS: Principal model, role-based policy engine, JWT issuer/verifier, agent-token issuance.",
+    libraryDependencies ++= Dependencies.jwt
+  )
 
 lazy val audit = (project in file("modules/aegis-audit"))
   .dependsOn(core, persistence)
-  .settings(commonSettings, name := "aegis-audit")
+  .settings(
+    commonSettings,
+    name := "aegis-audit",
+    description :=
+      "Append-only audit sink SPI for Aegis-KMS plus the stdout / in-memory implementations."
+  )
 
 lazy val sdkScala = (project in file("modules/aegis-sdk-scala"))
   .dependsOn(core)
-  .settings(commonSettings, name := "aegis-sdk-scala")
+  .settings(
+    commonSettings,
+    name        := "aegis-sdk-scala",
+    description := "Scala client SDK for the Aegis-KMS REST surface. No Pekko / pekko-http dependency."
+  )
 
 lazy val sdkJava = (project in file("modules/aegis-sdk-java"))
   .dependsOn(sdkScala)
-  .settings(commonSettings, name := "aegis-sdk-java", autoScalaLibrary := false)
+  .settings(
+    commonSettings,
+    name := "aegis-sdk-java",
+    description := "Java-friendly facade over `aegis-sdk-scala`. Pure JDK; no Scala in the consumer's classpath beyond the runtime.",
+    autoScalaLibrary := false
+  )
 
 // ── Server tier: depends on Pekko ──
 lazy val kmip = (project in file("modules/aegis-kmip"))
   .dependsOn(core, crypto, iam, audit)
-  .settings(commonSettings, name := "aegis-kmip", libraryDependencies ++= pekkoHttp)
+  .settings(
+    commonSettings,
+    name := "aegis-kmip",
+    description :=
+      "KMIP TTLV codec + TLS 1.3 server for Aegis-KMS. Storage vendors, database TDE, backup products. (skeleton in v0.1.x; full implementation in v0.4.0)",
+    libraryDependencies ++= pekkoHttp
+  )
 
 lazy val http = (project in file("modules/aegis-http"))
   .dependsOn(core, crypto, iam, audit)
   .settings(
     commonSettings,
     name := "aegis-http",
+    description :=
+      "REST plane for Aegis-KMS: Tapir endpoint definitions + pekko-http interpreter, OpenAPI 3.1 + Swagger UI on /docs.",
     libraryDependencies ++= pekkoHttp ++ Dependencies.tapir
   )
 
 lazy val agentAi = (project in file("modules/aegis-agent-ai"))
   .dependsOn(core, iam, audit)
-  .settings(commonSettings, name := "aegis-agent-ai", libraryDependencies ++= pekkoHttp)
+  .settings(
+    commonSettings,
+    name := "aegis-agent-ai",
+    description :=
+      "Risk scorer / anomaly detector / auto-responder / LLM advisor for Aegis-KMS. Drives the agent-governance wedge.",
+    libraryDependencies ++= pekkoHttp
+  )
 
 lazy val mcpServer = (project in file("modules/aegis-mcp-server"))
   .dependsOn(core, iam, http)
-  .settings(commonSettings, name := "aegis-mcp-server", libraryDependencies ++= pekkoHttp)
+  .settings(
+    commonSettings,
+    name := "aegis-mcp-server",
+    description :=
+      "Model Context Protocol server exposing Aegis-KMS as a curated tool surface for LLM clients (Claude, GPT, …). (skeleton in v0.1.x; full implementation in v0.4.0)",
+    libraryDependencies ++= pekkoHttp
+  )
 
 lazy val server = (project in file("modules/aegis-server"))
   .dependsOn(kmip, http, mcpServer, agentAi, iam, audit, persistence, crypto)
@@ -111,6 +171,9 @@ lazy val server = (project in file("modules/aegis-server"))
   .settings(
     commonSettings,
     name := "aegis-server",
+    description :=
+      "Standalone Aegis-KMS server: wires HTTP / KMIP / MCP / Agent-AI planes around the audited KeyService. Published as a Docker image, not a Maven library.",
+    publish / skip := true, // server is shipped as a Docker image, not a Maven artifact
     libraryDependencies ++=
       pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics ++ Dependencies.tracing,
     Docker / packageName := "aegis-server",
@@ -129,6 +192,9 @@ lazy val cli = (project in file("modules/aegis-cli"))
   .settings(
     commonSettings,
     name := "aegis-cli",
+    description :=
+      "`aegis` admin CLI for Aegis-KMS. Distributed as a tarball attached to GitHub Releases, not a Maven library.",
+    publish / skip := true, // CLI is shipped as a Universal tarball, not a Maven artifact
     // The published launcher should be `bin/aegis`, matching the README and the way users will
     // invoke it (`aegis keys create ...`). sbt-native-packager defaults to `bin/<name>` which
     // would produce `bin/aegis-cli`.


### PR DESCRIPTION
## Summary
Closes #14. Two parts:

1. **Per-module `description :=`** in `build.sbt` so Sonatype's POM-validation staging gate accepts every published library artifact (`aegis-core`, `-iam`, `-audit`, `-crypto`, `-persistence`, `-sdk-scala`, `-sdk-java`, `-kmip`, `-http`, `-agent-ai`, `-mcp-server`). `aegis-server` and `aegis-cli` get `publish / skip := true` — they ship as a Docker image and Universal tarball, not as Maven jars. A `ThisBuild / description` fallback covers any module that ever drops its override.

2. **`RELEASING.md` operator runbook** covering the one-time Sonatype OSSRH + GPG + GitHub-secrets setup that only the maintainer can do, plus the per-release flow (bump CHANGELOG, push a `v*` tag, watch the workflow), plus a troubleshooting matrix.

The existing `release.yml` workflow is already gated on `PGP_SECRET != ''`, so the first tag will Just Work once the four secrets are configured (`PGP_SECRET`, `PGP_PASSPHRASE`, `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`). Until then a tag still ships the Docker image + CLI tarball with a `::notice` on the workflow run.

**Required maintainer action before a Maven Central release will actually publish** (documented in `RELEASING.md`):
1. Sonatype OSSRH account on `s01.oss.sonatype.org` claiming the `dev.aegiskms` group.
2. GPG key generated + uploaded to the major keyservers.
3. Four secrets set in repo Settings → Actions.

## Test plan
- [x] `sbt show core / description` etc. confirms each module has its own description string.
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck "scalafixAll --check"` clean.
- [x] `sbt compile` clean — `publish / skip := true` on `server` and `cli` doesn't break the aggregate build.
- [x] CHANGELOG `## Unreleased` updated.
- [x] First actual `v*` tag publish — will happen the next time a release is cut; deferred to that operator action.
