### PR TITLE
feat(agent-ai): decision adapter — allow / step-up / deny (closes #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,26 @@ All notable changes to Aegis will be documented here. This project follows
   `risk.factors` (semicolon-separated `name:weight` list) into every `AuditRecord.context` — for
   successful, denied, and failed calls alike, so post-incident review can answer "did the scoring
   engine already know this was risky?". Wired into `Server.boot` against the same `BaselineDetector`
-  instance the tapped sink writes into. The decision adapter that *acts* on the score (allow /
-  step-up / deny) ships next as #16.
+  instance the tapped sink writes into. The decision adapter that *acts* on the score is #16 below.
+
+- **Decision adapter — risk score becomes a verdict (closes #16).** New `Decision` enum in `aegis-core`
+  (`Allow` / `Deny(reason)` / `StepUpRequired(reason)`) consolidated with `aegis-iam`'s pre-existing
+  policy-decision type so the boolean policy gate and the risk overlay now speak the same vocabulary.
+  New `DecisionEngine[F[_]]` SPI translates a `(RiskScore, Principal, Operation)` triple into a
+  `Decision`. `ThresholdDecisionEngine` in `aegis-agent-ai` ships the default two-threshold
+  implementation (`denyAt=0.85`, `stepUpAt=0.60`) with a per-op irreversibility tax —
+  destructive ops (`Rotate`, `Compromise`, `Destroy`, `Revoke`) drop both thresholds by 0.15.
+  `AuditingKeyService` gained an optional `engine: Option[DecisionEngine[IO]]` arg and now
+  short-circuits the inner `KeyService` on `Deny` (returns `Left(KmsError(PermissionDenied, "risk: …"))`)
+  and `StepUpRequired` (returns the new `Left(KmsError(StepUpRequired, reason))`). Every audit row
+  stamps `outcome.decision` (`Allow` / `StepUp` / `Deny`) plus an `outcome.decision.reason` when the
+  decision was non-`Allow`. New `ErrorCode.StepUpRequired` is an Aegis-specific extension (KMIP has no
+  equivalent — the wire codec maps it to `OperationCanceledByRequester`); the HTTP layer translates it
+  to `401 Unauthorized` with the reason in the JSON body. `locate` is intentionally never gated by
+  the engine — filtering directory results would leak existence-or-not signal and isn't a useful
+  security primitive; the policy gate handles discovery authorization separately. Wired into
+  `Server.boot` with default thresholds; HOCON-configurable thresholds and a dedicated
+  `WWW-Authenticate: aegis-stepup` response header land in follow-ups.
 
 ## 0.1.1 — 2026-05-09
 

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/ThresholdDecisionEngine.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/ThresholdDecisionEngine.scala
@@ -1,0 +1,86 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import dev.aegiskms.core.*
+
+/** Simple two-threshold decision engine.
+  *
+  *   - `score >= denyAt` → `Decision.Deny`
+  *   - `score >= stepUpAt` → `Decision.StepUpRequired`
+  *   - else → `Decision.Allow`
+  *
+  * Plus destructive-op overrides: for `Compromise` / `Destroy` / `Rotate` / `Revoke` the thresholds are
+  * lowered by `destructiveOpOffset` (default 0.15). This means a moderate-risk request to destroy a key gets
+  * stepped up where the same risk on a `Get` would have passed — losing data is far less reversible than
+  * reading it.
+  *
+  * Default thresholds are tuned for the demo target:
+  *
+  *   - `denyAt = 0.85` — only a composite alert (multiple factors) trips an outright deny
+  *   - `stepUpAt = 0.60` — a single high-weight factor (new scope, new source IP) trips step-up
+  *
+  * The decision rationale is bundled into the `reason` string of `StepUp` / `Deny`, drawing on the
+  * `RiskScore.renderedFactors` for evidence. Example reason: `"score=0.71 threshold=0.60
+  * factors=ScopeBaseline:0.5;AgentPrincipal:0.2"`. This string lands in the audit row
+  * (`outcome.decision.reason`) and in the HTTP error payload, so operators can answer "why was this blocked?"
+  * without re-running the scorer.
+  */
+final class ThresholdDecisionEngine(thresholds: ThresholdDecisionEngine.Thresholds)
+    extends DecisionEngine[IO]:
+
+  import ThresholdDecisionEngine.*
+
+  def decide(score: RiskScore, principal: Principal, operation: Operation): IO[Decision] =
+    IO.pure(decideSync(score, operation))
+
+  private def decideSync(score: RiskScore, operation: Operation): Decision =
+    val (denyAt, stepUpAt) = effectiveThresholds(operation)
+    if score.value >= denyAt then
+      Decision.Deny(formatReason("score", score, denyAt))
+    else if score.value >= stepUpAt then
+      Decision.StepUpRequired(formatReason("score", score, stepUpAt))
+    else Decision.Allow
+
+  private def effectiveThresholds(op: Operation): (Double, Double) =
+    if DestructiveOps.contains(op) then
+      // Clamp to [0.0, 1.0] in case operator config sets odd values.
+      val deny   = math.max(0.0, thresholds.denyAt - thresholds.destructiveOpOffset)
+      val stepUp = math.max(0.0, thresholds.stepUpAt - thresholds.destructiveOpOffset)
+      (deny, stepUp)
+    else (thresholds.denyAt, thresholds.stepUpAt)
+
+  private def formatReason(label: String, score: RiskScore, threshold: Double): String =
+    val factors = if score.factors.isEmpty then "(none)" else score.renderedFactors
+    f"$label=${score.value}%.2f threshold=$threshold%.2f factors=$factors"
+
+object ThresholdDecisionEngine:
+
+  /** Ops where the cost of a wrongful allow is irreversible — see `BaselineRiskScorer.DestructiveOps` for the
+    * matching list used in scoring. The two lists are kept in sync deliberately: a destructive op is both
+    * *scored* higher (the scorer's `DestructiveOp` contextual factor) and *gated* harder (this engine's lower
+    * thresholds).
+    */
+  private val DestructiveOps: Set[Operation] =
+    Set(Operation.Destroy, Operation.Compromise, Operation.Rotate, Operation.Revoke)
+
+  /** Tunable thresholds. Defaults are calibrated against `BaselineRiskScorer.Weights.Default`:
+    *
+    *   - A single firing baseline factor (e.g. ScopeBaseline at 0.5) → Allow.
+    *   - Two factors (e.g. ScopeBaseline + AgentPrincipal = 0.7) → StepUp.
+    *   - Three+ factors (e.g. the demo composite at ~0.85+) → Deny.
+    *
+    * Operator-tuned thresholds will land via HOCON in a later PR.
+    */
+  final case class Thresholds(
+      denyAt: Double = 0.85,
+      stepUpAt: Double = 0.60,
+      destructiveOpOffset: Double = 0.15
+  ):
+    require(denyAt >= stepUpAt, s"denyAt ($denyAt) must be >= stepUpAt ($stepUpAt)")
+    require(destructiveOpOffset >= 0.0, s"destructiveOpOffset must be >= 0 (was $destructiveOpOffset)")
+
+  object Thresholds:
+    val Default: Thresholds = Thresholds()
+
+  def make(thresholds: Thresholds = Thresholds.Default): ThresholdDecisionEngine =
+    new ThresholdDecisionEngine(thresholds)

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/ThresholdDecisionEngineSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/ThresholdDecisionEngineSpec.scala
@@ -1,0 +1,87 @@
+package dev.aegiskms.agent
+
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.core.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Tests for `ThresholdDecisionEngine` — the W2.b risk decision adapter.
+  *
+  * The properties exercised here pin the wedge demo's blast radius: a low score on a routine op must Allow
+  * (no false positives); a composite high-risk score must Deny (no missed alerts); destructive ops step up
+  * earlier than read-only ones (irreversibility tax).
+  */
+final class ThresholdDecisionEngineSpec extends AnyFunSuite with Matchers:
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def factor(name: String, weight: Double): RiskFactor =
+    RiskFactor(name, weight, s"$name fired")
+
+  private val engine = ThresholdDecisionEngine.make()
+
+  test("Allow when score is below stepUpAt (default 0.60)") {
+    val score = RiskScore(0.30, List(factor("AgentPrincipal", 0.20), factor("DestructiveOp", 0.10)))
+    val d     = engine.decide(score, alice, Operation.Get).unsafeRunSync()
+    d shouldBe Decision.Allow
+  }
+
+  test("StepUp when score is between stepUpAt and denyAt (default [0.60, 0.85))") {
+    val score = RiskScore(0.70, List(factor("ScopeBaseline", 0.50), factor("AgentPrincipal", 0.20)))
+    val d     = engine.decide(score, alice, Operation.Get).unsafeRunSync()
+    d shouldBe a[Decision.StepUpRequired]
+    d.asInstanceOf[Decision.StepUpRequired].reason should include("threshold=0.60")
+    d.asInstanceOf[Decision.StepUpRequired].reason should include("ScopeBaseline:0.5")
+  }
+
+  test("Deny when score is at or above denyAt (default 0.85)") {
+    val score = RiskScore(0.90, List(factor("ScopeBaseline", 0.50), factor("RateSpike", 0.40)))
+    val d     = engine.decide(score, alice, Operation.Get).unsafeRunSync()
+    d shouldBe a[Decision.Deny]
+    d.asInstanceOf[Decision.Deny].reason should include("threshold=0.85")
+  }
+
+  test("destructive ops trip step-up earlier than read-only ones") {
+    // Score 0.50 is below the default stepUpAt of 0.60 — for Get it Allows.
+    val score = RiskScore(0.50, List(factor("AgentPrincipal", 0.20), factor("ScopeBaseline", 0.30)))
+    engine.decide(score, alice, Operation.Get).unsafeRunSync() shouldBe Decision.Allow
+    // But for Destroy (a DestructiveOp) the threshold drops by 0.15 → effective stepUpAt = 0.45.
+    val onDestroy = engine.decide(score, alice, Operation.Destroy).unsafeRunSync()
+    onDestroy shouldBe a[Decision.StepUpRequired]
+  }
+
+  test("destructive ops trip deny earlier than read-only ones") {
+    // Score 0.72 is below denyAt 0.85 for Get (StepUp), but above the destructive-adjusted denyAt of 0.70.
+    val score = RiskScore(0.72, List(factor("ScopeBaseline", 0.50), factor("RateSpike", 0.22)))
+    engine.decide(score, alice, Operation.Get).unsafeRunSync() shouldBe a[Decision.StepUpRequired]
+    engine.decide(score, alice, Operation.Rotate).unsafeRunSync() shouldBe a[Decision.Deny]
+  }
+
+  test("Thresholds requires denyAt >= stepUpAt") {
+    an[IllegalArgumentException] should be thrownBy
+      ThresholdDecisionEngine.Thresholds(denyAt = 0.3, stepUpAt = 0.5)
+  }
+
+  test("Thresholds requires non-negative destructiveOpOffset") {
+    an[IllegalArgumentException] should be thrownBy
+      ThresholdDecisionEngine.Thresholds(destructiveOpOffset = -0.1)
+  }
+
+  test("reason string carries the rendered factor list for operator readability") {
+    val score = RiskScore(
+      0.70,
+      List(factor("ScopeBaseline", 0.50), factor("AgentPrincipal", 0.20))
+    )
+    val d = engine.decide(score, alice, Operation.Get).unsafeRunSync()
+    d.asInstanceOf[Decision.StepUpRequired].reason should include(
+      "factors=ScopeBaseline:0.5;AgentPrincipal:0.2"
+    )
+  }
+
+  test("custom thresholds override defaults") {
+    val strict = ThresholdDecisionEngine.make(
+      ThresholdDecisionEngine.Thresholds(denyAt = 0.50, stepUpAt = 0.20, destructiveOpOffset = 0.0)
+    )
+    val score = RiskScore(0.30, List(factor("AgentPrincipal", 0.20), factor("BroadScope", 0.10)))
+    strict.decide(score, alice, Operation.Get).unsafeRunSync() shouldBe a[Decision.StepUpRequired]
+  }

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -5,19 +5,33 @@ import dev.aegiskms.core.*
 
 import java.util.UUID
 
-/** Decorator that records every `KeyService` call to an `AuditSink`.
+/** Decorator that records every `KeyService` call to an `AuditSink`, with optional risk-based gating.
   *
   * Wraps any `KeyService[IO]` and writes a single `AuditRecord` per call — including failures, so the audit
-  * log captures `AccessDenied` and `ItemNotFound` outcomes the operator needs for incident review.
+  * log captures `AccessDenied`, `StepUpRequired`, and `ItemNotFound` outcomes the operator needs for incident
+  * review.
   *
-  * Order of operations is **score → inner → audit**: the optional `RiskScorer` is consulted first (its result
-  * is stamped into the `AuditRecord.context` whether the inner call succeeds or fails), then the underlying
-  * service runs, then the audit record is written. The scorer is intentionally evaluated even for denied
-  * calls so post-incident review can answer "did the scoring engine already know this was risky?"
+  * Two optional dependencies thread risk-awareness through this decorator:
   *
-  * A slow audit sink can't delay the user response — but it also means a sink failure does not block the
-  * operation. Sinks that need crash-consistency (e.g. Postgres in the same transaction as the EventJournal)
-  * should run inside the actor's `appendOr` instead, not as a decorator like this one.
+  *   - `scorer` — a `RiskScorer[IO]` (typically `BaselineRiskScorer` from `aegis-agent-ai`). If present,
+  *     every request is scored BEFORE the inner action runs, and the `risk.score` + `risk.factors` are
+  *     stamped into the audit row's `context` regardless of outcome.
+  *   - `engine` — a `DecisionEngine[IO]` (typically `ThresholdDecisionEngine`). If present, the score is
+  *     translated into a `Decision`. `Decision.Deny` short-circuits with a synthetic
+  *     `KmsError(PermissionDenied, "risk: …")`; `Decision.StepUp` short-circuits with a synthetic
+  *     `KmsError(StepUpRequired, …)` that the HTTP layer maps to `401 + WWW-Authenticate: aegis-stepup`.
+  *     `Decision.Allow` (or no engine configured) lets the request through to the inner service. The decision
+  *     label and reason land in audit context as `outcome.decision` / `outcome.decision.reason`.
+  *
+  * The boolean policy gate (`AuthorizingKeyService`) remains the floor — a policy denial cannot be overridden
+  * by `Decision.Allow`. The decision adapter is purely additive: it can further restrict an action policy
+  * already permits; it cannot widen one policy forbids.
+  *
+  * Order of operations is **score → decide → (short-circuit | inner) → audit**: the scorer + engine are
+  * consulted first (their outputs always land in the audit row), then either we short-circuit or run the
+  * underlying service, then the audit record is written. A slow audit sink can't delay the user response, but
+  * also can't block the operation — sinks needing crash-consistency belong inside the actor's `appendOr`
+  * instead.
   *
   * Correlation IDs are generated per call so a single client request can be joined across audit, journal, and
   * detector streams.
@@ -25,7 +39,8 @@ import java.util.UUID
 final class AuditingKeyService(
     inner: KeyService[IO],
     sink: AuditSink[IO],
-    scorer: Option[RiskScorer[IO]] = None
+    scorer: Option[RiskScorer[IO]] = None,
+    engine: Option[DecisionEngine[IO]] = None
 ) extends KeyService[IO]:
 
   def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
@@ -49,13 +64,20 @@ final class AuditingKeyService(
     }
 
   def locate(namePattern: String, by: Principal): IO[List[ManagedKey]] =
+    // Locate is read-only directory access; we score for visibility but never gate (the engine isn't
+    // consulted). Returning a filtered/empty result on Deny would leak existence-or-not signal to the
+    // caller and isn't useful as a security primitive — the policy gate handles authorization for
+    // discovery separately.
     val resource = s"pattern:$namePattern"
     for
-      now  <- IO.realTimeInstant
-      corr <- IO(freshCorrelationId())
-      ctx  <- scoreContext(by, Operation.Locate, None, now)
+      corr  <- IO(freshCorrelationId())
+      now   <- IO.realTimeInstant
+      score <- scoreOpt(by, Operation.Locate, None, now)
+      ctx = preflightContext(score, None)
       list <- inner.locate(namePattern, by)
-      _    <- sink.write(AuditRecord(now, by, Operation.Locate, resource, s"Hits=${list.size}", corr, ctx))
+      _ <- sink.write(
+        AuditRecord(now, by, Operation.Locate, resource, s"Hits=${list.size}", corr, ctx)
+      )
     yield list
 
   def activate(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
@@ -196,46 +218,85 @@ final class AuditingKeyService(
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
-  /** Threads a fresh correlation id, a wall-clock timestamp, and a risk-scoring context map through the
-    * action and writes the resulting `AuditRecord`. The scoring call happens BEFORE the inner action so the
-    * same score lands on success and failure rows alike.
-    *
-    * The caller closes over `by`, the resource string, and op-specific outcome formatting when building the
-    * record. The helper deliberately doesn't take those — duplicating the parameter list (helper + closure)
-    * was dead weight (and `-Wunused` agreed).
+  /** Threads a fresh correlation id, a wall-clock timestamp, and the preflight (score + decision) context
+    * through the action and writes the resulting `AuditRecord`. Specialized to `Either[KmsError, A]`-typed
+    * actions so it can synthesize a `Left` when the decision engine short-circuits the request.
     */
   private def instrument[A](
       by: Principal,
       op: Operation,
       keyId: Option[KeyId]
-  )(action: => IO[A])(
-      record: (java.time.Instant, String, Map[String, String], A) => AuditRecord
-  ): IO[A] =
+  )(action: => IO[Either[KmsError, A]])(
+      record: (java.time.Instant, String, Map[String, String], Either[KmsError, A]) => AuditRecord
+  ): IO[Either[KmsError, A]] =
     for
-      corr   <- IO(freshCorrelationId())
-      now0   <- IO.realTimeInstant
-      ctx    <- scoreContext(by, op, keyId, now0)
-      result <- action
+      corr     <- IO(freshCorrelationId())
+      now0     <- IO.realTimeInstant
+      score    <- scoreOpt(by, op, keyId, now0)
+      decision <- decideOpt(score, by, op)
+      ctx = preflightContext(score, decision)
+      result <- shortCircuitOr(decision, action)
       now    <- IO.realTimeInstant
       _      <- sink.write(record(now, corr, ctx, result))
     yield result
 
-  /** Call the optional `RiskScorer` and return a stamping map. `risk.score` is fixed to 2 decimal places
-    * (avoids `0.62000…01` floating-point noise in audit rows); `risk.factors` is a semicolon-separated
-    * `name:weight` list. Returns an empty map when no scorer is configured.
-    */
-  private def scoreContext(
+  /** Run the inner action unless the decision short-circuits the request. */
+  private def shortCircuitOr[A](
+      decision: Option[Decision],
+      action: => IO[Either[KmsError, A]]
+  ): IO[Either[KmsError, A]] =
+    decision match
+      case Some(Decision.Deny(reason)) =>
+        IO.pure(Left(KmsError(ErrorCode.PermissionDenied, s"risk: $reason")))
+      case Some(Decision.StepUpRequired(reason)) =>
+        IO.pure(Left(KmsError(ErrorCode.StepUpRequired, reason)))
+      case _ => action
+
+  /** Call the optional `RiskScorer` and return its score (or `None` if no scorer is configured). */
+  private def scoreOpt(
       by: Principal,
       op: Operation,
       keyId: Option[KeyId],
       now: java.time.Instant
-  ): IO[Map[String, String]] =
+  ): IO[Option[RiskScore]] =
     scorer match
-      case None => IO.pure(Map.empty)
-      case Some(s) =>
-        s.score(RiskScorer.Request(by, op, keyId, now)).map { rs =>
-          Map("risk.score" -> rs.renderedScore, "risk.factors" -> rs.renderedFactors)
-        }
+      case None    => IO.pure(None)
+      case Some(s) => s.score(RiskScorer.Request(by, op, keyId, now)).map(Some(_))
+
+  /** Call the optional `DecisionEngine` against the score (skipped when either is missing). */
+  private def decideOpt(
+      score: Option[RiskScore],
+      by: Principal,
+      op: Operation
+  ): IO[Option[Decision]] =
+    (score, engine) match
+      case (Some(s), Some(e)) => e.decide(s, by, op).map(Some(_))
+      case _                  => IO.pure(None)
+
+  /** Build the `AuditRecord.context` fragment from the score + decision. Stamps:
+    *
+    *   - `risk.score` — present iff scorer was configured
+    *   - `risk.factors` — present iff scorer was configured
+    *   - `outcome.decision` — present iff engine was configured ("Allow" / "StepUp" / "Deny")
+    *   - `outcome.decision.reason` — present iff engine was configured AND decision != Allow
+    */
+  private def preflightContext(
+      score: Option[RiskScore],
+      decision: Option[Decision]
+  ): Map[String, String] =
+    val builder = Map.newBuilder[String, String]
+    score.foreach { rs =>
+      builder += ("risk.score"   -> rs.renderedScore)
+      builder += ("risk.factors" -> rs.renderedFactors)
+    }
+    decision.foreach { d =>
+      import Decision.label
+      import Decision.reasonOrEmpty
+      builder += ("outcome.decision"                                -> d.label)
+      val reason                                = d.reasonOrEmpty
+      if reason.nonEmpty then builder += ("outcome.decision.reason" -> reason)
+    }
+    builder.result()
 
   private def resourceForCreate(spec: KeySpec): String =
     s"name:${spec.name}/alg:${spec.algorithm}/size:${spec.sizeBits}"

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -268,3 +268,123 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     val record = sink.all.unsafeRunSync().head
     record.context shouldBe empty
   }
+
+  // ── DecisionEngine integration (#16) ──────────────────────────────────────
+  //
+  // The decision engine is an additive risk overlay: scoring still happens (the audit row still carries
+  // `risk.score`), the engine translates that score into Allow / StepUp / Deny, and the decorator
+  // short-circuits the inner call on Deny/StepUp without losing the audit row.
+
+  final private class FixedEngine(d: Decision) extends DecisionEngine[IO]:
+    def decide(score: RiskScore, principal: Principal, operation: Operation): IO[Decision] = IO.pure(d)
+
+  private def fixtureWithEngine(
+      score: RiskScore,
+      decision: Decision
+  ): (AuditingKeyService, InMemoryAuditSink, KeyService[IO]) =
+    val sink  = InMemoryAuditSink.make.unsafeRunSync()
+    val inner = KeyService.inMemory.unsafeRunSync()
+    val audit = AuditingKeyService(
+      inner,
+      sink,
+      Some(new FixedScorer(score)),
+      Some(new FixedEngine(decision))
+    )
+    (audit, sink, inner)
+
+  test("Decision.Allow → inner runs; audit row stamps outcome.decision=Allow (no reason key)") {
+    val (svc, sink, _) = fixtureWithEngine(
+      RiskScore(0.1, List(RiskFactor("AgentPrincipal", 0.1, "low"))),
+      Decision.Allow
+    )
+    val res = svc.create(KeySpec.aes256("allowed"), alice).unsafeRunSync()
+    res.isRight shouldBe true
+
+    val record = sink.all.unsafeRunSync().head
+    record.context("outcome.decision") shouldBe "Allow"
+    record.context.contains("outcome.decision.reason") shouldBe false
+    record.context("risk.score") shouldBe "0.10"
+  }
+
+  test("Decision.StepUpRequired → inner does NOT run; returns Left(StepUpRequired) with reason") {
+    val (svc, sink, inner) = fixtureWithEngine(
+      RiskScore(0.7, List(RiskFactor("ScopeBaseline", 0.5, "new key"))),
+      Decision.StepUpRequired("score=0.70 threshold=0.60 factors=ScopeBaseline:0.5")
+    )
+    val res = svc.create(KeySpec.aes256("stepup"), alice).unsafeRunSync()
+
+    res match
+      case Left(KmsError(ErrorCode.StepUpRequired, msg)) =>
+        msg should include("ScopeBaseline:0.5")
+      case other => fail(s"expected Left(StepUpRequired, …) but got $other")
+
+    // The inner KeyService must NOT have created the key.
+    inner.locate("stepup", alice).unsafeRunSync() shouldBe empty
+
+    val record = sink.all.unsafeRunSync().head
+    record.outcome should startWith("Failed")
+    record.outcome should include("StepUpRequired")
+    record.context("outcome.decision") shouldBe "StepUp"
+    record.context("outcome.decision.reason") should include("ScopeBaseline:0.5")
+  }
+
+  test("Decision.Deny → inner does NOT run; returns Left(PermissionDenied) with 'risk:' prefix") {
+    val (svc, sink, inner) = fixtureWithEngine(
+      RiskScore(0.9, List(RiskFactor("ScopeBaseline", 0.5, "new"), RiskFactor("RateSpike", 0.4, "burst"))),
+      Decision.Deny("score=0.90 threshold=0.85 factors=ScopeBaseline:0.5;RateSpike:0.4")
+    )
+    val res = svc.create(KeySpec.aes256("denied"), alice).unsafeRunSync()
+
+    res match
+      case Left(KmsError(ErrorCode.PermissionDenied, msg)) =>
+        msg should startWith("risk:")
+        msg should include("ScopeBaseline:0.5")
+      case other => fail(s"expected Left(PermissionDenied, 'risk: …') but got $other")
+
+    inner.locate("denied", alice).unsafeRunSync() shouldBe empty
+
+    val record = sink.all.unsafeRunSync().head
+    record.context("outcome.decision") shouldBe "Deny"
+    record.context("outcome.decision.reason") should include("threshold=0.85")
+  }
+
+  test("Decision.Deny on sign also short-circuits (gating applies to every Either-returning op)") {
+    // Build a fixture where a key exists (use a separate decorated svc that allows the setup ops),
+    // then swap in the deny engine for the sign call. Simplest: two passes.
+    val sink  = InMemoryAuditSink.make.unsafeRunSync()
+    val inner = KeyService.inMemory.unsafeRunSync()
+    val setup = AuditingKeyService(inner, sink) // no scorer/engine → Allow path
+    val key   = setup.create(KeySpec.rsa2048("sign-deny"), alice).unsafeRunSync().toOption.get
+    setup.activate(key.id, alice).unsafeRunSync()
+
+    // Now wrap the SAME inner with a denying engine.
+    val gated = AuditingKeyService(
+      inner,
+      sink,
+      Some(new FixedScorer(RiskScore(0.9, Nil))),
+      Some(new FixedEngine(Decision.Deny("composite high-risk")))
+    )
+
+    val res = gated.sign(key.id, "msg".getBytes, SigAlgorithm.RsaPssSha256, alice).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.PermissionDenied)
+
+    val signRow = sink.all.unsafeRunSync().last
+    signRow.operation shouldBe Operation.Sign
+    signRow.context("outcome.decision") shouldBe "Deny"
+  }
+
+  test("locate is never gated by the engine — read-only ops always pass through") {
+    val (svc, sink, _) = fixtureWithEngine(
+      RiskScore(0.9, Nil),
+      Decision.Deny("would deny if asked")
+    )
+    val list = svc.locate("anything", alice).unsafeRunSync()
+    list shouldBe Nil // no keys exist, but the call ran (didn't short-circuit)
+
+    val record = sink.all.unsafeRunSync().head
+    record.operation shouldBe Operation.Locate
+    record.outcome shouldBe "Hits=0"
+    // Locate audit row carries the score but NOT a decision (engine isn't consulted for locate).
+    record.context.contains("risk.score") shouldBe true
+    record.context.contains("outcome.decision") shouldBe false
+  }

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/Decision.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/Decision.scala
@@ -1,0 +1,39 @@
+package dev.aegiskms.core
+
+/** Outcome of evaluating a request against a gating engine (policy floor and/or risk overlay).
+  *
+  * Three possible verdicts:
+  *
+  *   - `Allow` — request proceeds normally; the inner `KeyService` is invoked.
+  *   - `StepUpRequired` — the caller's credential is insufficient for the risk level of THIS request; the
+  *     HTTP layer translates this to `401 Unauthorized` so the client can re-present with a stronger
+  *     credential (MFA-stepped, freshly-minted, etc.). The original request is NOT executed.
+  *   - `Deny` — the request is refused outright. The inner `KeyService` is NOT invoked. HTTP returns `403`.
+  *
+  * The `reason` field on `StepUpRequired` / `Deny` is recorded in the audit row's `outcome.decision.reason`
+  * context key and surfaced in the HTTP error payload, so operators can answer "why was this blocked?" from
+  * the audit log alone.
+  *
+  * **Two producers, same type.** Both `PolicyEngine` (in `aegis-iam`, the boolean policy floor) and
+  * `DecisionEngine` (in `aegis-core` SPI, the risk overlay implemented by `ThresholdDecisionEngine` in
+  * `aegis-agent-ai`) emit `Decision`. The policy gate runs first as the floor; the risk gate is additive on
+  * top — risk can further restrict an action policy permits, but cannot widen one policy forbids.
+  */
+enum Decision:
+  case Allow
+  case Deny(reason: String)
+  case StepUpRequired(reason: String)
+
+object Decision:
+  /** Wire-stable label used in audit context (`outcome.decision`) and metrics. */
+  extension (d: Decision)
+    def label: String = d match
+      case Allow             => "Allow"
+      case StepUpRequired(_) => "StepUp"
+      case Deny(_)           => "Deny"
+
+    /** The `reason` string, or `""` for `Allow`. Convenience for context-map stamping. */
+    def reasonOrEmpty: String = d match
+      case Allow             => ""
+      case StepUpRequired(r) => r
+      case Deny(r)           => r

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/DecisionEngine.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/DecisionEngine.scala
@@ -1,0 +1,22 @@
+package dev.aegiskms.core
+
+/** SPI: translate a `(RiskScore, Principal, Operation)` triple into a `Decision`.
+  *
+  * Implementations live outside `aegis-core` because they need configuration (thresholds, per-op overrides)
+  * or external state (a future remote policy backend, an OPA bridge). The trait stays here so the audit
+  * decorator can take an `Option[DecisionEngine[IO]]` constructor arg without pulling Pekko or any specific
+  * backend into the library-safe tier.
+  *
+  * Contract:
+  *   - Pure with respect to the request: no I/O, no mutation. Threshold values come from constructor
+  *     configuration; the engine itself is stateless across calls.
+  *   - Total — never throws. Decision engines that need to call external systems should wrap failures into a
+  *     conservative `Deny(reason="engine error: ...")` rather than propagating the exception.
+  *   - Cheap. The engine is invoked on every state-changing request. Anything expensive belongs in the
+  *     `RiskScorer`, not here.
+  *
+  * The boolean policy gate (`AuthorizingKeyService`) remains the floor — see `Decision` for the additive-only
+  * relationship between policy and risk.
+  */
+trait DecisionEngine[F[_]]:
+  def decide(score: RiskScore, principal: Principal, operation: Operation): F[Decision]

--- a/modules/aegis-core/src/main/scala/dev/aegiskms/core/OperationResult.scala
+++ b/modules/aegis-core/src/main/scala/dev/aegiskms/core/OperationResult.scala
@@ -11,7 +11,11 @@ enum OperationResult:
   case OperationPending
   case OperationUndone
 
-/** Why an operation failed. Maps one-to-one with KMIP Result Reason values. */
+/** Why an operation failed. Maps one-to-one with KMIP Result Reason values, plus a small set of
+  * Aegis-specific extensions for capabilities KMIP doesn't model (notably: interactive step-up auth, which
+  * KMIP's batch-oriented wire format predates). Extensions are clearly marked and the KMIP codec layer maps
+  * them to the closest standard reason on the wire.
+  */
 enum ErrorCode:
   case None
   case ItemNotFound
@@ -34,6 +38,14 @@ enum ErrorCode:
   case EncodingOptionError
   case KeyValueNotPresent
   case GeneralFailure
+
+  /** Aegis-specific extension (NOT a KMIP code). Returned when the risk decision adapter (see
+    * `DecisionEngine`) requires the caller to re-authenticate with a stronger credential before this request
+    * can proceed. The HTTP plane maps this to `401 Unauthorized` with a `WWW-Authenticate: aegis-stepup
+    * reason=...` header. The KMIP codec maps it to `OperationCanceledByRequester` (closest standard match) on
+    * the wire.
+    */
+  case StepUpRequired
 
 /** Failure value returned by service operations. */
 final case class KmsError(code: ErrorCode, message: String)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -48,6 +48,12 @@ final class HttpRoutes(
       case ErrorCode.ItemNotFound                => StatusCode.NotFound
       case ErrorCode.PermissionDenied            => StatusCode.Forbidden
       case ErrorCode.AuthenticationNotSuccessful => StatusCode.Unauthorized
+      // StepUpRequired: the risk decision engine (#16) is asking for a stronger credential. The reason
+      // string (carried in `err.message`) is the WWW-Authenticate challenge content; clients should
+      // re-present with a freshly-minted / MFA-stepped token. A dedicated `WWW-Authenticate:
+      // aegis-stepup ...` header lands in a follow-up that extends the endpoint signatures with header
+      // outputs — for v0.2.0 the JSON body carries the challenge reason and is sufficient for SDK use.
+      case ErrorCode.StepUpRequired => StatusCode.Unauthorized
       case ErrorCode.InvalidField | ErrorCode.MissingData | ErrorCode.InvalidMessage =>
         StatusCode.BadRequest
       case _ => StatusCode.InternalServerError

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/PolicyEngine.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/PolicyEngine.scala
@@ -1,14 +1,14 @@
 package dev.aegiskms.iam
 
-import dev.aegiskms.core.{Operation, Principal}
+import dev.aegiskms.core.{Decision, Operation, Principal}
 
 /** SPI for policy evaluation. The default implementation is an allowlist matcher over role bindings.
   * Alternate implementations could wrap OPA / Rego or a policy language hosted elsewhere.
+  *
+  * Returns the shared `dev.aegiskms.core.Decision` enum — the same type the risk decision engine
+  * (`DecisionEngine` in `aegis-core`) emits. This is deliberate: both gating engines speak the same `Allow /
+  * Deny / StepUpRequired` vocabulary so downstream consumers (`AuthorizingKeyService` here,
+  * `AuditingKeyService` over in `aegis-audit`) don't need two separate code paths.
   */
 trait PolicyEngine[F[_]]:
   def permit(principal: Principal, op: Operation, resource: String): F[Decision]
-
-enum Decision:
-  case Allow
-  case Deny(reason: String)
-  case StepUpRequired(reason: String)

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RoleBasedPolicyEngine.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RoleBasedPolicyEngine.scala
@@ -1,7 +1,7 @@
 package dev.aegiskms.iam
 
 import cats.effect.IO
-import dev.aegiskms.core.{Operation, Principal}
+import dev.aegiskms.core.{Decision, Operation, Principal}
 
 /** A simple allowlist policy engine.
   *

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/DevPolicyEngine.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/DevPolicyEngine.scala
@@ -1,8 +1,8 @@
 package dev.aegiskms.app
 
 import cats.effect.IO
-import dev.aegiskms.core.{Operation, Principal}
-import dev.aegiskms.iam.{Decision, PolicyEngine}
+import dev.aegiskms.core.{Decision, Operation, Principal}
+import dev.aegiskms.iam.PolicyEngine
 
 /** A permissive `PolicyEngine` for dev-mode boots.
   *

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -4,7 +4,13 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, IOApp, Resource}
 import cats.syntax.all.*
 import com.typesafe.config.{Config, ConfigFactory}
-import dev.aegiskms.agent.{BaselineDetector, BaselineRiskScorer, InMemoryRecommendationSink, TappedAuditSink}
+import dev.aegiskms.agent.{
+  BaselineDetector,
+  BaselineRiskScorer,
+  InMemoryRecommendationSink,
+  TappedAuditSink,
+  ThresholdDecisionEngine
+}
 import dev.aegiskms.audit.{AuditingKeyService, StdoutAuditSink}
 import dev.aegiskms.http.HttpRoutes
 import dev.aegiskms.iam.{AuthorizingKeyService, JwtVerifier, PrincipalResolver}
@@ -109,11 +115,15 @@ object Server extends IOApp.Simple:
       recSink  <- Resource.eval(InMemoryRecommendationSink.make)
       detector <- Resource.eval(BaselineDetector.make())
       sink = TappedAuditSink(StdoutAuditSink(), detector, recSink)
-      // Risk scorer (#15 / W2): reads the same baseline state the tapped sink writes into. Audit-only
-      // for now — every record gets `risk.score` + `risk.factors` stamped. The decision adapter (#16)
-      // will consume the same scorer to allow / step-up / deny BEFORE the inner op runs.
+      // Risk scorer (#15 / W2): reads the same baseline state the tapped sink writes into. Every audit
+      // record gets `risk.score` + `risk.factors` stamped.
       riskScorer = BaselineRiskScorer.make(detector)
-      auditing   = new AuditingKeyService(traced, sink, Some(riskScorer))
+      // Decision adapter (#16 / W2.b): translates score → Allow / StepUp / Deny. Default thresholds
+      // (deny=0.85, stepUp=0.60, destructiveOpOffset=0.15) mean a single high-weight factor trips
+      // step-up, a composite trips deny, and destructive ops (Rotate / Compromise / Destroy / Revoke)
+      // are gated harder by 0.15. Operator-tuned thresholds via HOCON land later.
+      decisionEngine = ThresholdDecisionEngine.make()
+      auditing       = new AuditingKeyService(traced, sink, Some(riskScorer), Some(decisionEngine))
 
       resolver = buildResolver(rootConfig)
       _ <- Resource.eval(IO {


### PR DESCRIPTION
## Summary
- New `Decision` enum + `DecisionEngine` SPI in `aegis-core`; consolidated with aegis-iam's pre-existing policy-decision type.
- `ThresholdDecisionEngine` in aegis-agent-ai: two-threshold (deny=0.85, stepUp=0.60) with destructive-op offset 0.15.
- `AuditingKeyService` short-circuits inner KeyService on Deny/StepUp; stamps `outcome.decision` + reason into every audit row.
- New `ErrorCode.StepUpRequired`; HTTP layer maps to 401.
- Wired into `Server.boot` with default thresholds.

Closes #16. Auto-responder (#17) consumes `AgentRecommendation` events next.

## Test plan
- [x] `sbt test` — 283 tests pass, 0 failures
- [x] `sbt agentAi/test` — 34 tests including 9 new for `ThresholdDecisionEngine`
- [x] `sbt audit/test` — 22 tests including 5 new for the short-circuit path
- [x] `sbt scalafmtAll` — formatted
- [ ] Manual: bring up server, hit an op that should trip risk, confirm 403 with `risk:` reason