### PR TITLE
docs(site): Mermaid diagrams + full op-surface quickstart

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,38 +2,50 @@
 
 Aegis-KMS is a key management service designed for a world where humans, services, storage vendors, and AI agents all need to use the same keys safely. Four protocol planes (REST, KMIP, MCP, Agent-AI) terminate at a single audited core. The core is split into a library-safe tier (algebras, codecs, SDKs) that any JVM application can embed, and a server tier that adds wire protocols, persistence, and a pluggable root-of-trust.
 
-This document describes the system the project is building toward. For current implementation state, see [§9 Status](#9-status).
+This document describes the system the project is building toward. For current implementation state, see [§11 Status](#11-status).
 
 ## 1. Module layout
 
 The build is split into two tiers. The split is enforced at build time: anything in the library-safe tier that imports Pekko fails to compile because Pekko isn't on its classpath. This guarantees `aegis-core` and the SDKs stay slim enough to embed in any JVM app.
 
-```
-                     ┌────────────────────────────────────────────────────────┐
-                     │                     aegis-server                       │
-                     │   (entry point, wires HTTP + KMIP + MCP + agent-ai)    │
-                     └───────┬───────────┬───────────┬───────────┬────────────┘
-                             │           │           │           │
-                ┌────────────▼─┐  ┌──────▼─────┐  ┌──▼───────┐  ┌▼──────────┐
-   server tier  │  aegis-http  │  │ aegis-kmip │  │ aegis-   │  │ aegis-    │
-  (Pekko-aware) │  Tapir +     │  │ TTLV + TLS │  │ mcp-     │  │ agent-ai  │
-                │  pekko-http  │  │            │  │ server   │  │           │
-                └──────┬───────┘  └─────┬──────┘  └────┬─────┘  └─────┬─────┘
-                       │                │              │              │
-                       └────────┬───────┴──────────────┴──────────────┘
-                                │
-        ┌───────────────────────▼───────────────────────────────┐
-        │               aegis-core  (algebras, model)           │
-        │   KeyService[F[_]], ManagedKey, KmsError, Principal   │
-        └───┬──────────────┬──────────────┬─────────────────────┘
-            │              │              │
-   ┌────────▼─────┐  ┌─────▼─────┐  ┌─────▼──────┐  ┌──────────┐  ┌──────────┐
-   │ aegis-       │  │ aegis-    │  │ aegis-     │  │ aegis-   │  │ aegis-   │
-   │ persistence  │  │ crypto    │  │ iam        │  │ audit    │  │ sdk-*    │
-   │ Doobie / PG  │  │ Root of   │  │ OIDC, JWT, │  │ event    │  │ Scala +  │
-   │              │  │  Trust    │  │ agent ID   │  │ log      │  │ Java     │
-   └──────────────┘  └───────────┘  └────────────┘  └──────────┘  └──────────┘
-            ────────────  library-safe tier (no Pekko)  ────────────
+```mermaid
+flowchart TD
+    classDef server   fill:#1d3557,stroke:#1d3557,color:#fff
+    classDef library  fill:#457b9d,stroke:#457b9d,color:#fff
+    classDef boot     fill:#e63946,stroke:#e63946,color:#fff
+
+    boot["<b>aegis-server</b><br/><i>entry point<br/>wires HTTP · KMIP · MCP · Agent-AI</i>"]:::boot
+
+    subgraph ServerTier["Server tier (Pekko-aware)"]
+        http["<b>aegis-http</b><br/>Tapir + pekko-http<br/>OpenAPI on /docs"]:::server
+        kmip["<b>aegis-kmip</b><br/>TTLV + TLS 1.3<br/>(v0.4.0 🚧)"]:::server
+        mcp["<b>aegis-mcp-server</b><br/>JSON-RPC over stdio/SSE<br/>(v0.4.0 🚧)"]:::server
+        agent["<b>aegis-agent-ai</b><br/>Function-call shape<br/>+ BaselineDetector"]:::server
+    end
+
+    core["<b>aegis-core</b><br/><i>KeyService&#91;F&#91;_&#93;&#93; algebra · ManagedKey · KmsError · Principal · KeyEvent</i>"]:::library
+
+    subgraph LibraryTier["Library-safe tier (no Pekko · embeddable in any JVM app)"]
+        persistence["<b>aegis-persistence</b><br/>Doobie + Postgres<br/>event journal"]:::library
+        crypto["<b>aegis-crypto</b><br/>Root-of-Trust SPI<br/>+ AWS KMS adapter"]:::library
+        iam["<b>aegis-iam</b><br/>JWT issue/verify<br/>policy engine"]:::library
+        audit["<b>aegis-audit</b><br/>append-only sink<br/>(stdout · Postgres 🚧)"]:::library
+        sdks["<b>aegis-sdk-scala</b><br/><b>aegis-sdk-java</b><br/>thin REST clients"]:::library
+    end
+
+    boot --> http
+    boot --> kmip
+    boot --> mcp
+    boot --> agent
+    http --> core
+    kmip --> core
+    mcp --> core
+    agent --> core
+    core --> persistence
+    core --> crypto
+    core --> iam
+    core --> audit
+    core --> sdks
 ```
 
 | Module | Tier | Purpose |
@@ -84,21 +96,37 @@ In a deployment that has no storage / DB / backup / tape consumers, the KMIP lis
 
 A managed key in Aegis-KMS is a state machine, not a bag of bytes. Every operation either reads the current state or transitions it, and every transition produces an audit event.
 
-```
-       create                 activate              schedule rotation
-   ┌──────────►  PreActive  ───────────►  Active  ──────────────┐
-   │                                       │  ▲                 │
-   │                                       │  │                 ▼
-   │                                       │  │             Active'  (new version)
-   │                                       │  │                 │
-   │                                       ▼  │                 │
-   │                                  Deactivated  ◄────────────┘ old version, verify-only
-   │                                       │
-   │                                       ▼  retention period
-   │                                   Compromised? ──► Compromised  (manual)
-   │                                       │
-   │                                       ▼
-   └────────────────────────────────►  Destroyed     audit row preserved forever
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*]          --> PreActive    : create
+    PreActive    --> Active       : activate
+    PreActive    --> Compromised  : compromise<br/>(operator override)
+    PreActive    --> Destroyed    : destroy
+    Active       --> Active       : rotate<br/>(currentVersion += 1)
+    Active       --> Deactivated  : revoke<br/>(or rotation moves prior version here)
+    Active       --> Compromised  : compromise<br/>(severity=Critical audit)
+    Active       --> Destroyed    : destroy
+    Deactivated  --> Compromised  : compromise
+    Deactivated  --> Destroyed    : destroy
+    Compromised  --> Destroyed    : destroy
+    Destroyed    --> [*]          : audit row<br/>preserved forever
+
+    note right of Active
+        sign · verify
+        encrypt · decrypt
+        wrap · unwrap
+    end note
+    note right of Deactivated
+        verify · decrypt · unwrap only
+        (read-only, for ciphertexts
+        produced before rotation)
+    end note
+    note right of Compromised
+        every crypto op refused
+        — including verify —
+        with IllegalOperation
+    end note
 ```
 
 Each transition has a single owner and a clear semantic:
@@ -159,10 +187,24 @@ The result: a Claude or GPT agent can use Aegis-KMS as if it were any other MCP-
 
 Every request, regardless of plane, follows the same shape:
 
-```
-client ─► plane terminator ─► IAM (authn + authz) ─► KeyService ─► [persistence + root-of-trust]
-                                                          │
-                                                          └─► AuditEvent ─► audit sink
+```mermaid
+flowchart LR
+    classDef plane    fill:#1d3557,stroke:#1d3557,color:#fff
+    classDef gate     fill:#f4a261,stroke:#f4a261,color:#000
+    classDef metric   fill:#2a9d8f,stroke:#2a9d8f,color:#fff
+    classDef core     fill:#457b9d,stroke:#457b9d,color:#fff
+    classDef sink     fill:#e76f51,stroke:#e76f51,color:#fff
+
+    client[Client] --> plane["Plane terminator<br/>(REST · KMIP · MCP · Agent-AI)"]:::plane
+    plane --> audit["AuditingKeyService<br/><i>outermost — records every call</i>"]:::sink
+    audit --> traced["TracingKeyService<br/><i>OTel span per op</i>"]:::metric
+    traced --> metered["MeteredKeyService<br/><i>Prometheus counter + timer</i>"]:::metric
+    metered --> authz["AuthorizingKeyService<br/><i>policy engine gate</i>"]:::gate
+    authz --> svc["KeyService.&lt;op&gt;"]:::core
+    svc --> actor["KeyOpsActor<br/><i>single-thread state owner</i>"]:::core
+    actor --> journal[(Event journal)]:::sink
+    actor --> rot[(Root of Trust<br/>AWS KMS adapter)]:::sink
+    audit -. on every call .-> auditSink[(Audit sink<br/>stdout · SIEM · Kafka 🚧)]:::sink
 ```
 
 For a `POST /v1/keys` over REST, the concrete steps are:
@@ -180,21 +222,21 @@ KMIP, MCP, and Agent-AI flows differ only in steps 1, 2, and 6 — the framing l
 
 Aegis-KMS distinguishes **operational logs** (for engineers) from **audit events** (for compliance and forensics). They have different retention, different consumers, and different write paths.
 
-```
-                                                    ┌─ stdout (JSON, slf4j) ──► loki / cloudwatch / datadog
-   any plane ──► HTTP / KMIP / MCP / Agent ──► logger ─┤
-                            │                          └─ stderr (errors)
-                            │
-                            ▼
-                       KeyService
-                            │
-                            │  on every state-changing event
-                            ▼
-                        audit sink
-                            │
-                            ├─► append-only Postgres table
-                            ├─► fan-out to S3 / object store
-                            └─► optional SIEM webhook
+```mermaid
+flowchart LR
+    classDef plane  fill:#1d3557,stroke:#1d3557,color:#fff
+    classDef ops    fill:#2a9d8f,stroke:#2a9d8f,color:#fff
+    classDef audit  fill:#e76f51,stroke:#e76f51,color:#fff
+
+    plane["Any plane<br/>(REST · KMIP · MCP · Agent-AI)"]:::plane --> logger[Logger<br/>slf4j + logback]:::ops
+    plane --> svc[KeyService op]
+    logger --> stdout[stdout JSON<br/>→ Loki / CloudWatch / Datadog]:::ops
+    logger --> stderr[stderr errors]:::ops
+    svc -. on every state-changing event .-> sink[Audit sink]:::audit
+    sink --> pg[(Postgres audit table 🚧)]:::audit
+    sink --> obj[(S3 / object store 🚧)]:::audit
+    sink --> siem[(SIEM webhook 🚧)]:::audit
+    sink --> sout[stdout JSON<br/>v0.1.x default]:::audit
 ```
 
 ### What gets logged vs audited
@@ -247,25 +289,26 @@ A single `request-id` joins log lines, audit events, and the client-side trace i
 
 ## 8. Operational topology
 
-```
-                       ┌──────────────────────────────┐
-                       │       Load Balancer (TLS)    │
-                       └───────┬──────────────┬───────┘
-                               │              │
-                       ┌───────▼─────┐ ┌──────▼───────┐
-                       │ aegis-server│ │ aegis-server │   N replicas, each runs:
-                       │   pod 1     │ │   pod 2      │     • HTTP (8080)
-                       └───────┬─────┘ └──────┬───────┘     • KMIP (5696, mTLS)
-                               │              │              • MCP   (8443, optional)
-                               └──────┬───────┘              • Agent-AI (8081, internal)
-                                      │
-                              ┌───────▼────────┐
-                              │  Postgres HA   │  ─── event journal + audit log
-                              └────────────────┘
-                                      │
-                              ┌───────▼────────┐
-                              │  Root of Trust │  ─── never accessed except through aegis-crypto
-                              └────────────────┘
+```mermaid
+flowchart TD
+    classDef edge   fill:#264653,stroke:#264653,color:#fff
+    classDef pod    fill:#1d3557,stroke:#1d3557,color:#fff
+    classDef ports  fill:#fff,stroke:#1d3557,color:#1d3557
+    classDef state  fill:#e76f51,stroke:#e76f51,color:#fff
+    classDef rot    fill:#e63946,stroke:#e63946,color:#fff
+
+    lb["Load Balancer<br/>(TLS termination)"]:::edge --> pod1
+    lb --> pod2
+
+    subgraph aegis_server_pods["aegis-server pods (N replicas)"]
+        pod1["aegis-server<br/>pod 1"]:::pod
+        pod2["aegis-server<br/>pod 2"]:::pod
+        ports["Each pod runs:<br/>• HTTP 8080 (+ /docs + /metrics)<br/>• KMIP 5696 mTLS 🚧<br/>• MCP 8443 optional 🚧<br/>• Agent-AI 8081 internal 🚧"]:::ports
+    end
+
+    pod1 --> pg[(Postgres HA<br/>event journal + audit log)]:::state
+    pod2 --> pg
+    pg   --> rot{{"Root of Trust<br/>AWS KMS adapter (v0.1.x)<br/>GCP · Azure · Vault · PKCS#11 🚧<br/><i>never touched outside aegis-crypto</i>"}}:::rot
 ```
 
 The `ActorSystem` is local to each pod; cross-pod consistency is achieved through the journal — two pods racing on the same `KeyId` conflict at the persistence layer, not via cluster sharding. This is deliberate: a single-pod-first deployment lets KMIP, MCP, and the SDKs ride alongside without waiting on cluster-mode work, and most production deployments run a small fixed pool of pods rather than autoscaling the KMS itself.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,11 +1,12 @@
 # Quickstart
 
-**Goal:** in ~5 minutes, get Aegis-KMS running on your machine and use it to sign + verify a
-message. Step 0 → Step 9, every command runnable, every output shown.
+**Goal:** in ~10 minutes, get Aegis-KMS running on your machine and exercise the full v0.1.x
+operation surface — sign / verify, encrypt / decrypt (with AAD), wrap / unwrap a DEK, rotate, and
+compromise — plus the three observability surfaces (Swagger UI, Prometheus, OpenTelemetry). Step
+0 → Step 14, every command runnable, every output shown.
 
-For a deeper hands-on tour covering every operation (encrypt, decrypt, wrap, unwrap, rotate,
-compromise, audit log, metrics, traces, CLI, JWT, AWS KMS), see the
-[full walkthrough](../USAGE.md) (~20 minutes).
+For a deeper tour covering CLI usage, JWT auth, and configuring AWS KMS as the Root of Trust, see
+the [full walkthrough](../USAGE.md) (~20 minutes).
 
 ---
 
@@ -254,7 +255,169 @@ That's the cryptographic guarantee working: even a one-byte change to the messag
 
 ---
 
-## Step 9 — Stop the server
+## Step 9 — Encrypt and decrypt with an encryption context
+
+`encrypt` takes an additional **encryption context** — a free-form `Map[String, String]` that's
+bound to the ciphertext as additional authenticated data (AAD). The same context must be supplied
+to `decrypt` or the call fails with `CryptographicFailure`. This is AWS KMS's `EncryptionContext`
+model — useful for tying a ciphertext to its tenant / dataset / purpose.
+
+```bash
+PT_B64=$(echo -n 'secret invoice payload' | base64)
+
+CIPHERTEXT=$(curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/encrypt" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"plaintextBase64\":\"$PT_B64\",\"context\":{\"dataset\":\"q2\",\"tenant\":\"acme\"}}" \
+  | jq -r '.ciphertextBase64')
+
+# Decrypt with the *same* context — succeeds
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/decrypt" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"ciphertextBase64\":\"$CIPHERTEXT\",\"context\":{\"dataset\":\"q2\",\"tenant\":\"acme\"}}" \
+  | jq -r '.plaintextBase64' | base64 -d
+# → secret invoice payload
+
+# Decrypt with a *different* context — fails (CryptographicFailure)
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/decrypt" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"ciphertextBase64\":\"$CIPHERTEXT\",\"context\":{\"dataset\":\"q3\"}}" \
+  | jq
+```
+
+The mismatched-context call returns:
+
+```json
+{ "error": "CryptographicFailure", "message": "encryption context mismatch" }
+```
+
+---
+
+## Step 10 — Wrap and unwrap a DEK (envelope encryption)
+
+For data too large for a single `encrypt` call (or for tools like `aws-encryption-sdk` that expect
+envelope-encrypted blobs), wrap a Data Encryption Key under the Aegis KEK:
+
+```bash
+DEK_B64=$(head -c 32 /dev/urandom | base64)   # a 256-bit DEK
+
+WRAPPED=$(curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/wrap" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"dekBase64\":\"$DEK_B64\"}" \
+  | jq -r '.wrappedDekBase64')
+
+# Unwrap to recover the original DEK — bytes-identical
+UNWRAPPED=$(curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/unwrap" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"wrappedDekBase64\":\"$WRAPPED\"}" \
+  | jq -r '.dekBase64')
+
+diff <(echo "$DEK_B64") <(echo "$UNWRAPPED") && echo "round-trip OK"
+```
+
+Use the unwrapped DEK locally with `openssl` / your AES library of choice; persist the *wrapped*
+form alongside your ciphertext. Rotating the KEK (Step 11) re-wraps without re-encrypting any of
+the payload data.
+
+---
+
+## Step 11 — Rotate the key
+
+Rotation increments the key's `currentVersion`. The dev backend produces deterministic-shape output
+keyed by `KeyId` only, so signatures + ciphertexts produced before the rotation continue to verify
+and decrypt — that's the contract the AWS KMS adapter preserves too:
+
+```bash
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/rotate" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d '{"policy":"Manual"}' \
+  | jq
+```
+
+Expected output:
+
+```json
+{
+  "id":             "8a3f1e25-...",
+  "state":          "Active",
+  "currentVersion": 2,
+  "rotatedAt":      "2026-05-09T01:30:12Z"
+}
+```
+
+Verify that the signature from Step 7 *still* validates against the rotated key:
+
+```bash
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/verify" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"messageBase64\":\"$MSG_B64\",\"signatureBase64\":\"$SIG\",\"algorithm\":\"RsaPssSha256\"}" \
+  | jq
+# → { "valid": true, "algorithm": "RsaPssSha256" }
+```
+
+Other policy shapes the server accepts: `TimeBased:7days`, `OpCountBased:10000`. v0.1.x records
+the policy on the audit row; the auto-scheduler that *drives* rotation from the policy lands in
+v0.2.0.
+
+---
+
+## Step 12 — Mark a key as compromised (operator override)
+
+This is the breakglass operation. From `Compromised` every cryptographic call — including
+`verify` — refuses with `IllegalOperation`. The audit row carries `severity=Critical` and the
+operator-supplied `reason`.
+
+```bash
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/compromise" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d '{"reason":"discovered in S3 audit leak 2026-05-08"}' \
+  | jq
+```
+
+Expected output:
+
+```json
+{
+  "id":            "8a3f1e25-...",
+  "state":         "Compromised",
+  "compromisedAt": "2026-05-09T01:31:00Z",
+  "reason":        "discovered in S3 audit leak 2026-05-08"
+}
+```
+
+Subsequent calls now refuse:
+
+```bash
+curl -s -X POST "$AEGIS/v1/keys/$KEY_ID/sign" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"messageBase64\":\"$MSG_B64\",\"algorithm\":\"RsaPssSha256\"}" \
+  | jq
+# → { "error": "IllegalOperation", "message": "Key 8a3f1e25-... is Compromised" }
+```
+
+Compromise is **one-way** — there's no `un-compromise` operation. Cut a fresh key with a new
+`create` + `activate`.
+
+---
+
+## Step 13 — Watch the observability surfaces
+
+While the server is running, every operation you've made is visible on three surfaces. Open each
+in a browser tab:
+
+| Surface | URL | What you see |
+|---|---|---|
+| **Swagger UI** | <http://localhost:8080/docs/> | Live OpenAPI 3.1 spec for every endpoint. "Try it out" lets you fire requests from the browser. |
+| **Prometheus metrics** | <http://localhost:8080/metrics> | `aegis_keys_op_total{operation="Sign"}`, latency histograms, error counters, plus the standard JVM / GC / process collectors. |
+| **OpenAPI YAML** | <http://localhost:8080/docs/docs.yaml> | The raw spec — feed it to Postman, Insomnia, or `openapi-generator`. |
+
+For full traces, point the OpenTelemetry SDK at any OTLP collector by setting env vars on the
+container (`OTEL_TRACES_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318`,
+`OTEL_SERVICE_NAME=aegis-server`). The full env-var matrix is in
+[Operations → Observability](../operations/observability.md).
+
+---
+
+## Step 14 — Stop the server
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml down
@@ -270,14 +433,17 @@ docker compose -f deploy/docker/docker-compose.yml down -v
 
 ## What you just did
 
-In ~5 minutes you:
+In ~10 minutes you:
 
 - Booted Aegis-KMS with a Postgres event journal
 - Created a key (in safe `PreActive` state by default)
 - Activated the key (explicit transition)
-- Signed a message with RSA-PSS-SHA-256
-- Verified the signature (and saw the tamper detection work)
-- Watched audit rows land on stdout in real time
+- Signed a message with RSA-PSS-SHA-256 + verified (and saw tamper detection work)
+- Encrypted with an `EncryptionContext` AAD + saw context-mismatch refusal
+- Wrapped + unwrapped a 256-bit DEK (envelope encryption)
+- Rotated the key and confirmed the prior signature still validates
+- Marked the key as `Compromised` and saw every subsequent crypto op refuse
+- Opened the Swagger UI, scraped `/metrics`, watched audit rows on stdout in real time
 
 Every operation was attributed to `alice` (the principal you passed via `X-Aegis-User`),
 recorded in the audit journal, exposed as a Prometheus metric on `/metrics`, and traced as

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,31 @@ GCP / Azure / Vault adapters in v0.2.0) and adds the four things role-centric KM
 
 </div>
 
+## How a request flows through Aegis
+
+Every operation — whether it arrives over REST, the CLI, or (eventually) MCP — passes through the same set of decorators around the `KeyService` algebra. Each layer does one thing and one thing only:
+
+```mermaid
+flowchart LR
+    classDef plane   fill:#1d3557,stroke:#1d3557,color:#fff
+    classDef ops     fill:#2a9d8f,stroke:#2a9d8f,color:#fff
+    classDef gate    fill:#f4a261,stroke:#f4a261,color:#000
+    classDef core    fill:#457b9d,stroke:#457b9d,color:#fff
+    classDef sink    fill:#e76f51,stroke:#e76f51,color:#fff
+
+    rest["REST · CLI · SDK"]:::plane --> audit["AuditingKeyService<br/><i>records every call</i>"]:::sink
+    audit --> traced["TracingKeyService<br/><i>OTel span per op</i>"]:::ops
+    traced --> metered["MeteredKeyService<br/><i>Prometheus counter + timer</i>"]:::ops
+    metered --> authz["AuthorizingKeyService<br/><i>policy gate</i>"]:::gate
+    authz --> actor["KeyOpsActor<br/><i>single-thread state owner</i>"]:::core
+    actor --> rot[("Root of Trust<br/>AWS KMS · GCP 🚧 · Azure 🚧")]:::sink
+    actor --> journal[(Postgres event journal)]:::sink
+```
+
+- **Audit is outermost** so denied calls + errors still produce a row.
+- **Auth is innermost** of the decorators so a deny short-circuits before any real work.
+- **Tracing + metrics** sit between them so dashboards see the work that actually happened, while the audit row reflects the post-trace outcome.
+
 ## Quickstart in 30 seconds
 
 ```bash


### PR DESCRIPTION
## Summary
Two reader-facing fixes for https://sharma-bhaskar.github.io/aegis-kms/, both flagged after the v0.1.1 release:

1. **Every architecture diagram is now Mermaid** (was ASCII). Mermaid was already wired in `mkdocs.yml` — the diagrams just hadn't been converted. Replaced all five: module layout, key lifecycle (state machine), request lifecycle, logs vs audit fan-out, operational topology. Same colour-coded visual language across the page.
2. **Quickstart now covers the full v0.1.x op surface** — added Steps 9–14 for encrypt/decrypt (with AAD context mismatch demo), wrap/unwrap (with round-trip diff), rotate (with proof the prior signature still validates), compromise (with proof subsequent ops refuse), and the three observability surfaces. Bumped the opening promise from "~5 min, sign + verify" to "~10 min, full surface".
3. **Landing page** gained a decorator-chain Mermaid between the feature cards and the quickstart, so first-time readers see the audit → tracing → metrics → auth → actor → journal flow at a glance.

Also fixed a pre-existing broken `#9-status` → `#11-status` anchor in ARCHITECTURE.md.

## Test plan
- [x] `mkdocs build --strict` clean — no warnings, all internal links resolve.
- [x] Every Mermaid block uses a syntax (`flowchart TD/LR`, `stateDiagram-v2`) that Material's bundled Mermaid renderer supports.
- [x] Quickstart curl commands tested against a freshly booted server using the existing `docker compose` flow from Step 2.
- [ ] GitHub Pages render — will be visible at https://sharma-bhaskar.github.io/aegis-kms/ after merge + workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)