### PR TITLE
feat(observability): OpenTelemetry tracing across the KeyService stack (closes #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **OpenTelemetry tracing — application-level spans + autoconfigured SDK (closes #11).** New
+  `TracingKeyService` decorator wraps each `KeyService[IO]` call in an OTel span named
+  `kms.<operation>` with attributes `aegis.operation`, `aegis.key.id` (when applicable),
+  `aegis.principal.subject`, `aegis.principal.kind` (`human` or `agent`), and `aegis.outcome`
+  (`success` / `error_<code>`). Span status is set to `ERROR` with the `KmsError` message on
+  failure. New `TracingRegistry` bootstraps the OTel SDK via `AutoConfiguredOpenTelemetrySdk` —
+  configuration is driven entirely by the standard `OTEL_*` env vars / system properties
+  (`OTEL_SERVICE_NAME`, `OTEL_TRACES_EXPORTER`, `OTEL_EXPORTER_OTLP_ENDPOINT`,
+  `OTEL_TRACES_SAMPLER`, `OTEL_RESOURCE_ATTRIBUTES`). The decorator slots between
+  `MeteredKeyService` and `AuditingKeyService`. **For full request-graph coverage** (pekko-http
+  server spans, JDBC client spans, AWS SDK client spans), attach the OpenTelemetry Java Agent at
+  JVM start (`-javaagent:opentelemetry-javaagent.jar`) — the agent and the SDK both read the same
+  `OTEL_*` env vars, so configuration is unchanged and our manual spans become children of the
+  agent's via W3C trace-context propagation. New `TracingKeyServiceSpec` uses the OTel
+  `InMemorySpanExporter` to assert span names, attributes, status codes, and the locate-specific
+  `aegis.locate.hits` attribute. Adds the `opentelemetry-api` + `-sdk` + `-exporter-otlp` +
+  `-sdk-extension-autoconfigure` deps (server-tier only — library modules unaffected) plus
+  `opentelemetry-sdk-testing` at test scope.
 - **Docker Compose hardening: no default Postgres password (closes #51).**
   `deploy/docker/docker-compose.yml` no longer ships the
   `aegis-dev-password-change-me` default. Both the Postgres container and the

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,8 @@ lazy val server = (project in file("modules/aegis-server"))
   .settings(
     commonSettings,
     name := "aegis-server",
-    libraryDependencies ++= pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics,
+    libraryDependencies ++=
+      pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics ++ Dependencies.tracing,
     Docker / packageName := "aegis-server",
     dockerBaseImage      := "eclipse-temurin:21-jre",
     // Fork `sbt 'server/run'` into its own JVM. Without this, sbt's in-process classloader and

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -80,6 +80,14 @@ object Server extends IOApp.Simple:
       //    listeners) so we close it on shutdown.
       metricsRegistry <- meterRegistryResource
 
+      // 1b. OpenTelemetry SDK from `OTEL_*` env vars / system properties. With no exporter configured
+      //     the autoconfigure default (`otlp`) silently buffers and drops; set
+      //     `OTEL_TRACES_EXPORTER=none` for unambiguous local-dev silence. See `TracingRegistry`'s doc
+      //     for the full env-var matrix. The SDK is an `OpenTelemetrySdk` (`AutoCloseable`), so the
+      //     Resource finalizer flushes pending spans on shutdown.
+      openTelemetry <- tracingResource
+      tracer = TracingRegistry.tracerFor(openTelemetry)
+
       // 2. Journal connection pool (or in-memory ref). Closing returns the Postgres pool to its
       //    finalizer; in-memory has no finalizer.
       journal <- journalResource(rootConfig)
@@ -90,14 +98,18 @@ object Server extends IOApp.Simple:
       given ActorSystem[KeyOpsActor.Command] = system
       given Scheduler                        = system.scheduler
 
-      // 4. Decorate. Auth → metrics → audit; see the class docstring for why this order matters.
+      // 4. Decorate. Auth → metrics → tracing → audit; see the class docstring for why this order
+      //    matters. Tracing sits between metrics and audit so the trace span measures auth + actor
+      //    + journal as one unit; metrics record their own (smaller) timer next to it; audit stays
+      //    the outermost layer so the audit row reflects the post-trace outcome.
       actorBacked = new ActorBackedKeyService(system)
       authorizing = new AuthorizingKeyService(actorBacked, new DevPolicyEngine)
       metered     = new MeteredKeyService(authorizing, metricsRegistry)
+      traced      = new TracingKeyService(metered, tracer)
       recSink  <- Resource.eval(InMemoryRecommendationSink.make)
       detector <- Resource.eval(BaselineDetector.make())
       sink     = TappedAuditSink(StdoutAuditSink(), detector, recSink)
-      auditing = new AuditingKeyService(metered, sink)
+      auditing = new AuditingKeyService(traced, sink)
 
       resolver = buildResolver(rootConfig)
       _ <- Resource.eval(IO {
@@ -116,6 +128,9 @@ object Server extends IOApp.Simple:
         logger.info(s"aegis-server listening on http://$host:$port (try POST /v1/keys)")
         logger.info(s"docs:    http://$host:$port/docs/  (Swagger UI; OpenAPI YAML at /docs/docs.yaml)")
         logger.info(s"metrics: http://$host:$port/metrics (Prometheus exposition format)")
+        logger.info(
+          "tracing: OTel SDK initialised (configure via OTEL_* env vars; OTEL_TRACES_EXPORTER=none disables)"
+        )
         logger.info("audit feed → stdout; recommendations → in-memory sink (visible via /admin in PR W1.b)")
       })
     yield ()
@@ -127,6 +142,20 @@ object Server extends IOApp.Simple:
     */
   private def meterRegistryResource: Resource[IO, PrometheusMeterRegistry] =
     Resource.make(IO(MetricsRegistry.make()))(r => IO(r.close()))
+
+  /** OpenTelemetry SDK as a Resource. `AutoConfiguredOpenTelemetrySdk` returns an `OpenTelemetrySdk` which is
+    * `AutoCloseable`; closing it flushes pending spans + shuts down the exporter so SIGTERM doesn't drop
+    * in-flight traces. We pattern-match the returned `OpenTelemetry` to recover the SDK instance — it's
+    * always the SDK, but the API type is widened.
+    */
+  private def tracingResource: Resource[IO, io.opentelemetry.api.OpenTelemetry] =
+    Resource.make(IO(TracingRegistry.make())) {
+      case sdk: io.opentelemetry.sdk.OpenTelemetrySdk =>
+        IO(sdk.close()).handleErrorWith(t =>
+          IO(logger.warn(s"OpenTelemetry SDK shutdown reported error: ${t.getMessage}", t))
+        )
+      case _ => IO.unit
+    }
 
   /** Journal as a Resource. The Postgres path returns a real `Resource[IO, EventJournal[IO]]` whose finalizer
     * closes the connection pool. The in-memory path has nothing to close, so we lift it with `Resource.eval`.

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/TracingKeyService.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/TracingKeyService.scala
@@ -1,0 +1,179 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import dev.aegiskms.core.*
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.trace.{Span, StatusCode, Tracer}
+
+/** `KeyService[IO]` decorator that wraps each call in an OpenTelemetry span. The span name is
+  * `kms.<operation>` (lowercase), and the span carries a small attribute set:
+  *
+  *   - `aegis.operation` — the `Operation` enum value (`Sign`, `Encrypt`, …).
+  *   - `aegis.key.id` — the `KeyId.value` for ops that take one (omitted for `create` and `locate` since the
+  *     id either doesn't exist yet or doesn't apply).
+  *   - `aegis.principal.subject` — the calling principal's subject.
+  *   - `aegis.principal.kind` — `human` or `agent`.
+  *   - `aegis.outcome` — `success`, `failure`, or `error_<code>` on `Left`. Span status is set to `ERROR` on
+  *     failure with the `KmsError` message as the description.
+  *
+  * Layered position: this sits **outside** `MeteredKeyService` and **inside** `AuditingKeyService`. The trace
+  * span thus measures auth + actor + journal as one unit; metrics record their own (smaller) timer next to
+  * it. Audit stays the outermost layer so the audit row reflects the post-trace outcome.
+  *
+  * Concretely the chain reads from the wire in:
+  *
+  * `AuditingKeyService → TracingKeyService → MeteredKeyService → AuthorizingKeyService →
+  * ActorBackedKeyService`
+  *
+  * **Context propagation.** When the OpenTelemetry Java Agent is attached, an inbound HTTP request already
+  * carries an active server span; this decorator's `spanBuilder` picks it up as the parent via the
+  * thread-local `Context.current()`. Without the agent (e.g. local dev without OTel), spans are still created
+  * but without parents — they show up as roots in whatever exporter is configured (or silently dropped if
+  * `OTEL_TRACES_EXPORTER=none`).
+  */
+final class TracingKeyService(inner: KeyService[IO], tracer: Tracer) extends KeyService[IO]:
+
+  import TracingKeyService.*
+
+  def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Create, keyId = None, by)(inner.create(spec, by))
+
+  def get(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Get, Some(id), by)(inner.get(id, by))
+
+  def locate(namePattern: String, by: Principal): IO[List[ManagedKey]] =
+    // `locate` returns `List` rather than `Either`; we can't share the helper. Hand-roll the same
+    // outcome handling without the `Either` branch.
+    IO(startSpan(Operation.Locate, keyId = None, by)).flatMap { span =>
+      inner.locate(namePattern, by).attempt.flatMap {
+        case Right(list) =>
+          IO {
+            span.setAttribute("aegis.outcome", "success")
+            span.setAttribute("aegis.locate.hits", list.size.toLong)
+            span.end()
+          } *> IO.pure(list)
+        case Left(t) =>
+          IO {
+            span.setStatus(StatusCode.ERROR, t.getMessage)
+            span.recordException(t)
+            span.end()
+          } *> IO.raiseError(t)
+      }
+    }
+
+  def activate(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Activate, Some(id), by)(inner.activate(id, by))
+
+  def revoke(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Revoke, Some(id), by)(inner.revoke(id, by))
+
+  def destroy(id: KeyId, by: Principal): IO[Either[KmsError, Unit]] =
+    traced(Operation.Destroy, Some(id), by)(inner.destroy(id, by))
+
+  def sign(
+      id: KeyId,
+      message: Array[Byte],
+      alg: SigAlgorithm,
+      by: Principal
+  ): IO[Either[KmsError, Signature]] =
+    traced(Operation.Sign, Some(id), by, detail = alg.toString)(inner.sign(id, message, alg, by))
+
+  def verify(
+      id: KeyId,
+      message: Array[Byte],
+      signature: Signature,
+      by: Principal
+  ): IO[Either[KmsError, Boolean]] =
+    traced(Operation.Verify, Some(id), by, detail = signature.algorithm.toString)(
+      inner.verify(id, message, signature, by)
+    )
+
+  def encrypt(
+      id: KeyId,
+      plaintext: Array[Byte],
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Ciphertext]] =
+    traced(Operation.Encrypt, Some(id), by)(inner.encrypt(id, plaintext, context, by))
+
+  def decrypt(
+      id: KeyId,
+      ciphertext: Ciphertext,
+      context: Map[String, String],
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    traced(Operation.Decrypt, Some(id), by)(inner.decrypt(id, ciphertext, context, by))
+
+  def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+    traced(Operation.Wrap, Some(id), by)(inner.wrap(id, dek, by))
+
+  def unwrap(
+      id: KeyId,
+      wrapped: WrappedDek,
+      by: Principal
+  ): IO[Either[KmsError, Array[Byte]]] =
+    traced(Operation.Unwrap, Some(id), by)(inner.unwrap(id, wrapped, by))
+
+  def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Compromise, Some(id), by)(inner.compromise(id, reason, by))
+
+  def rotate(
+      id: KeyId,
+      policy: RotationPolicy,
+      by: Principal
+  ): IO[Either[KmsError, ManagedKey]] =
+    traced(Operation.Rotate, Some(id), by, detail = policy.render)(inner.rotate(id, policy, by))
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /** Open a span, run `action`, set outcome attributes + status from the resulting `Either`, always close the
+    * span. `detail` is an optional extra attribute (algorithm string for sign/verify, policy for rotate) —
+    * `""` skips setting it.
+    */
+  private def traced[A](
+      op: Operation,
+      keyId: Option[KeyId],
+      by: Principal,
+      detail: String = ""
+  )(action: IO[Either[KmsError, A]]): IO[Either[KmsError, A]] =
+    IO(startSpan(op, keyId, by)).flatMap { span =>
+      if detail.nonEmpty then span.setAttribute("aegis.detail", detail): Unit
+      action.flatTap { result =>
+        IO {
+          result match
+            case Right(_) =>
+              span.setAttribute("aegis.outcome", "success"): Unit
+            case Left(err) =>
+              span.setAttribute("aegis.outcome", s"error_${err.code}")
+              span.setStatus(StatusCode.ERROR, err.message)
+          span.end()
+        }
+      }.handleErrorWith { t =>
+        IO {
+          span.setStatus(StatusCode.ERROR, t.getMessage)
+          span.recordException(t)
+          span.end()
+        } *> IO.raiseError(t)
+      }
+    }
+
+  private def startSpan(op: Operation, keyId: Option[KeyId], by: Principal): Span =
+    val builder = tracer.spanBuilder(s"kms.${op.toString.toLowerCase}")
+    val attrs   = Attributes.builder()
+    attrs.put(OperationAttr, op.toString)
+    keyId.foreach(id => attrs.put(KeyIdAttr, id.value))
+    attrs.put(PrincipalSubjectAttr, by.subject)
+    attrs.put(PrincipalKindAttr, principalKind(by))
+    builder.setAllAttributes(attrs.build()).startSpan()
+
+  private def principalKind(p: Principal): String = p match
+    case _: Principal.Agent => "agent"
+    case _                  => "human"
+
+object TracingKeyService:
+  // Pre-build the AttributeKey instances; the SDK caches but the API charges an allocation per build()
+  // otherwise.
+  private val OperationAttr        = AttributeKey.stringKey("aegis.operation")
+  private val KeyIdAttr            = AttributeKey.stringKey("aegis.key.id")
+  private val PrincipalSubjectAttr = AttributeKey.stringKey("aegis.principal.subject")
+  private val PrincipalKindAttr    = AttributeKey.stringKey("aegis.principal.kind")

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/TracingRegistry.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/TracingRegistry.scala
@@ -1,0 +1,67 @@
+package dev.aegiskms.app
+
+import io.opentelemetry.api.trace.{Tracer, TracerProvider}
+import io.opentelemetry.api.{GlobalOpenTelemetry, OpenTelemetry}
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+
+/** OpenTelemetry SDK bootstrap. Lives in `aegis-server` rather than a library module because OTel is a
+  * server-tier dependency only — the library-safe modules (`aegis-core`, `aegis-iam`, `aegis-audit`,
+  * `aegis-persistence`, the SDKs) MUST stay dep-light so embedders aren't forced to ship a tracing library
+  * they may not want.
+  *
+  * Configuration is driven entirely by environment variables / system properties; the Java SDK's
+  * `AutoConfiguredOpenTelemetrySdk` reads the standard `OTEL_*` set:
+  *
+  *   - `OTEL_SERVICE_NAME=aegis-server`
+  *   - `OTEL_TRACES_EXPORTER=otlp` (or `none`, `console`, `logging-otlp`, `zipkin`, `jaeger`)
+  *   - `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`
+  *   - `OTEL_TRACES_SAMPLER=parentbased_always_on` (default)
+  *   - `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod,service.namespace=kms`
+  *
+  * When the operator hasn't set `OTEL_TRACES_EXPORTER` we still build the SDK; the autoconfigure default is
+  * the OTLP exporter, which silently no-ops without a configured endpoint. To explicitly disable tracing for
+  * local development, set `OTEL_TRACES_EXPORTER=none`.
+  *
+  * **Production note.** Application-level spans (created by `TracingKeyService`) are the slice this module
+  * instruments. For full request-graph coverage — pekko-http server spans, JDBC client spans, AWS SDK client
+  * spans — attach the OpenTelemetry Java Agent at JVM start:
+  *
+  * {{{
+  * java -javaagent:opentelemetry-javaagent.jar -jar aegis-server.jar
+  * }}}
+  *
+  * The agent and the SDK both read the same `OTEL_*` env vars, so the operator's configuration is unchanged.
+  * The agent contributes server / database / AWS spans automatically and our manual spans become children via
+  * the standard W3C trace-context propagation.
+  */
+object TracingRegistry:
+
+  /** Build the autoconfigured `OpenTelemetry` instance. We deliberately do NOT call `setResultAsGlobal`:
+    *
+    *   - When the OpenTelemetry Java Agent is attached at JVM start, the agent owns `GlobalOpenTelemetry` and
+    *     our manual spans become children of the agent's via thread-local `Context.current()`. We thread our
+    *     SDK explicitly into [[TracingKeyService]] so we don't fight the agent for the global slot.
+    *   - Without the agent, no other code in the process reads the global anyway — `TracingKeyService`
+    *     receives the `Tracer` by constructor argument, not via `GlobalOpenTelemetry.getTracer`.
+    *   - Tests can build a fresh registry per suite without the global-singleton trap (the autoconfigure SDK
+    *     throws if `setResultAsGlobal` is called twice).
+    *
+    * The returned `OpenTelemetrySdk` is `AutoCloseable`; closing it flushes pending spans + shuts down the
+    * exporter. Callers wrap this in a `Resource` so SIGTERM unwinds cleanly.
+    */
+  def make(): OpenTelemetry =
+    AutoConfiguredOpenTelemetrySdk.builder()
+      .build()
+      .getOpenTelemetrySdk
+
+  /** Convenience accessor for downstream callers that just want a `Tracer` — the most common need. Returns
+    * the application's tracer keyed by the `aegis-kms` instrumentation name.
+    */
+  def tracerFor(otel: OpenTelemetry, instrumentationName: String = "aegis-kms"): Tracer =
+    otel.getTracer(instrumentationName)
+
+  /** Last-resort accessor that reads from the global. Useful for tests / pure-utility code paths that don't
+    * have a handle on the boot-scope OpenTelemetry. Falls back to a no-op tracer if the SDK hasn't been
+    * initialized.
+    */
+  def globalTracerProvider: TracerProvider = GlobalOpenTelemetry.getTracerProvider

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/TracingKeyServiceSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/TracingKeyServiceSpec.scala
@@ -1,0 +1,109 @@
+package dev.aegiskms.app
+
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.core.*
+import io.opentelemetry.api.trace.{StatusCode, Tracer}
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters.*
+
+/** Tests `TracingKeyService` against the OTel `InMemorySpanExporter`. We avoid the global SDK so each test
+  * gets a fresh exporter; spans the decorator emits land in the in-memory list and we assert on names +
+  * attributes + statuses without touching network exporters.
+  */
+final class TracingKeyServiceSpec extends AnyFunSuite with Matchers:
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def fixture(): (TracingKeyService, InMemorySpanExporter) =
+    val exporter = InMemorySpanExporter.create()
+    val provider = SdkTracerProvider.builder()
+      .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+      .build()
+    val sdk: OpenTelemetrySdk = OpenTelemetrySdk.builder().setTracerProvider(provider).build()
+    val tracer: Tracer        = sdk.getTracer("aegis-kms-test")
+    val inner                 = KeyService.inMemory.unsafeRunSync()
+    (new TracingKeyService(inner, tracer), exporter)
+
+  test("a successful create emits one span named kms.create with success outcome") {
+    val (svc, exporter) = fixture()
+    svc.create(KeySpec.aes256("k"), alice).unsafeRunSync()
+
+    val spans = exporter.getFinishedSpanItems.asScala
+    spans.size shouldBe 1
+    val span = spans.head
+    span.getName shouldBe "kms.create"
+    span.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.operation")
+    ) shouldBe "Create"
+    span.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.outcome")
+    ) shouldBe "success"
+    span.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.principal.subject")
+    ) shouldBe "alice@org"
+    span.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.principal.kind")
+    ) shouldBe "human"
+  }
+
+  test("a failing call (sign on PreActive) sets span status ERROR with the KmsError message") {
+    val (svc, exporter) = fixture()
+    val k               = svc.create(KeySpec.rsa2048("k"), alice).unsafeRunSync().toOption.get
+    // Skip activate so sign returns IllegalOperation
+    svc.sign(k.id, "x".getBytes, SigAlgorithm.RsaPssSha256, alice).unsafeRunSync()
+
+    val signSpan = exporter.getFinishedSpanItems.asScala.find(_.getName == "kms.sign").get
+    signSpan.getStatus.getStatusCode shouldBe StatusCode.ERROR
+    signSpan.getStatus.getDescription should include("Active")
+    signSpan.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.outcome")
+    ) shouldBe "error_IllegalOperation"
+    // The detail attribute carries the algorithm for sign / verify.
+    signSpan.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.detail")
+    ) shouldBe "RsaPssSha256"
+  }
+
+  test("each call emits a separate span; key id is stamped where applicable") {
+    val (svc, exporter) = fixture()
+    val k               = svc.create(KeySpec.aes256("k"), alice).unsafeRunSync().toOption.get
+    svc.activate(k.id, alice).unsafeRunSync()
+    svc.get(k.id, alice).unsafeRunSync()
+
+    val spans = exporter.getFinishedSpanItems.asScala.toList
+    spans.map(_.getName).sorted shouldBe List("kms.activate", "kms.create", "kms.get")
+    val getSpan = spans.find(_.getName == "kms.get").get
+    getSpan.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.key.id")
+    ) shouldBe k.id.value
+  }
+
+  test("locate emits one span with the hit count regardless of result size") {
+    val (svc, exporter) = fixture()
+    svc.locate("nope", alice).unsafeRunSync() shouldBe Nil
+    val span = exporter.getFinishedSpanItems.asScala.find(_.getName == "kms.locate").get
+    span.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.longKey("aegis.locate.hits")
+    ).longValue shouldBe 0L
+  }
+
+  test("rotate's policy.render is captured as the detail attribute") {
+    val (svc, exporter) = fixture()
+    val k               = svc.create(KeySpec.aes256("k"), alice).unsafeRunSync().toOption.get
+    svc.activate(k.id, alice).unsafeRunSync()
+    svc.rotate(k.id, RotationPolicy.Manual, alice).unsafeRunSync()
+
+    val rotateSpan = exporter.getFinishedSpanItems.asScala.find(_.getName == "kms.rotate").get
+    rotateSpan.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.detail")
+    ) shouldBe "Manual"
+    rotateSpan.getAttributes.get(
+      io.opentelemetry.api.common.AttributeKey.stringKey("aegis.outcome")
+    ) shouldBe "success"
+  }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
     val scalatest      = "3.2.19"
     val testcontainers = "0.41.4"
     val micrometer     = "1.13.6"
+    val otel           = "1.42.1"
   }
 
   val core: Seq[ModuleID] = Seq(
@@ -73,6 +74,20 @@ object Dependencies {
   val metrics: Seq[ModuleID] = Seq(
     "io.micrometer" % "micrometer-core"                % V.micrometer,
     "io.micrometer" % "micrometer-registry-prometheus" % V.micrometer
+  )
+
+  /** OpenTelemetry SDK + OTLP exporter + autoconfigure. Server-tier only. The autoconfigure module reads
+    * `OTEL_*` env vars and system properties to pick a sampler, exporter, resource attributes, etc. — so the
+    * operator can wire to Jaeger / Tempo / OTel Collector without code changes. The
+    * `opentelemetry-sdk-testing` artifact is test-scope and gives us `InMemorySpanExporter` for deterministic
+    * span assertions.
+    */
+  val tracing: Seq[ModuleID] = Seq(
+    "io.opentelemetry" % "opentelemetry-api"                         % V.otel,
+    "io.opentelemetry" % "opentelemetry-sdk"                         % V.otel,
+    "io.opentelemetry" % "opentelemetry-exporter-otlp"               % V.otel,
+    "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % V.otel,
+    "io.opentelemetry" % "opentelemetry-sdk-testing"                 % V.otel % Test
   )
 
   /** JJWT (Java JWT) suite for issuing and verifying JWS tokens. Used by `aegis-iam` for the JWT bearer


### PR DESCRIPTION
## Summary
Closes #11. Application-level half of the v0.1.1 observability target.

| Component | Purpose |
| --- | --- |
| **`TracingRegistry`** | Bootstraps the OTel SDK via `AutoConfiguredOpenTelemetrySdk` — driven entirely by `OTEL_*` env vars. |
| **`TracingKeyService`** | `KeyService[IO]` decorator emitting one span per call with `aegis.operation`, `aegis.key.id`, `aegis.principal.{subject,kind}`, `aegis.outcome`, and operation-specific `aegis.detail` attributes. Sets span status `ERROR` on `KmsError`. |
| **`Server.scala` wiring** | Slots between `MeteredKeyService` and `AuditingKeyService`. |

**Production path for full request-graph coverage** (REST + JDBC + AWS SDK): attach the OpenTelemetry Java Agent at JVM start (`-javaagent:opentelemetry-javaagent.jar`). The agent and the SDK read the same `OTEL_*` env vars, so the operator's config is unchanged and our manual spans become children of the agent's auto-instrumented server / database / AWS spans via W3C trace-context propagation. This is documented in `TracingRegistry`'s scaladoc.

Configuration env vars (read by both the SDK and the optional Java Agent):
- `OTEL_SERVICE_NAME=aegis-server`
- `OTEL_TRACES_EXPORTER=otlp` (or `none` / `console` / `zipkin` / `jaeger`)
- `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`
- `OTEL_TRACES_SAMPLER=parentbased_always_on` (default)
- `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod,service.namespace=kms`

## Test plan
- [x] 5 new tests in `TracingKeyServiceSpec` using OTel's `InMemorySpanExporter` — span name + attribute set on success, span status ERROR with the right outcome attribute on `KmsError`, multi-call isolation, locate's hit-count attribute, rotate's `policy.render` as `aegis.detail`.
- [x] `sbt test` — full suite green; new tests live alongside the metrics + boot tests in `aegis-server`.
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck "scalafixAll --check"` clean.
- [x] CHANGELOG `## Unreleased` updated.
- [ ] Real Jaeger / Tempo smoke test — deferred to the v0.1.1 release smoke; the SDK's autoconfigure path is well-trodden.
