### PR TITLE
feat(detector): time-of-day + source-IP + op-histogram baselines (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Anomaly detector expansion: time-of-day, source-IP, op-histogram baselines (closes #13).**
+  `BaselineDetector` now ships five detectors instead of two — adds `OpHistogramBaseline` (actor
+  performed an `Operation` it has never used), `TimeOfDayBaseline` (actor active in a UTC hour
+  outside their seen set), and `SourceIpBaseline` (request from a new IP, read from
+  `AuditRecord.context("source.ip")`). Each detector has a cold-start guard: it requires the actor
+  to have at least one prior observation in that dimension, so the first call doesn't alert. A
+  single anomalous record can fire multiple detectors at once (compound anomalies — see the
+  README's "Claude goes rogue" path). `ActorBaseline` gained `hoursSeen: Set[Int]` and
+  `sourceIpsSeen: Set[String]`. `AuditRecord` gained an additive `context: Map[String, String] =
+  Map.empty` field; the `SourceIpBaseline` detector reads `BaselineDetector.SourceIpContextKey`
+  (`"source.ip"`) from it. The HTTP layer doesn't yet populate the context — that's a follow-up;
+  until then the SourceIp detector is shape-complete and tested but inert in production.
 - **OpenAPI 3.1 spec + Swagger UI on the REST plane (closes #52).** `HttpRoutes` now generates an
   OpenAPI document from the live `Endpoints.all` list and mounts the standard Swagger UI bundle at
   `/docs/`, with the raw YAML at `/docs/docs.yaml`. Because the spec is derived from the same Tapir

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
@@ -4,7 +4,7 @@ import cats.effect.{IO, Ref}
 import dev.aegiskms.audit.AuditRecord
 import dev.aegiskms.core.{Operation, Principal}
 
-import java.time.{Duration, Instant}
+import java.time.{Duration, Instant, ZoneOffset}
 import java.util.UUID
 
 /** Sliding-window baseline detector — the W1 MVP that powers the "Claude goes rogue" demo in the README.
@@ -12,13 +12,23 @@ import java.util.UUID
   * Maintains, per actor subject, a small in-memory baseline:
   *   - the set of keys the actor has ever touched (within the retention window),
   *   - the histogram of ops the actor has ever performed,
+  *   - the set of UTC hours-of-day the actor has been active in,
+  *   - the set of source IPs the actor has been seen from,
   *   - the timestamps of the last N requests, used for rate-spike detection.
   *
-  * Two detector heuristics:
+  * Five detector heuristics:
   *   - `ScopeBaseline`: the actor touched a key not in its baseline. For agents this is severity High
   *     (suggested action `Revoke`); for humans it's severity Low (suggested action `Alert`).
   *   - `RateSpike`: the actor issued more than `rateBurstThreshold` requests in `rateBurstWindow`. Severity
   *     scales linearly with the multiplier above the burst threshold.
+  *   - `OpHistogramBaseline`: the actor performed an `Operation` it has never performed before.
+  *   - `TimeOfDayBaseline`: the actor was active in a UTC hour-of-day they have never been active in.
+  *   - `SourceIpBaseline`: the actor's request came from an IP not in their seen set. Reads
+  *     `record.context("source.ip")`; inert until the HTTP plumbing PR populates that key.
+  *
+  * Cold-start: every detector requires the actor to have at least one prior observation in the relevant
+  * dimension before it can fire. The first time `claude-session-7a3` shows up we record but don't alert; the
+  * *second* observation is what produces a recommendation if it deviates.
   *
   * The detector is intentionally tiny: this is the demo bar, not the production scorer. Risk-scored access
   * decisions and the LLM advisor are PRs W2 and W4.
@@ -45,6 +55,12 @@ final class BaselineDetector private (
 
 object BaselineDetector:
 
+  /** Well-known key the SourceIp detector reads from `AuditRecord.context`. The HTTP layer is responsible for
+    * populating this once per-request context plumbing lands; until then the SourceIp detector stays inert in
+    * production but can be exercised by tests that build records with the context populated.
+    */
+  val SourceIpContextKey: String = "source.ip"
+
   final case class Config(
       rateRetention: Duration,
       rateBurstWindow: Duration,
@@ -58,25 +74,36 @@ object BaselineDetector:
       rateBurstThreshold = 30
     )
 
+  /** Per-actor baseline. `hoursSeen` are UTC hours-of-day (`0`–`23`); we deliberately don't try to be
+    * timezone-aware in v0.1.1 — this is the *demo* detector. `sourceIpsSeen` is empty until the HTTP plumbing
+    * PR populates `AuditRecord.context("source.ip")`.
+    */
   final case class ActorBaseline(
       keysSeen: Set[String],
       opsSeen: Map[Operation, Int],
+      hoursSeen: Set[Int],
+      sourceIpsSeen: Set[String],
       recentRequests: Vector[Instant],
       firstSeen: Option[Instant]
   ):
     def update(rec: AuditRecord, resource: String, retention: Duration): ActorBaseline =
-      val cutoff = rec.at.minus(retention)
-      val pruned = recentRequests.dropWhile(_.isBefore(cutoff))
-      val newOps = opsSeen.updatedWith(rec.operation)(o => Some(o.getOrElse(0) + 1))
+      val cutoff  = rec.at.minus(retention)
+      val pruned  = recentRequests.dropWhile(_.isBefore(cutoff))
+      val newOps  = opsSeen.updatedWith(rec.operation)(o => Some(o.getOrElse(0) + 1))
+      val newHour = rec.at.atZone(ZoneOffset.UTC).getHour
+      val maybeIp = rec.context.get(SourceIpContextKey)
       ActorBaseline(
         keysSeen = keysSeen + resource,
         opsSeen = newOps,
+        hoursSeen = hoursSeen + newHour,
+        sourceIpsSeen = maybeIp.fold(sourceIpsSeen)(sourceIpsSeen + _),
         recentRequests = pruned :+ rec.at,
         firstSeen = firstSeen.orElse(Some(rec.at))
       )
 
   object ActorBaseline:
-    val empty: ActorBaseline = ActorBaseline(Set.empty, Map.empty, Vector.empty, None)
+    val empty: ActorBaseline =
+      ActorBaseline(Set.empty, Map.empty, Set.empty, Set.empty, Vector.empty, None)
 
   def make(config: Config = Config.Demo): IO[BaselineDetector] =
     Ref.of[IO, Map[String, ActorBaseline]](Map.empty).map(new BaselineDetector(_, config))
@@ -93,18 +120,12 @@ object BaselineDetector:
 
     // 1. ScopeBaseline — actor touched a key it has never touched before.
     if existing.keysSeen.nonEmpty && !existing.keysSeen.contains(resource) then
-      val severity = rec.principal match
-        case _: Principal.Agent => Severity.High
-        case _                  => Severity.Low
-      val action = rec.principal match
-        case _: Principal.Agent => SuggestedAction.Revoke
-        case _                  => SuggestedAction.Alert
       recs += AgentRecommendation(
         eventId = freshId(),
         at = rec.at,
         actor = rec.principal,
         detector = "ScopeBaseline",
-        severity = severity,
+        severity = severityForActor(rec.principal),
         summary = s"Actor touched a key outside its established baseline (${resource})",
         details = Map(
           "resource"      -> resource,
@@ -112,7 +133,7 @@ object BaselineDetector:
           "outcome"       -> rec.outcome,
           "correlationId" -> rec.correlationId
         ),
-        suggestedAction = action
+        suggestedAction = actionForActor(rec.principal)
       )
 
     // 2. RateSpike — too many requests in the burst window.
@@ -144,7 +165,79 @@ object BaselineDetector:
         suggestedAction = action
       )
 
+    // 3. OpHistogramBaseline — actor performed an Operation it has never used before.
+    //    Cold-start guard: we need at least one prior op (`opsSeen.nonEmpty`) before the *novelty* of
+    //    a new op is meaningful. Without this guard the detector would fire on every actor's first call.
+    if existing.opsSeen.nonEmpty && !existing.opsSeen.contains(rec.operation) then
+      recs += AgentRecommendation(
+        eventId = freshId(),
+        at = rec.at,
+        actor = rec.principal,
+        detector = "OpHistogramBaseline",
+        severity = severityForActor(rec.principal),
+        summary =
+          s"Actor performed ${rec.operation} for the first time (prior ops: ${existing.opsSeen.keys.toSeq.sortBy(_.toString).mkString(", ")})",
+        details = Map(
+          "newOperation"  -> rec.operation.toString,
+          "priorOpKinds"  -> existing.opsSeen.size.toString,
+          "outcome"       -> rec.outcome,
+          "correlationId" -> rec.correlationId
+        ),
+        suggestedAction = actionForActor(rec.principal)
+      )
+
+    // 4. TimeOfDayBaseline — actor active in a UTC hour-of-day they've never been active in.
+    val hour = rec.at.atZone(ZoneOffset.UTC).getHour
+    if existing.hoursSeen.nonEmpty && !existing.hoursSeen.contains(hour) then
+      recs += AgentRecommendation(
+        eventId = freshId(),
+        at = rec.at,
+        actor = rec.principal,
+        detector = "TimeOfDayBaseline",
+        // Off-hours is suspicious for any principal, but we keep agents at High because they should
+        // never be the ones widening their schedule on their own.
+        severity = severityForActor(rec.principal),
+        summary =
+          s"Actor active at UTC hour=$hour, outside the established baseline (${existing.hoursSeen.toSeq.sorted.mkString(",")})",
+        details = Map(
+          "newHourUtc"    -> hour.toString,
+          "hoursSeen"     -> existing.hoursSeen.toSeq.sorted.mkString(","),
+          "correlationId" -> rec.correlationId
+        ),
+        suggestedAction = actionForActor(rec.principal)
+      )
+
+    // 5. SourceIpBaseline — request from an IP not in the actor's seen set. Reads
+    //    `record.context("source.ip")`. Inert in production until the HTTP plumbing PR populates the
+    //    key; tests can build records with the context map set directly. We only fire when the actor
+    //    has at least one prior IP — so the cold-start case (no IP history at all) doesn't alert.
+    rec.context.get(SourceIpContextKey).foreach { ip =>
+      if existing.sourceIpsSeen.nonEmpty && !existing.sourceIpsSeen.contains(ip) then
+        recs += AgentRecommendation(
+          eventId = freshId(),
+          at = rec.at,
+          actor = rec.principal,
+          detector = "SourceIpBaseline",
+          severity = severityForActor(rec.principal),
+          summary = s"Actor request from new source IP $ip (prior IPs: ${existing.sourceIpsSeen.size})",
+          details = Map(
+            "sourceIp"      -> ip,
+            "priorIpCount"  -> existing.sourceIpsSeen.size.toString,
+            "correlationId" -> rec.correlationId
+          ),
+          suggestedAction = actionForActor(rec.principal)
+        )
+    }
+
     recs.result()
+
+  private def severityForActor(p: Principal): Severity = p match
+    case _: Principal.Agent => Severity.High
+    case _                  => Severity.Low
+
+  private def actionForActor(p: Principal): SuggestedAction = p match
+    case _: Principal.Agent => SuggestedAction.Revoke
+    case _                  => SuggestedAction.Alert
 
   private def keyResource(rec: AuditRecord): String =
     // Audit records carry resource as `key:<id>` for op-on-key, or `name:<n>/...` for create.

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineDetectorSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineDetectorSpec.scala
@@ -117,3 +117,129 @@ final class BaselineDetectorSpec extends AnyFunSuite with Matchers:
     aliceBaseline.opsSeen(Operation.Get) shouldBe 2
     aliceBaseline.opsSeen(Operation.Create) shouldBe 1
   }
+
+  // ── New v0.1.1 detectors ───────────────────────────────────────────────────
+
+  test("Agent's first novel Operation emits a High-severity OpHistogramBaseline rec with Revoke") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+    // Establish baseline with `Get`.
+    det.observe(rec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Get, "k1", "Success"))
+      .unsafeRunSync()
+    // Now perform a `Sign` — never seen before for this agent.
+    val recs = det
+      .observe(rec(Instant.parse("2026-04-25T03:00:05Z"), ag, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+
+    val opRec = recs.find(_.detector == "OpHistogramBaseline").get
+    opRec.severity shouldBe Severity.High
+    opRec.suggestedAction shouldBe SuggestedAction.Revoke
+    opRec.details("newOperation") shouldBe "Sign"
+  }
+
+  test("OpHistogramBaseline does NOT fire on the actor's very first call (cold-start guard)") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val recs = det
+      .observe(rec(Instant.parse("2026-04-25T03:00:00Z"), alice, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+    recs.exists(_.detector == "OpHistogramBaseline") shouldBe false
+  }
+
+  test("TimeOfDayBaseline fires when actor active in a UTC hour-of-day they've never used") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+    // Establish baseline at hour 03 UTC.
+    det.observe(rec(Instant.parse("2026-04-25T03:14:00Z"), ag, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+    // Move to hour 17 UTC — completely outside the agent's known schedule.
+    val recs = det
+      .observe(rec(Instant.parse("2026-04-25T17:00:00Z"), ag, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+
+    val todRec = recs.find(_.detector == "TimeOfDayBaseline").get
+    todRec.severity shouldBe Severity.High
+    todRec.details("newHourUtc") shouldBe "17"
+    todRec.details("hoursSeen") shouldBe "3"
+  }
+
+  test("TimeOfDayBaseline does NOT fire on the actor's first call (cold-start guard)") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val recs = det
+      .observe(rec(Instant.parse("2026-04-25T03:00:00Z"), alice, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+    recs.exists(_.detector == "TimeOfDayBaseline") shouldBe false
+  }
+
+  test("SourceIpBaseline fires when context.source.ip is new for this actor") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+    // Establish baseline IP via context.
+    val first = AuditRecord(
+      at = Instant.parse("2026-04-25T03:00:00Z"),
+      principal = ag,
+      operation = Operation.Sign,
+      resource = "key:k1",
+      outcome = "Success",
+      correlationId = "c1",
+      context = Map("source.ip" -> "10.0.5.10")
+    )
+    det.observe(first).unsafeRunSync()
+
+    val second = first.copy(
+      at = Instant.parse("2026-04-25T03:00:05Z"),
+      correlationId = "c2",
+      context = Map("source.ip" -> "203.0.113.99")
+    )
+    val recs = det.observe(second).unsafeRunSync()
+
+    val ipRec = recs.find(_.detector == "SourceIpBaseline").get
+    ipRec.severity shouldBe Severity.High
+    ipRec.details("sourceIp") shouldBe "203.0.113.99"
+    ipRec.details("priorIpCount") shouldBe "1"
+  }
+
+  test("SourceIpBaseline stays inert when records carry no source.ip context") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+    det.observe(rec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+    val recs = det
+      .observe(rec(Instant.parse("2026-04-25T03:00:05Z"), ag, Operation.Sign, "k1", "Success"))
+      .unsafeRunSync()
+    recs.exists(_.detector == "SourceIpBaseline") shouldBe false
+  }
+
+  test("a single observation can fire multiple detectors at once (compound anomaly)") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+    // Establish a tight baseline.
+    det.observe(AuditRecord(
+      at = Instant.parse("2026-04-25T03:14:00Z"),
+      principal = ag,
+      operation = Operation.Get,
+      resource = "key:invoice-2026",
+      outcome = "Success",
+      correlationId = "c0",
+      context = Map("source.ip" -> "10.0.5.10")
+    )).unsafeRunSync()
+
+    // Now: new key + new operation + new hour + new source IP, all in one record.
+    val anomaly = AuditRecord(
+      at = Instant.parse("2026-04-25T17:30:00Z"),
+      principal = ag,
+      operation = Operation.Sign,
+      resource = "key:treasury-master",
+      outcome = "Success",
+      correlationId = "c1",
+      context = Map("source.ip" -> "203.0.113.99")
+    )
+    val recs = det.observe(anomaly).unsafeRunSync()
+
+    val detectors = recs.map(_.detector).toSet
+    detectors should contain allOf (
+      "ScopeBaseline",
+      "OpHistogramBaseline",
+      "TimeOfDayBaseline",
+      "SourceIpBaseline"
+    )
+  }

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditSink.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditSink.scala
@@ -6,6 +6,12 @@ import java.time.Instant
 
 /** A single audit record. Append-only; the sink must never offer a mutation API. Writing must be crash-safe
   * before the originating operation is acknowledged to the client.
+  *
+  * `context` is a free-form bag of per-request metadata (source IP, user agent, request id, MCP session id,
+  * KMIP correlation id, ...). It's additive with a default of `Map.empty` so older callers compile unchanged;
+  * downstream consumers (the `BaselineDetector`'s SourceIp baseline, the SIEM webhook fan-out planned for
+  * v0.2.0) read specific keys from it. The well-known keys live alongside their producers — `"source.ip"` is
+  * set by the HTTP layer when the v0.1.x request-context plumbing PR lands.
   */
 final case class AuditRecord(
     at: Instant,
@@ -13,7 +19,8 @@ final case class AuditRecord(
     operation: Operation,
     resource: String,
     outcome: String,
-    correlationId: String
+    correlationId: String,
+    context: Map[String, String] = Map.empty
 )
 
 /** SPI for an audit-record sink. Bundled implementations: Postgres (via `aegis-persistence`) and


### PR DESCRIPTION
## Summary
Closes #13. Expands `BaselineDetector` from two heuristics to five:

| Detector | What it catches | Source |
| --- | --- | --- |
| `ScopeBaseline` (existing) | Actor touched a key not in their seen set | `keysSeen` |
| `RateSpike` (existing) | Burst above `rateBurstThreshold` in `rateBurstWindow` | `recentRequests` |
| **`OpHistogramBaseline`** (new) | Actor performed an `Operation` they have never used | `opsSeen` |
| **`TimeOfDayBaseline`** (new) | Actor active in a UTC hour outside their seen set | `hoursSeen` |
| **`SourceIpBaseline`** (new) | Request from an IP not in their seen set | `AuditRecord.context("source.ip")` |

`AuditRecord` gained an additive `context: Map[String, String] = Map.empty` field so the SourceIp detector has a place to read from. Default is empty — every existing call site compiles unchanged.

**Carve-out:** the HTTP layer doesn't yet populate `source.ip` (extracting `RemoteAddress` from pekko-http and threading it through Tapir is a separate small PR). Until then `SourceIpBaseline` is shape-complete and tested via synthetic records but inert in production. The other four detectors are live end-to-end.

Cold-start guards: each new detector requires at least one prior observation in its dimension before it can fire. First call records, second-and-onwards alerts.

## Test plan
- [x] 7 new tests in `BaselineDetectorSpec`: each new detector's firing path + each detector's cold-start guard + a compound-anomaly test where one record fires four detectors at once.
- [x] `sbt test` — full 14 agent-ai tests pass; full suite green.
- [x] `sbt scalafmtCheckAll "scalafixAll --check"` clean.
- [x] CHANGELOG `## Unreleased` updated.
- [ ] HTTP source-IP plumbing — deferred to a follow-up; flagged in the body and the `SourceIpContextKey` doc.

