### PR TITLE
feat(agent-ai): risk scorer with baseline + contextual factors (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ All notable changes to Aegis will be documented here. This project follows
 
 ## Unreleased
 
-_No entries yet — open the next PR with its `Added` / `Changed` / `Fixed` block._
+### Added
+
+- **Risk scorer with reasoning (closes #15).** New `RiskScorer[F[_]]` SPI in `aegis-core` returns a
+  numeric score in `[0.0, 1.0]` plus a list of `RiskFactor` evidence rows (name + weight +
+  human-readable evidence string) for every request. `BaselineRiskScorer` in `aegis-agent-ai`
+  combines the five baseline detectors (scope, rate-spike, op-histogram, time-of-day, source-IP)
+  with four contextual signals (`AgentPrincipal`, `CredentialAge` past 80 % of TTL, `BroadScope`
+  > 5 allowed ops, `DestructiveOp` for Rotate / Compromise / Destroy / Revoke). `AuditingKeyService`
+  takes an optional scorer constructor arg and stamps `risk.score` (two-decimal-place string) and
+  `risk.factors` (semicolon-separated `name:weight` list) into every `AuditRecord.context` — for
+  successful, denied, and failed calls alike, so post-incident review can answer "did the scoring
+  engine already know this was risky?". Wired into `Server.boot` against the same `BaselineDetector`
+  instance the tapped sink writes into. The decision adapter that *acts* on the score (allow /
+  step-up / deny) ships next as #16.
 
 ## 0.1.1 — 2026-05-09
 

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineRiskScorer.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineRiskScorer.scala
@@ -1,0 +1,183 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import dev.aegiskms.core.*
+
+import java.time.{Duration, ZoneOffset}
+import scala.concurrent.duration.FiniteDuration
+
+/** `RiskScorer` implementation that combines `BaselineDetector` signals with contextual signals from the
+  * `Principal`. This is the AI-governance Pillar 2 surface — every request gets a number + reasoning before
+  * the decision adapter (issue #16) consumes it.
+  *
+  * Two input sources:
+  *
+  *   1. **Baseline signals.** Read `BaselineDetector.snapshot()` to get the per-actor `ActorBaseline`, then
+  *      check the current request against it for each of the five baselines the detector tracks (scope, rate,
+  *      op-histogram, time-of-day, source-IP). A "fired" baseline contributes a factor with a fixed weight;
+  *      the actual `BaselineDetector.observe` (which writes the new request *into* the baseline) happens
+  *      separately when the audit row is built. 2. **Contextual signals.** Read the `Principal` shape: agents
+  *      are riskier than humans; long-lived credentials are riskier than fresh ones; broad scopes are riskier
+  *      than narrow ones; destructive operations are riskier than read-only ones.
+  *
+  * The weights in `Weights.Default` are tuned for the demo target — they produce risk scores between `0.0`
+  * (cold-start human Get) and ~`0.95` (agent doing a rotate on a new key at 3 AM from a new IP). They're a
+  * starting point, not a science: PR W4 will rebalance once we have real customer telemetry.
+  */
+final class BaselineRiskScorer(detector: BaselineDetector, weights: BaselineRiskScorer.Weights)
+    extends RiskScorer[IO]:
+
+  import BaselineRiskScorer.*
+
+  def score(request: RiskScorer.Request): IO[RiskScore] =
+    detector.snapshot.map { snap =>
+      val baseline     = snap.getOrElse(request.principal.subject, BaselineDetector.ActorBaseline.empty)
+      val baselineFs   = baselineFactors(request, baseline)
+      val contextualFs = contextualFactors(request)
+      RiskScore.fromFactors(baselineFs ++ contextualFs)
+    }.handleError { t =>
+      RiskScore(0.0, List(RiskFactor("ScorerError", 0.0, s"scorer error: ${t.getMessage}")))
+    }
+
+  // ── Baseline factors ──────────────────────────────────────────────────────
+
+  private def baselineFactors(
+      req: RiskScorer.Request,
+      baseline: BaselineDetector.ActorBaseline
+  ): List[RiskFactor] =
+    val fs = List.newBuilder[RiskFactor]
+
+    // Cold start: no baseline at all. Don't fire any baseline factors — contextual ones will still apply.
+    if baseline.firstSeen.isEmpty then return fs.result()
+
+    // ScopeBaseline: key not in the actor's seen set.
+    val resource = req.keyId.fold("")(id => s"key:${id.value}")
+    if resource.nonEmpty && baseline.keysSeen.nonEmpty && !baseline.keysSeen.contains(resource) then
+      fs += RiskFactor(
+        "ScopeBaseline",
+        weights.scope,
+        s"actor never touched $resource before (${baseline.keysSeen.size} prior keys)"
+      )
+
+    // OpHistogramBaseline: operation kind the actor has never performed.
+    if baseline.opsSeen.nonEmpty && !baseline.opsSeen.contains(req.operation) then
+      fs += RiskFactor(
+        "OpHistogramBaseline",
+        weights.opHistogram,
+        s"actor never performed ${req.operation} before (${baseline.opsSeen.size} prior op kinds)"
+      )
+
+    // TimeOfDayBaseline: hour-of-day outside the seen set.
+    val hour = req.at.atZone(ZoneOffset.UTC).getHour
+    if baseline.hoursSeen.nonEmpty && !baseline.hoursSeen.contains(hour) then
+      fs += RiskFactor(
+        "TimeOfDayBaseline",
+        weights.timeOfDay,
+        s"UTC hour $hour outside the actor's pattern (${baseline.hoursSeen.toSeq.sorted.mkString(",")})"
+      )
+
+    // SourceIpBaseline: source IP not in the seen set. Reads the same context key the detector reads.
+    req.context.get(BaselineDetector.SourceIpContextKey).foreach { ip =>
+      if baseline.sourceIpsSeen.nonEmpty && !baseline.sourceIpsSeen.contains(ip) then
+        fs += RiskFactor(
+          "SourceIpBaseline",
+          weights.sourceIp,
+          s"new source IP $ip (${baseline.sourceIpsSeen.size} prior)"
+        )
+    }
+
+    // RateSpike: scaled — the burst factor `recent / threshold` determines the weight (capped at the
+    // configured max). A 3× burst gets the full weight; smaller bursts are proportional.
+    val burstStart    = req.at.minus(Duration.ofSeconds(weights.rateBurstWindowSecs))
+    val recentInBurst = baseline.recentRequests.count(t => !t.isBefore(burstStart))
+    if recentInBurst >= weights.rateBurstThreshold then
+      val factor       = recentInBurst.toDouble / weights.rateBurstThreshold
+      val scaledWeight = math.min(weights.rateMax, weights.rateMax * (factor / 3.0))
+      fs += RiskFactor(
+        "RateSpike",
+        scaledWeight,
+        f"$recentInBurst requests in ${weights.rateBurstWindowSecs}s (factor=$factor%.2f)"
+      )
+
+    fs.result()
+
+  // ── Contextual factors ────────────────────────────────────────────────────
+
+  private def contextualFactors(req: RiskScorer.Request): List[RiskFactor] =
+    val fs = List.newBuilder[RiskFactor]
+
+    req.principal match
+      case agent: Principal.Agent =>
+        fs += RiskFactor(
+          "AgentPrincipal",
+          weights.agentKind,
+          s"actor is an Agent on behalf of ${agent.operator.subject} (humans default lower)"
+        )
+
+        // Credential age — if the agent's JWT is past 80% of its TTL, weight up. Older credentials are
+        // more likely to have leaked or been picked up by a compromised script.
+        val ageSecs = math.max(0L, java.time.Duration.between(agent.issuedAt, req.at).getSeconds)
+        val ttlSecs = agent.ttl match
+          case fd: FiniteDuration => fd.toSeconds
+          case _                  => 0L
+        if ttlSecs > 0 && ageSecs.toDouble / ttlSecs.toDouble >= 0.8 then
+          fs += RiskFactor(
+            "CredentialAge",
+            weights.credentialAge,
+            f"credential is ${ageSecs}s of ${ttlSecs}s TTL (${ageSecs.toDouble / ttlSecs * 100}%.0f%%)"
+          )
+
+        // Broad scope — agents with allowedOps covering more than the threshold are flagged.
+        if agent.allowedOps.size > weights.broadScopeOpThreshold then
+          fs += RiskFactor(
+            "BroadScope",
+            weights.broadScope,
+            s"agent has ${agent.allowedOps.size} allowed ops (threshold ${weights.broadScopeOpThreshold})"
+          )
+
+      case _ => () // Humans and Services: no agent-specific factors
+
+    // Destructive operations carry an extra weight regardless of principal kind.
+    if DestructiveOps.contains(req.operation) then
+      fs += RiskFactor(
+        "DestructiveOp",
+        weights.destructiveOp,
+        s"${req.operation} is destructive or irreversible"
+      )
+
+    fs.result()
+
+object BaselineRiskScorer:
+
+  /** Ops that move a key to a terminal or near-terminal state. A high score on these is the difference
+    * between "alert" and "block" — see #16's decision adapter.
+    */
+  private val DestructiveOps: Set[Operation] =
+    Set(Operation.Destroy, Operation.Compromise, Operation.Rotate, Operation.Revoke)
+
+  /** Weights tuned for the demo target. All values are starting points; v0.2.1 / W4 rebalance them with real
+    * telemetry. Documented per-factor so reviewers can see what's intentional vs accidental.
+    */
+  final case class Weights(
+      // Baseline factor weights — match the BaselineDetector's severity model.
+      scope: Double = 0.50,
+      opHistogram: Double = 0.30,
+      timeOfDay: Double = 0.20,
+      sourceIp: Double = 0.30,
+      rateMax: Double = 0.40,
+      rateBurstThreshold: Int = 30,
+      rateBurstWindowSecs: Long = 60L,
+
+      // Contextual factor weights.
+      agentKind: Double = 0.20,
+      credentialAge: Double = 0.10,
+      broadScope: Double = 0.10,
+      broadScopeOpThreshold: Int = 5,
+      destructiveOp: Double = 0.10
+  )
+
+  object Weights:
+    val Default: Weights = Weights()
+
+  def make(detector: BaselineDetector, weights: Weights = Weights.Default): BaselineRiskScorer =
+    new BaselineRiskScorer(detector, weights)

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineRiskScorerSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineRiskScorerSpec.scala
@@ -1,0 +1,268 @@
+package dev.aegiskms.agent
+
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.audit.AuditRecord
+import dev.aegiskms.core.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.duration.*
+
+/** Tests for `BaselineRiskScorer` — the W2 risk-scoring SPI.
+  *
+  * The two big properties exercised here:
+  *
+  *   1. Cold-start humans on a routine op produce `RiskScore.Zero`. We never want the demo to falsely alert
+  *      on the very first request from a brand-new actor. 2. The "Claude goes rogue" composite (agent + new
+  *      key + new hour + destructive op + old credential) produces a high score with reasoning the demo can
+  *      show.
+  */
+final class BaselineRiskScorerSpec extends AnyFunSuite with Matchers:
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def agent(issuedAt: Instant, ttl: scala.concurrent.duration.FiniteDuration = 1.hour) =
+    Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "invoice-signing",
+      issuedAt = issuedAt,
+      ttl = ttl,
+      allowedOps = Set(Operation.Get, Operation.Sign),
+      parent = None
+    )
+
+  private def rec(
+      at: Instant,
+      principal: Principal,
+      op: Operation,
+      key: String,
+      ctx: Map[String, String] = Map.empty
+  ) =
+    AuditRecord(
+      at = at,
+      principal = principal,
+      operation = op,
+      resource = s"key:$key",
+      outcome = "Success",
+      correlationId = java.util.UUID.randomUUID().toString,
+      context = ctx
+    )
+
+  // Establish a tiny baseline (one Get on `invoice-2026` from IP 10.0.0.1 at hour 10 UTC).
+  private def primeBaseline(det: BaselineDetector, p: Principal): Unit =
+    det.observe(rec(
+      at = Instant.parse("2026-04-25T10:00:00Z"),
+      principal = p,
+      op = Operation.Get,
+      key = "invoice-2026",
+      ctx = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+    )).unsafeRunSync()
+    ()
+
+  test("cold-start human on a routine op scores 0.0 with no factors") {
+    val det    = BaselineDetector.make().unsafeRunSync()
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = alice,
+      operation = Operation.Get,
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get),
+      at = Instant.parse("2026-04-25T10:00:00Z")
+    )
+    val score = scorer.score(req).unsafeRunSync()
+    score.value shouldBe 0.0
+    score.factors shouldBe empty
+  }
+
+  test("known human touching a NEW key fires ScopeBaseline") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    primeBaseline(det, alice)
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = alice,
+      operation = Operation.Get,
+      keyId = Some(KeyId.fromString("paystubs-2026").toOption.get), // not in baseline
+      at = Instant.parse("2026-04-25T10:05:00Z"),
+      context = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1") // same IP
+    )
+    val score = scorer.score(req).unsafeRunSync()
+    score.factors.map(_.name) should contain("ScopeBaseline")
+    score.value should be > 0.0
+  }
+
+  test("agent on a destructive op gets agent + destructive contextual factors") {
+    val det    = BaselineDetector.make().unsafeRunSync()
+    val ag     = agent(Instant.parse("2026-04-25T10:00:00Z"))
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = ag,
+      operation = Operation.Destroy,
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get),
+      at = Instant.parse("2026-04-25T10:05:00Z")
+    )
+    val score = scorer.score(req).unsafeRunSync()
+    val names = score.factors.map(_.name).toSet
+    names should contain allOf ("AgentPrincipal", "DestructiveOp")
+  }
+
+  test("agent past 80% of TTL fires CredentialAge") {
+    val det    = BaselineDetector.make().unsafeRunSync()
+    val ag     = agent(issuedAt = Instant.parse("2026-04-25T10:00:00Z"), ttl = 1.hour)
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = ag,
+      operation = Operation.Get,
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get),
+      at = Instant.parse("2026-04-25T10:55:00Z") // 91% of TTL elapsed
+    )
+    val score = scorer.score(req).unsafeRunSync()
+    score.factors.map(_.name) should contain("CredentialAge")
+  }
+
+  test("the demo composite (agent + new key + new IP + destructive + old credential) scores high") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(issuedAt = Instant.parse("2026-04-25T10:00:00Z"), ttl = 1.hour)
+    // Prime baseline: agent has done Get from 10.0.0.1 on invoice-2026 at hour 10.
+    det.observe(rec(
+      at = Instant.parse("2026-04-25T10:01:00Z"),
+      principal = ag,
+      op = Operation.Get,
+      key = "invoice-2026",
+      ctx = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+    )).unsafeRunSync()
+
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = ag,
+      operation = Operation.Rotate,                                 // destructive, never done
+      keyId = Some(KeyId.fromString("paystubs-2026").toOption.get), // not in baseline
+      at = Instant.parse("2026-04-25T10:55:00Z"),                   // past 80% TTL
+      context = Map(BaselineDetector.SourceIpContextKey -> "203.0.113.42") // new IP
+    )
+    val score = scorer.score(req).unsafeRunSync()
+    val names = score.factors.map(_.name).toSet
+    names should contain allOf (
+      "ScopeBaseline",
+      "OpHistogramBaseline",
+      "SourceIpBaseline",
+      "AgentPrincipal",
+      "CredentialAge",
+      "DestructiveOp"
+    )
+    score.value should be >= 0.7
+    score.value should be <= 1.0 // clamped
+  }
+
+  test("renderedScore is fixed to 2 decimal places") {
+    val s = RiskScore(0.6234567, Nil)
+    s.renderedScore shouldBe "0.62"
+  }
+
+  test("renderedFactors is a semicolon-separated name:weight list") {
+    val s = RiskScore(
+      0.5,
+      List(
+        RiskFactor("A", 0.3, "first"),
+        RiskFactor("B", 0.2, "second")
+      )
+    )
+    s.renderedFactors shouldBe "A:0.3;B:0.2"
+  }
+
+  test("RiskScore.fromFactors clamps to [0, 1]") {
+    val s = RiskScore.fromFactors(List(
+      RiskFactor("A", 0.7, ""),
+      RiskFactor("B", 0.6, "")
+    ))
+    s.value shouldBe 1.0
+  }
+
+  test("RateSpike fires when the actor exceeds the burst threshold inside the burst window") {
+    val det    = BaselineDetector.make().unsafeRunSync()
+    val baseTs = Instant.parse("2026-04-25T10:00:00Z")
+    // Prime: 30 Gets on the same key, IP, and hour — 1 per second through baseTs..baseTs+29s.
+    // This puts all 30 inside the default 60s burst window when we score at baseTs+30s.
+    (0 until 30).foreach { i =>
+      det.observe(rec(
+        at = baseTs.plusSeconds(i.toLong),
+        principal = alice,
+        op = Operation.Get,
+        key = "invoice-2026",
+        ctx = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+      )).unsafeRunSync()
+    }
+
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = alice,
+      operation = Operation.Get,                                   // not a new op
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get), // not a new key
+      at = baseTs.plusSeconds(30),                                 // hour 10, same baseline
+      context = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1") // same IP
+    )
+    val score = scorer.score(req).unsafeRunSync()
+
+    val rateFactor = score.factors.find(_.name == "RateSpike")
+    rateFactor shouldBe defined
+    rateFactor.get.weight should be > 0.0
+    rateFactor.get.weight should be <= 0.40 // capped at rateMax
+    // Only RateSpike should have fired — the other dimensions are unchanged.
+    score.factors.map(_.name).toSet shouldBe Set("RateSpike")
+  }
+
+  test("RateSpike at 3× burst saturates at rateMax (0.40 default)") {
+    val det    = BaselineDetector.make().unsafeRunSync()
+    val baseTs = Instant.parse("2026-04-25T10:00:00Z")
+    // 90 requests in 60s = 3× the default threshold of 30. Per the scorer formula
+    // `min(rateMax, rateMax * (factor/3.0))`, factor=3.0 → scaledWeight = rateMax = 0.40.
+    (0 until 90).foreach { i =>
+      det.observe(rec(
+        at = baseTs.plusMillis(i.toLong * 666), // ~666ms apart so all 90 fit in 60s
+        principal = alice,
+        op = Operation.Get,
+        key = "invoice-2026",
+        ctx = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+      )).unsafeRunSync()
+    }
+
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = alice,
+      operation = Operation.Get,
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get),
+      at = baseTs.plusSeconds(60),
+      context = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+    )
+    val score      = scorer.score(req).unsafeRunSync()
+    val rateFactor = score.factors.find(_.name == "RateSpike").get
+    rateFactor.weight shouldBe 0.40 +- 1e-9
+  }
+
+  test("TimeOfDayBaseline fires when actor is active in a UTC hour outside their seen set") {
+    val det = BaselineDetector.make().unsafeRunSync()
+    // Prime baseline: alice has only ever been active at UTC hour 10.
+    det.observe(rec(
+      at = Instant.parse("2026-04-25T10:00:00Z"),
+      principal = alice,
+      op = Operation.Get,
+      key = "invoice-2026",
+      ctx = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+    )).unsafeRunSync()
+
+    val scorer = BaselineRiskScorer.make(det)
+    val req = RiskScorer.Request(
+      principal = alice,
+      operation = Operation.Get,                                   // not a new op
+      keyId = Some(KeyId.fromString("invoice-2026").toOption.get), // not a new key
+      // Next day at 03:00 UTC — hour 3 is not in {10}. Same key & IP so only TimeOfDay fires.
+      at = Instant.parse("2026-04-26T03:00:00Z"),
+      context = Map(BaselineDetector.SourceIpContextKey -> "10.0.0.1")
+    )
+    val score = scorer.score(req).unsafeRunSync()
+
+    score.factors.map(_.name) should contain("TimeOfDayBaseline")
+    val todFactor = score.factors.find(_.name == "TimeOfDayBaseline").get
+    todFactor.weight shouldBe 0.20 +- 1e-9
+    todFactor.evidence should include("hour 3")
+  }

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -10,34 +10,42 @@ import java.util.UUID
   * Wraps any `KeyService[IO]` and writes a single `AuditRecord` per call — including failures, so the audit
   * log captures `AccessDenied` and `ItemNotFound` outcomes the operator needs for incident review.
   *
-  * Order of operations is **inner-then-audit**: the underlying service runs first, then the audit record is
-  * written. This means a slow audit sink can't delay the user response — but it also means a sink failure
-  * does not block the operation. Sinks that need crash-consistency (e.g. Postgres in the same transaction as
-  * the EventJournal) should run inside the actor's `appendOr` instead, not as a decorator like this one.
+  * Order of operations is **score → inner → audit**: the optional `RiskScorer` is consulted first (its result
+  * is stamped into the `AuditRecord.context` whether the inner call succeeds or fails), then the underlying
+  * service runs, then the audit record is written. The scorer is intentionally evaluated even for denied
+  * calls so post-incident review can answer "did the scoring engine already know this was risky?"
+  *
+  * A slow audit sink can't delay the user response — but it also means a sink failure does not block the
+  * operation. Sinks that need crash-consistency (e.g. Postgres in the same transaction as the EventJournal)
+  * should run inside the actor's `appendOr` instead, not as a decorator like this one.
   *
   * Correlation IDs are generated per call so a single client request can be joined across audit, journal, and
   * detector streams.
   */
-final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) extends KeyService[IO]:
+final class AuditingKeyService(
+    inner: KeyService[IO],
+    sink: AuditSink[IO],
+    scorer: Option[RiskScorer[IO]] = None
+) extends KeyService[IO]:
 
   def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Create, None) {
       inner.create(spec, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(k) => s"Success keyId=${k.id.value}"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Create, resourceForCreate(spec), outcome, corr)
+      AuditRecord(now, by, Operation.Create, resourceForCreate(spec), outcome, corr, ctx)
     }
 
   def get(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Get, Some(id)) {
       inner.get(id, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => "Success"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Get, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Get, id.value, outcome, corr, ctx)
     }
 
   def locate(namePattern: String, by: Principal): IO[List[ManagedKey]] =
@@ -45,38 +53,39 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
     for
       now  <- IO.realTimeInstant
       corr <- IO(freshCorrelationId())
+      ctx  <- scoreContext(by, Operation.Locate, None, now)
       list <- inner.locate(namePattern, by)
-      _    <- sink.write(AuditRecord(now, by, Operation.Locate, resource, s"Hits=${list.size}", corr))
+      _    <- sink.write(AuditRecord(now, by, Operation.Locate, resource, s"Hits=${list.size}", corr, ctx))
     yield list
 
   def activate(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Activate, Some(id)) {
       inner.activate(id, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => "Success"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Activate, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Activate, id.value, outcome, corr, ctx)
     }
 
   def revoke(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Revoke, Some(id)) {
       inner.revoke(id, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => "Success"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Revoke, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Revoke, id.value, outcome, corr, ctx)
     }
 
   def destroy(id: KeyId, by: Principal): IO[Either[KmsError, Unit]] =
-    instrument {
+    instrument(by, Operation.Destroy, Some(id)) {
       inner.destroy(id, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => "Success"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Destroy, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Destroy, id.value, outcome, corr, ctx)
     }
 
   def sign(
@@ -85,13 +94,13 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       alg: SigAlgorithm,
       by: Principal
   ): IO[Either[KmsError, Signature]] =
-    instrument {
+    instrument(by, Operation.Sign, Some(id)) {
       inner.sign(id, message, alg, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => s"Success alg=$alg msgLen=${message.length}"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Sign, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Sign, id.value, outcome, corr, ctx)
     }
 
   def verify(
@@ -100,14 +109,14 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       signature: Signature,
       by: Principal
   ): IO[Either[KmsError, Boolean]] =
-    instrument {
+    instrument(by, Operation.Verify, Some(id)) {
       inner.verify(id, message, signature, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(true)  => s"Success valid=true alg=${signature.algorithm}"
         case Right(false) => s"Success valid=false alg=${signature.algorithm}"
         case Left(e)      => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Verify, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Verify, id.value, outcome, corr, ctx)
     }
 
   def encrypt(
@@ -116,14 +125,14 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       context: Map[String, String],
       by: Principal
   ): IO[Either[KmsError, Ciphertext]] =
-    instrument {
+    instrument(by, Operation.Encrypt, Some(id)) {
       inner.encrypt(id, plaintext, context, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) =>
           s"Success ctxKeys=${context.keys.toSeq.sorted.mkString(",")} ptLen=${plaintext.length}"
         case Left(e) => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Encrypt, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Encrypt, id.value, outcome, corr, ctx)
     }
 
   def decrypt(
@@ -132,23 +141,23 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       context: Map[String, String],
       by: Principal
   ): IO[Either[KmsError, Array[Byte]]] =
-    instrument {
+    instrument(by, Operation.Decrypt, Some(id)) {
       inner.decrypt(id, ciphertext, context, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(pt) => s"Success ctxKeys=${context.keys.toSeq.sorted.mkString(",")} ptLen=${pt.length}"
         case Left(e)   => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Decrypt, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Decrypt, id.value, outcome, corr, ctx)
     }
 
   def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
-    instrument {
+    instrument(by, Operation.Wrap, Some(id)) {
       inner.wrap(id, dek, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => s"Success dekLen=${dek.length}"
         case Left(e)  => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Wrap, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Wrap, id.value, outcome, corr, ctx)
     }
 
   def unwrap(
@@ -156,54 +165,77 @@ final class AuditingKeyService(inner: KeyService[IO], sink: AuditSink[IO]) exten
       wrapped: WrappedDek,
       by: Principal
   ): IO[Either[KmsError, Array[Byte]]] =
-    instrument {
+    instrument(by, Operation.Unwrap, Some(id)) {
       inner.unwrap(id, wrapped, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(dek) => s"Success dekLen=${dek.length}"
         case Left(e)    => s"Failed code=${e.code}"
-      AuditRecord(now, by, Operation.Unwrap, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Unwrap, id.value, outcome, corr, ctx)
     }
 
   def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Compromise, Some(id)) {
       inner.compromise(id, reason, by)
-    } { (now, corr, result) =>
-      // Compromise is the highest-severity event in the system. Mark the audit row with the
-      // `severity=Critical` prefix so SIEM ingestion can route on it without re-deriving from
-      // the operation type alone.
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(_) => s"severity=Critical Success reason=$reason"
         case Left(e)  => s"severity=Critical Failed code=${e.code} reason=$reason"
-      AuditRecord(now, by, Operation.Compromise, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Compromise, id.value, outcome, corr, ctx)
     }
 
   def rotate(id: KeyId, policy: RotationPolicy, by: Principal): IO[Either[KmsError, ManagedKey]] =
-    instrument {
+    instrument(by, Operation.Rotate, Some(id)) {
       inner.rotate(id, policy, by)
-    } { (now, corr, result) =>
+    } { (now, corr, ctx, result) =>
       val outcome = result match
         case Right(k) => s"Success newVersion=${k.currentVersion} policy=${policy.render}"
         case Left(e)  => s"Failed code=${e.code} policy=${policy.render}"
-      AuditRecord(now, by, Operation.Rotate, id.value, outcome, corr)
+      AuditRecord(now, by, Operation.Rotate, id.value, outcome, corr, ctx)
     }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
-  /** Threads a fresh correlation id and a wall-clock timestamp through the action and writes the resulting
-    * `AuditRecord`. The caller closes over `op`, `by`, and `resource` directly when building the record —
-    * this helper deliberately doesn't take them, since duplicating that parameter list (helper + closure) was
-    * dead weight (and the compiler's `-Wunused` agreed).
+  /** Threads a fresh correlation id, a wall-clock timestamp, and a risk-scoring context map through the
+    * action and writes the resulting `AuditRecord`. The scoring call happens BEFORE the inner action so the
+    * same score lands on success and failure rows alike.
+    *
+    * The caller closes over `by`, the resource string, and op-specific outcome formatting when building the
+    * record. The helper deliberately doesn't take those — duplicating the parameter list (helper + closure)
+    * was dead weight (and `-Wunused` agreed).
     */
-  private def instrument[A](action: => IO[A])(
-      record: (java.time.Instant, String, A) => AuditRecord
+  private def instrument[A](
+      by: Principal,
+      op: Operation,
+      keyId: Option[KeyId]
+  )(action: => IO[A])(
+      record: (java.time.Instant, String, Map[String, String], A) => AuditRecord
   ): IO[A] =
     for
       corr   <- IO(freshCorrelationId())
+      now0   <- IO.realTimeInstant
+      ctx    <- scoreContext(by, op, keyId, now0)
       result <- action
       now    <- IO.realTimeInstant
-      _      <- sink.write(record(now, corr, result))
+      _      <- sink.write(record(now, corr, ctx, result))
     yield result
+
+  /** Call the optional `RiskScorer` and return a stamping map. `risk.score` is fixed to 2 decimal places
+    * (avoids `0.62000…01` floating-point noise in audit rows); `risk.factors` is a semicolon-separated
+    * `name:weight` list. Returns an empty map when no scorer is configured.
+    */
+  private def scoreContext(
+      by: Principal,
+      op: Operation,
+      keyId: Option[KeyId],
+      now: java.time.Instant
+  ): IO[Map[String, String]] =
+    scorer match
+      case None => IO.pure(Map.empty)
+      case Some(s) =>
+        s.score(RiskScorer.Request(by, op, keyId, now)).map { rs =>
+          Map("risk.score" -> rs.renderedScore, "risk.factors" -> rs.renderedFactors)
+        }
 
   private def resourceForCreate(spec: KeySpec): String =
     s"name:${spec.name}/alg:${spec.algorithm}/size:${spec.sizeBits}"

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -1,5 +1,6 @@
 package dev.aegiskms.audit
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import dev.aegiskms.core.*
 import org.scalatest.funsuite.AnyFunSuite
@@ -208,4 +209,62 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     rec.outcome should startWith("Failed")
     rec.outcome should include("IllegalOperation")
     rec.outcome should include("policy=Manual")
+  }
+
+  // ── RiskScorer integration ────────────────────────────────────────────────
+  //
+  // When the decorator is built with a `RiskScorer`, every audit record (success, denial, and failure
+  // alike) must carry `risk.score` + `risk.factors` in its `context` map. This is the load-bearing
+  // contract of the W2 wiring: the SIEM exporters and the upcoming decision adapter (#16) both depend
+  // on these keys being present.
+
+  /** Stub scorer that returns a fixed `RiskScore`. The method param is `req` (not `request`) to keep the line
+    * short; the value param is `s` (not `score`) to avoid clashing with the method name.
+    */
+  final private class FixedScorer(s: RiskScore) extends RiskScorer[IO]:
+    def score(req: RiskScorer.Request): IO[RiskScore] = IO.pure(s)
+
+  private def fixtureWithScorer(score: RiskScore): (AuditingKeyService, InMemoryAuditSink) =
+    val sink  = InMemoryAuditSink.make.unsafeRunSync()
+    val inner = KeyService.inMemory.unsafeRunSync()
+    val audit = AuditingKeyService(inner, sink, Some(new FixedScorer(score)))
+    (audit, sink)
+
+  test("scorer-decorated create stamps risk.score + risk.factors into the record context") {
+    val rs = RiskScore(
+      0.42,
+      List(RiskFactor("AgentPrincipal", 0.2, "agent"), RiskFactor("DestructiveOp", 0.1, "destroy"))
+    )
+    val (svc, sink) = fixtureWithScorer(rs)
+
+    svc.create(KeySpec.aes256("scored"), alice).unsafeRunSync()
+
+    val record = sink.all.unsafeRunSync().head
+    record.context.get("risk.score") shouldBe Some("0.42")
+    record.context.get("risk.factors") shouldBe Some("AgentPrincipal:0.2;DestructiveOp:0.1")
+  }
+
+  test("scorer is invoked on FAILED ops too — denied/notfound calls still carry risk context") {
+    val rs = RiskScore(
+      0.71,
+      List(RiskFactor("ScopeBaseline", 0.5, "new key"), RiskFactor("AgentPrincipal", 0.2, "agent"))
+    )
+    val (svc, sink) = fixtureWithScorer(rs)
+
+    // Get on a never-created key → KeyService returns ItemNotFound. The audit row is still written
+    // and must still carry the score.
+    svc.get(KeyId.generate(), alice).unsafeRunSync().isLeft shouldBe true
+
+    val record = sink.all.unsafeRunSync().head
+    record.outcome should startWith("Failed")
+    record.context("risk.score") shouldBe "0.71"
+    record.context("risk.factors") shouldBe "ScopeBaseline:0.5;AgentPrincipal:0.2"
+  }
+
+  test("no scorer configured (default arg) → context map stays empty (back-compat)") {
+    val (svc, sink) = fixture() // 2-arg constructor — no scorer
+    svc.create(KeySpec.aes256("unscored"), alice).unsafeRunSync()
+
+    val record = sink.all.unsafeRunSync().head
+    record.context shouldBe empty
   }

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/RiskScore.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/RiskScore.scala
@@ -1,0 +1,47 @@
+package dev.aegiskms.core
+
+/** A per-request risk score in `[0.0, 1.0]`, with structured reasoning.
+  *
+  * The numeric value is a single roll-up — useful for thresholding (e.g. `score >= 0.7 → deny`, `score >= 0.4
+  * → step-up`) and for dashboards. The `factors` list is the *evidence*: which inputs fired, what weight each
+  * contributed, and an evidence string a human operator can read after the fact.
+  *
+  * Recorded on the `AuditRecord.context` map as:
+  *
+  *   - `risk.score` → `"0.62"` (the value, fixed to 2 decimal places)
+  *   - `risk.factors` → `"ScopeBaseline:0.50;TimeOfDayBaseline:0.20"` (semicolon-separated `name:weight`
+  *     pairs)
+  *
+  * The wire/log format is a string because `AuditRecord.context` is a `Map[String, String]`. SIEM consumers
+  * parse the score string; dashboards render it directly.
+  */
+final case class RiskScore(value: Double, factors: List[RiskFactor]):
+  /** Compact wire representation of the factor list, suitable for an `AuditRecord.context` value. */
+  def renderedFactors: String = factors.map(f => s"${f.name}:${f.weight}").mkString(";")
+
+  /** Fixed-two-decimal-places rendering of the score. Avoids `0.6200000000000001` floating-point noise in
+    * audit rows.
+    */
+  def renderedScore: String = f"$value%.2f"
+
+object RiskScore:
+
+  /** The "no risk signals at all" score. Returned when an actor has no baseline and the request carries no
+    * elevated contextual signals. Useful as a starting point in reductions.
+    */
+  val Zero: RiskScore = RiskScore(0.0, Nil)
+
+  /** Build a score by summing factor weights and clamping to `[0.0, 1.0]`. The reduction lives on the
+    * companion so call sites can't accidentally produce a score outside the contract range.
+    */
+  def fromFactors(factors: List[RiskFactor]): RiskScore =
+    val raw     = factors.map(_.weight).sum
+    val clamped = math.max(0.0, math.min(1.0, raw))
+    RiskScore(clamped, factors)
+
+/** A single contributing factor to a risk score. `name` identifies the producer (e.g. `"ScopeBaseline"`,
+  * `"AgentPrincipal"`, `"BroadScope"`), `weight` is the per-factor contribution in `[0.0, 1.0]` (which the
+  * scorer sums + clamps), and `evidence` is a short human-readable string explaining *why* this factor fired
+  * — surfaced in audit rows and (eventually) in the `aegis advisor explain` CLI output.
+  */
+final case class RiskFactor(name: String, weight: Double, evidence: String)

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/RiskScorer.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/RiskScorer.scala
@@ -1,0 +1,37 @@
+package dev.aegiskms.core
+
+/** SPI: compute a per-request `RiskScore` from the request shape.
+  *
+  * Implementations live outside `aegis-core` because they need state (the `BaselineDetector` in
+  * `aegis-agent-ai`) or external signals (a future ML scorer, a future Bedrock-backed advisor). The trait
+  * itself stays here so the audit decorator can take it as a constructor argument without dragging Pekko or
+  * any specific backend into the library-safe tier.
+  *
+  * The scorer is called BEFORE the inner `KeyService` runs, on every request — including ones that will be
+  * denied by policy. That's deliberate: we want the audit row for the denied call to also carry its risk
+  * score, so post-incident review can answer "was this denied because policy already knew it was risky?"
+  *
+  * Contract:
+  *   - Pure I/O — the scorer must not mutate any state visible outside its own (BaselineDetector reads are
+  *     fine; writes happen separately after the request completes).
+  *   - Must always produce a value, even on missing baseline. Use `RiskScore.Zero` for a cold-start actor.
+  *   - Total — never throws. Internal failures collapse to `RiskScore.Zero` plus a `RiskFactor` with evidence
+  *     `"scorer error: <message>"` so the audit row records that scoring failed without crashing the request
+  *     path.
+  */
+trait RiskScorer[F[_]]:
+  def score(request: RiskScorer.Request): F[RiskScore]
+
+object RiskScorer:
+
+  /** Everything a scorer needs about the current request. Constructed by the audit decorator from the
+    * `KeyService` method arguments — same shape regardless of which op (sign / encrypt / rotate / …) the
+    * caller invoked. The scorer reads the fields it cares about; future scorers can ignore the rest.
+    */
+  final case class Request(
+      principal: Principal,
+      operation: Operation,
+      keyId: Option[KeyId],
+      at: java.time.Instant,
+      context: Map[String, String] = Map.empty
+  )

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -4,7 +4,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, IOApp, Resource}
 import cats.syntax.all.*
 import com.typesafe.config.{Config, ConfigFactory}
-import dev.aegiskms.agent.{BaselineDetector, InMemoryRecommendationSink, TappedAuditSink}
+import dev.aegiskms.agent.{BaselineDetector, BaselineRiskScorer, InMemoryRecommendationSink, TappedAuditSink}
 import dev.aegiskms.audit.{AuditingKeyService, StdoutAuditSink}
 import dev.aegiskms.http.HttpRoutes
 import dev.aegiskms.iam.{AuthorizingKeyService, JwtVerifier, PrincipalResolver}
@@ -108,8 +108,12 @@ object Server extends IOApp.Simple:
       traced      = new TracingKeyService(metered, tracer)
       recSink  <- Resource.eval(InMemoryRecommendationSink.make)
       detector <- Resource.eval(BaselineDetector.make())
-      sink     = TappedAuditSink(StdoutAuditSink(), detector, recSink)
-      auditing = new AuditingKeyService(traced, sink)
+      sink = TappedAuditSink(StdoutAuditSink(), detector, recSink)
+      // Risk scorer (#15 / W2): reads the same baseline state the tapped sink writes into. Audit-only
+      // for now — every record gets `risk.score` + `risk.factors` stamped. The decision adapter (#16)
+      // will consume the same scorer to allow / step-up / deny BEFORE the inner op runs.
+      riskScorer = BaselineRiskScorer.make(detector)
+      auditing   = new AuditingKeyService(traced, sink, Some(riskScorer))
 
       resolver = buildResolver(rootConfig)
       _ <- Resource.eval(IO {


### PR DESCRIPTION
## Summary
- New `RiskScorer[F[_]]` SPI in `aegis-core` (no Pekko, library-safe tier).
- `BaselineRiskScorer` in `aegis-agent-ai` combines 5 baseline + 4 contextual factors, sums + clamps to `[0.0, 1.0]`.
- `AuditingKeyService` stamps `risk.score` + `risk.factors` into every `AuditRecord.context` (success, deny, fail).
- Wired at `Server.boot` against the same `BaselineDetector` the tapped sink writes into.

Closes #15. Decision adapter (#16) consumes the score next.

## Test plan
- [x] `sbt test` — 269 tests pass, 0 failures (3 Docker-gated suites correctly canceled)
- [x] `sbt agentAi/test` — 25 tests including 11 new for the scorer (RateSpike isolated + at 3× saturation, TimeOfDay isolated, cold-start, composite ≥ 0.7, rendering, clamping)
- [x] `sbt audit/test` — 17 tests including 3 new asserting the audit record carries `risk.score` / `risk.factors` on success AND failure, plus the no-scorer back-compat path
- [x] `sbt scalafmtAll` — formatted
- [ ] Manual: bring up server, hit `/v1/keys`, confirm stdout audit row carries `risk.score=…` / `risk.factors=…`