### PR TITLE
feat(agent-ai): auto-responder turns recommendations into actions (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Auto-responder — recommendations become actions (closes #17).** New `AutoResponder` in
+  `aegis-agent-ai` is itself a `RecommendationSink`: it decorates the existing in-memory store, so
+  every `AgentRecommendation` is persisted first, then matched against a configured `List[AutoResponseRule]`,
+  then executed if the rule fires and the per-`(actor, action)` cooldown allows.
+  `AutoResponseAction` enum models the four execution actions: `Alert` (audit-only annotation),
+  `Revoke` (calls `KeyService.revoke` on the target key extracted from `details("resource")`),
+  `Deactivate` (mapped to `Revoke` for v0.2.0), and `Freeze` (records intent; full enforcement
+  arrives with #24's JTI blacklist). Action audit rows are written with
+  `actor = Principal.Service("aegis-system", TenantId("system"))` and the outcome string
+  `AnomalyAlert(detector=…, severity=…, rec=<id>, action=…) Success|Failed …` so operators can grep
+  the responder's timeline. The responder calls a "below the audit decorator" `KeyService` on
+  purpose: routing through the outer `AuditingKeyService` would feed every auto-response back into
+  the detector → recommendation pipeline, causing recursion. Default rule set covers all five
+  baseline detectors at `High → Revoke` and `Medium → Alert`; `Low` is intentionally absent (too
+  much noise — operators opt in). Wired into `Server.boot` between the recommendation store and the
+  tapped audit sink. Failure modes (missing target key, invalid keyId, KMS error) are captured in
+  the audit row, never thrown — `publish` is total. Operator-tuned rules via HOCON land in a follow-up.
+
+
+
 - **Risk scorer with reasoning (closes #15).** New `RiskScorer[F[_]]` SPI in `aegis-core` returns a
   numeric score in `[0.0, 1.0]` plus a list of `RiskFactor` evidence rows (name + weight +
   human-readable evidence string) for every request. `BaselineRiskScorer` in `aegis-agent-ai`

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AutoResponder.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AutoResponder.scala
@@ -1,0 +1,203 @@
+package dev.aegiskms.agent
+
+import cats.effect.{IO, Ref}
+import dev.aegiskms.audit.{AuditRecord, AuditSink}
+import dev.aegiskms.core.*
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import java.util.UUID
+import scala.concurrent.duration.*
+
+/** The W3 auto-responder: turns `AgentRecommendation` events into KMS actions.
+  *
+  * Slotted into the existing detector → recommendation pipeline as a decorating `RecommendationSink`: every
+  * recommendation is first persisted to the inner sink (so operators still see the full alert history
+  * regardless of what the responder does), then matched against the configured rule list, then (if a rule
+  * fires and the cooldown allows) the action is executed.
+  *
+  * **Action execution path bypasses `AuditingKeyService` on purpose.** The responder calls a "below the audit
+  * decorator" `KeyService` and writes its own action audit row directly. Routing through the audited service
+  * would feed every auto-response back into the detector → recommendation pipeline, causing recursion (revoke
+  * → audit row → detector fires → more revokes). Each action is recorded as a separate audit event with
+  * `actor = Principal.Service("aegis-system", TenantId("system"))` and the outcome string
+  * `"AnomalyAlert(detector=…, severity=…, rec=<id>, action=…)"` — matching the spec in issue #17. Operators
+  * can filter on this actor to see the full auto-response timeline.
+  *
+  * **Cooldown.** Per-`(actor.subject, action)` cooldown (default 60 s) suppresses repeat fires. Without this,
+  * a sustained rate-spike would issue dozens of revokes-per-second for the same key. The cooldown is
+  * in-memory only — restart resets it, which is fine for v0.2.0 (the operator-visible behaviour is "we acted
+  * once per minute per actor" — restart just means "the clock resets"). Persistent cooldown lands with the
+  * SIEM webhook PR (#21) which needs durable de-duplication anyway.
+  *
+  * **Failure handling.** Action failures (revoke errors, missing target keys, malformed details) are logged +
+  * audited but never propagated back to the caller — the responder's `publish` is total. The recommendation
+  * has already been persisted by the inner sink, so the operator still sees the event; the audit row
+  * documents WHY the action couldn't proceed.
+  */
+final class AutoResponder private (
+    rules: List[AutoResponseRule],
+    inner: RecommendationSink,
+    keyService: KeyService[IO],
+    auditSink: AuditSink[IO],
+    cooldown: FiniteDuration,
+    recentlyFired: Ref[IO, Map[(String, AutoResponseAction), Instant]],
+    now: IO[Instant]
+) extends RecommendationSink:
+
+  import AutoResponder.*
+
+  private val logger = LoggerFactory.getLogger(classOf[AutoResponder])
+
+  def publish(rec: AgentRecommendation): IO[Unit] =
+    inner.publish(rec) *> maybeApplyRule(rec)
+
+  private def maybeApplyRule(rec: AgentRecommendation): IO[Unit] =
+    matchRule(rec) match
+      case None => IO.unit // no rule for this detector + severity
+      case Some(rule) =>
+        cooldownGate(rec.actor.subject, rule.action).flatMap {
+          case false => IO.unit
+          case true  => executeRule(rule, rec)
+        }
+
+  private def matchRule(rec: AgentRecommendation): Option[AutoResponseRule] =
+    rules.find(r => r.detector == rec.detector && r.severity == rec.severity)
+
+  /** Returns `true` if this `(subject, action)` pair is OUTSIDE its cooldown window (i.e. we should fire). */
+  private def cooldownGate(subject: String, action: AutoResponseAction): IO[Boolean] =
+    now.flatMap { t =>
+      recentlyFired.modify { map =>
+        val key = (subject, action)
+        map.get(key) match
+          case Some(prev) if java.time.Duration.between(prev, t).toMillis < cooldown.toMillis =>
+            (map, false)
+          case _ => (map + (key -> t), true)
+      }
+    }
+
+  private def executeRule(rule: AutoResponseRule, rec: AgentRecommendation): IO[Unit] =
+    val attempt: IO[Either[String, String]] = rule.action match
+      case AutoResponseAction.Alert      => IO.pure(Right("alert recorded"))
+      case AutoResponseAction.Revoke     => doRevoke(rec)
+      case AutoResponseAction.Deactivate => doRevoke(rec) // mapped — see AutoResponseAction docs
+      case AutoResponseAction.Freeze     => doFreeze(rec)
+
+    for
+      outcome <- attempt
+      _       <- writeActionAudit(rule, rec, outcome)
+      _       <- IO(logResult(rule, rec, outcome))
+    yield ()
+
+  private def doRevoke(rec: AgentRecommendation): IO[Either[String, String]] =
+    extractKeyId(rec) match
+      case Left(why) => IO.pure(Left(why))
+      case Right(kid) =>
+        keyService.revoke(kid, SystemPrincipal).map {
+          case Right(_) => Right(s"revoked key=${kid.value}")
+          case Left(e)  => Left(s"revoke failed code=${e.code} msg=${e.message}")
+        }
+
+  private def doFreeze(rec: AgentRecommendation): IO[Either[String, String]] =
+    // v0.2.0: no enforcement. Real freeze requires the JTI blacklist (#24).
+    IO.pure(
+      Right(s"freeze noted for actor=${rec.actor.subject} (enforcement deferred to #24)")
+    )
+
+  private def extractKeyId(rec: AgentRecommendation): Either[String, KeyId] =
+    rec.details.get("resource") match
+      case Some(r) if r.startsWith("key:") =>
+        KeyId.fromString(r.stripPrefix("key:")).left.map(msg => s"invalid keyId in details: $msg")
+      case Some(other) =>
+        Left(s"recommendation resource is not a key reference: '$other'")
+      case None =>
+        Left("recommendation has no 'resource' detail to target")
+
+  private def writeActionAudit(
+      rule: AutoResponseRule,
+      rec: AgentRecommendation,
+      outcome: Either[String, String]
+  ): IO[Unit] =
+    now.flatMap { t =>
+      val outcomeStr = outcome match
+        case Right(msg) => s"Success $msg"
+        case Left(msg)  => s"Failed $msg"
+      val record = AuditRecord(
+        at = t,
+        principal = SystemPrincipal,
+        operation = operationForAction(rule.action),
+        resource = rec.details.getOrElse("resource", s"actor:${rec.actor.subject}"),
+        outcome =
+          s"AnomalyAlert(detector=${rec.detector}, severity=${rec.severity}, rec=${rec.eventId}, action=${rule.action}) $outcomeStr",
+        correlationId = UUID.randomUUID().toString,
+        context = Map(
+          "auto.response.rule"        -> s"${rule.detector}:${rule.severity}:${rule.action}",
+          "auto.response.actor"       -> rec.actor.subject,
+          "auto.response.recId"       -> rec.eventId,
+          "auto.response.detectorMsg" -> rec.summary
+        )
+      )
+      auditSink.write(record)
+    }
+
+  private def operationForAction(a: AutoResponseAction): Operation = a match
+    case AutoResponseAction.Alert      => Operation.AddAttribute // closest "informational" op; see note below
+    case AutoResponseAction.Revoke     => Operation.Revoke
+    case AutoResponseAction.Deactivate => Operation.Revoke       // mapped, see action docs
+    case AutoResponseAction.Freeze     => Operation.Revoke
+
+  private def logResult(
+      rule: AutoResponseRule,
+      rec: AgentRecommendation,
+      outcome: Either[String, String]
+  ): Unit =
+    outcome match
+      case Right(msg) =>
+        logger.warn(
+          s"auto-response action=${rule.action} fired for ${rec.detector}/${rec.severity} actor=${rec.actor.subject}: $msg"
+        )
+      case Left(msg) =>
+        logger.error(
+          s"auto-response action=${rule.action} FAILED for ${rec.detector}/${rec.severity} actor=${rec.actor.subject}: $msg"
+        )
+
+object AutoResponder:
+
+  /** The system actor under whose identity auto-response actions are taken. Identifying as a `Service` (not a
+    * `Human`) lets the policy gate carve a single per-`subject` exception for it; identifying as
+    * `"aegis-system"` (a deliberately namespaced name no operator would pick) keeps it greppable in audit log
+    * searches.
+    */
+  val SystemPrincipal: Principal =
+    Principal.Service(subject = "aegis-system", tenant = TenantId("system"))
+
+  /** Sensible out-of-the-box defaults that ship the wedge demo:
+    *
+    *   - Any `High` severity from any of the five detectors → `Revoke`.
+    *   - Any `Medium` severity → `Alert` (informational; lets operators see the trend without acting).
+    *   - `Low` severity is intentionally absent — too much noise; operators opt in by adding their own rule.
+    *
+    * Operator-tuned rules will land via HOCON in a later PR; for v0.2.0 these defaults are baked into
+    * `Server.boot`.
+    */
+  val DefaultRules: List[AutoResponseRule] =
+    val detectors =
+      List("ScopeBaseline", "RateSpike", "OpHistogramBaseline", "TimeOfDayBaseline", "SourceIpBaseline")
+    detectors.flatMap(d =>
+      List(
+        AutoResponseRule(d, Severity.High, AutoResponseAction.Revoke),
+        AutoResponseRule(d, Severity.Medium, AutoResponseAction.Alert)
+      )
+    )
+
+  def make(
+      rules: List[AutoResponseRule],
+      inner: RecommendationSink,
+      keyService: KeyService[IO],
+      auditSink: AuditSink[IO],
+      cooldown: FiniteDuration = 60.seconds,
+      now: IO[Instant] = IO.realTimeInstant
+  ): IO[AutoResponder] =
+    Ref.of[IO, Map[(String, AutoResponseAction), Instant]](Map.empty).map { ref =>
+      new AutoResponder(rules, inner, keyService, auditSink, cooldown, ref, now)
+    }

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AutoResponseRule.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AutoResponseRule.scala
@@ -1,0 +1,38 @@
+package dev.aegiskms.agent
+
+/** A single mapping from `(detector, severity)` to an `AutoResponseAction`.
+  *
+  * The auto-responder evaluates rules in order; the first match wins. Multiple rules per detector are fine —
+  * finer-grained severities can pair with stronger actions (e.g. `Low → Alert`, `High → Revoke`).
+  *
+  * The `detector` field matches `AgentRecommendation.detector` exactly: `"ScopeBaseline"`, `"RateSpike"`,
+  * `"OpHistogramBaseline"`, `"TimeOfDayBaseline"`, `"SourceIpBaseline"`. No wildcard matching in v0.2.0 — if
+  * an operator wants "any detector at High severity → Revoke", they enumerate the five rules explicitly.
+  * Wildcard rules are cheap to add later if real configurations show the need.
+  */
+final case class AutoResponseRule(
+    detector: String,
+    severity: Severity,
+    action: AutoResponseAction
+)
+
+/** Concrete execution-level action the auto-responder can take. Deliberately a separate vocabulary from
+  * `SuggestedAction` (the detector's *suggestion*): the responder owns what it actually *does*, while
+  * detectors only opine.
+  *
+  *   - `Alert` — write an audit row noting the recommendation; no state change. The minimum auto- response —
+  *     guarantees the event is captured in the audit timeline for operators.
+  *   - `Revoke` — call `KeyService.revoke` on the target key extracted from
+  *     `AgentRecommendation.details("resource")`. Moves Active → Deactivated. Reversible by re-activation if
+  *     the operator deems the alert a false positive.
+  *   - `Deactivate` — for v0.2.0 mapped to `Revoke` (KMIP's Deactivate→Revoke separation isn't wired into
+  *     `KeyService` yet — see ROADMAP §v0.3.0).
+  *   - `Freeze` — temporarily block the agent's credential from issuing further ops. Full enforcement
+  *     requires #24 (Redis-backed JTI blacklist); for v0.2.0 the action records an audit row + log line
+  *     documenting the freeze intent, so operators see the call.
+  */
+enum AutoResponseAction:
+  case Alert
+  case Revoke
+  case Deactivate
+  case Freeze

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AutoResponderSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AutoResponderSpec.scala
@@ -1,0 +1,268 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.audit.InMemoryAuditSink
+import dev.aegiskms.core.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.duration.*
+
+/** Tests for `AutoResponder` — the W3 wedge feature.
+  *
+  * The properties exercised here cover the full responder contract:
+  *
+  *   1. Persistence is always-on — every recommendation hits the inner sink before any rule is applied. 2.
+  *      Rule matching is exact on (detector, severity); no wildcard inference. 3. The action audit row is
+  *      recorded with the SystemPrincipal so operators can grep on it. 4. Revoke actually mutates KMS state
+  *      (the target key is moved to Revoked). 5. Failures (missing target key, invalid id, KMS error) are
+  *      captured in the audit row, not thrown. 6. Cooldown suppresses repeat fires for the same (actor,
+  *      action) inside the window. 7. Recommendations with no matching rule are no-ops (still persisted,
+  *      never acted on).
+  */
+final class AutoResponderSpec extends AnyFunSuite with Matchers:
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def agent(): Principal.Agent =
+    Principal.Agent(
+      subject = "claude-session-7a3",
+      operator = alice,
+      purpose = "invoice-signing",
+      issuedAt = Instant.parse("2026-05-01T10:00:00Z"),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get, Operation.Sign),
+      parent = None
+    )
+
+  private def rec(
+      detector: String,
+      severity: Severity,
+      actor: Principal = agent(),
+      resource: Option[String] = Some("key:invoice-2026"),
+      eventId: String = java.util.UUID.randomUUID().toString
+  ): AgentRecommendation =
+    AgentRecommendation(
+      eventId = eventId,
+      at = Instant.parse("2026-05-01T10:30:00Z"),
+      actor = actor,
+      detector = detector,
+      severity = severity,
+      summary = s"$detector $severity for ${actor.subject}",
+      details = resource.fold(Map.empty[String, String])(r => Map("resource" -> r)),
+      suggestedAction = SuggestedAction.Alert
+    )
+
+  /** A KeyService stub that records every method call and lets a test assert what happened. */
+  final private class RecordingKeyService extends KeyService[IO]:
+    val revokeCalls = scala.collection.mutable.ListBuffer[(KeyId, Principal)]()
+
+    def revoke(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      revokeCalls += (id -> by)
+      IO.pure(Right(stubKey(id)))
+
+    // All other ops are unused by these tests; produce sensible stubs.
+    def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      IO.pure(Right(stubKey(KeyId.fromString("stub").toOption.get)))
+    def get(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      IO.pure(Right(stubKey(id)))
+    def locate(namePattern: String, by: Principal): IO[List[ManagedKey]] = IO.pure(Nil)
+    def activate(id: KeyId, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      IO.pure(Right(stubKey(id)))
+    def destroy(id: KeyId, by: Principal): IO[Either[KmsError, Unit]] = IO.pure(Right(()))
+    def sign(id: KeyId, msg: Array[Byte], alg: SigAlgorithm, by: Principal): IO[Either[KmsError, Signature]] =
+      IO.pure(Left(KmsError(ErrorCode.OperationNotSupported, "stub")))
+    def verify(id: KeyId, msg: Array[Byte], sig: Signature, by: Principal): IO[Either[KmsError, Boolean]] =
+      IO.pure(Right(true))
+    def encrypt(
+        id: KeyId,
+        pt: Array[Byte],
+        ctx: Map[String, String],
+        by: Principal
+    ): IO[Either[KmsError, Ciphertext]] =
+      IO.pure(Left(KmsError(ErrorCode.OperationNotSupported, "stub")))
+    def decrypt(
+        id: KeyId,
+        ct: Ciphertext,
+        ctx: Map[String, String],
+        by: Principal
+    ): IO[Either[KmsError, Array[Byte]]] =
+      IO.pure(Left(KmsError(ErrorCode.OperationNotSupported, "stub")))
+    def wrap(id: KeyId, dek: Array[Byte], by: Principal): IO[Either[KmsError, WrappedDek]] =
+      IO.pure(Left(KmsError(ErrorCode.OperationNotSupported, "stub")))
+    def unwrap(id: KeyId, w: WrappedDek, by: Principal): IO[Either[KmsError, Array[Byte]]] =
+      IO.pure(Left(KmsError(ErrorCode.OperationNotSupported, "stub")))
+    def compromise(id: KeyId, reason: String, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      IO.pure(Right(stubKey(id)))
+    def rotate(id: KeyId, policy: RotationPolicy, by: Principal): IO[Either[KmsError, ManagedKey]] =
+      IO.pure(Right(stubKey(id)))
+
+    private def stubKey(id: KeyId): ManagedKey =
+      ManagedKey(
+        id = id,
+        spec = KeySpec.aes256("stub"),
+        owner = alice,
+        createdAt = Instant.parse("2026-05-01T10:00:00Z"),
+        state = KeyState.Deactivated,
+        currentVersion = 1
+      )
+
+  private def fixture(rules: List[AutoResponseRule], cooldown: FiniteDuration = 60.seconds): (
+      AutoResponder,
+      InMemoryRecommendationSink,
+      InMemoryAuditSink,
+      RecordingKeyService
+  ) =
+    val recStore = InMemoryRecommendationSink.make.unsafeRunSync()
+    val audit    = InMemoryAuditSink.make.unsafeRunSync()
+    val ks       = new RecordingKeyService
+    val resp = AutoResponder
+      .make(rules, recStore, ks, audit, cooldown = cooldown)
+      .unsafeRunSync()
+    (resp, recStore, audit, ks)
+
+  // ── Persistence ────────────────────────────────────────────────────────────
+
+  test("recommendations are always persisted to the inner sink, even when no rule matches") {
+    val (resp, store, audit, _) = fixture(rules = Nil) // empty rules → never act
+    val r                       = rec("ScopeBaseline", Severity.High)
+    resp.publish(r).unsafeRunSync()
+
+    store.all.unsafeRunSync() shouldBe List(r)
+    audit.all.unsafeRunSync() shouldBe empty // no rule → no action audit row
+  }
+
+  // ── Rule matching ──────────────────────────────────────────────────────────
+
+  test("Revoke rule on a matching High recommendation calls KeyService.revoke") {
+    val rules = List(AutoResponseRule("ScopeBaseline", Severity.High, AutoResponseAction.Revoke))
+    val (resp, _, audit, ks) = fixture(rules)
+    val r                    = rec("ScopeBaseline", Severity.High, resource = Some("key:invoice-2026"))
+
+    resp.publish(r).unsafeRunSync()
+
+    ks.revokeCalls.size shouldBe 1
+    val (id, by) = ks.revokeCalls.head
+    id.value shouldBe "invoice-2026"
+    by shouldBe AutoResponder.SystemPrincipal
+
+    val row = audit.all.unsafeRunSync().head
+    row.principal shouldBe AutoResponder.SystemPrincipal
+    row.operation shouldBe Operation.Revoke
+    row.outcome should startWith("AnomalyAlert")
+    row.outcome should include("detector=ScopeBaseline")
+    row.outcome should include("action=Revoke")
+    row.outcome should include("Success revoked key=invoice-2026")
+    row.context("auto.response.rule") shouldBe "ScopeBaseline:High:Revoke"
+    row.context("auto.response.actor") shouldBe "claude-session-7a3"
+  }
+
+  test("rule matching is exact — Low severity recommendation doesn't trip a High rule") {
+    val rules = List(AutoResponseRule("ScopeBaseline", Severity.High, AutoResponseAction.Revoke))
+    val (resp, store, audit, ks) = fixture(rules)
+    val r                        = rec("ScopeBaseline", Severity.Low)
+
+    resp.publish(r).unsafeRunSync()
+
+    store.all.unsafeRunSync() should have size 1 // still persisted
+    ks.revokeCalls shouldBe empty
+    audit.all.unsafeRunSync() shouldBe empty
+  }
+
+  test("Alert action writes an audit row but does not call KeyService") {
+    val rules                = List(AutoResponseRule("RateSpike", Severity.Medium, AutoResponseAction.Alert))
+    val (resp, _, audit, ks) = fixture(rules)
+    val r                    = rec("RateSpike", Severity.Medium)
+
+    resp.publish(r).unsafeRunSync()
+
+    ks.revokeCalls shouldBe empty
+    val row = audit.all.unsafeRunSync().head
+    row.outcome should include("action=Alert")
+    row.outcome should include("Success alert recorded")
+  }
+
+  test("Freeze action records audit + log but does not enforce (v0.2.0; #24 will enforce)") {
+    val rules = List(AutoResponseRule("SourceIpBaseline", Severity.High, AutoResponseAction.Freeze))
+    val (resp, _, audit, ks) = fixture(rules)
+    resp.publish(rec("SourceIpBaseline", Severity.High)).unsafeRunSync()
+
+    ks.revokeCalls shouldBe empty
+    val row = audit.all.unsafeRunSync().head
+    row.outcome should include("action=Freeze")
+    row.outcome should include("freeze noted")
+    row.outcome should include("enforcement deferred to #24")
+  }
+
+  // ── Failure handling ──────────────────────────────────────────────────────
+
+  test("Revoke against a recommendation missing 'resource' is captured as Failed in audit") {
+    val rules                = List(AutoResponseRule("RateSpike", Severity.High, AutoResponseAction.Revoke))
+    val (resp, _, audit, ks) = fixture(rules)
+    val r                    = rec("RateSpike", Severity.High, resource = None) // no key target
+
+    resp.publish(r).unsafeRunSync() // must not throw
+
+    ks.revokeCalls shouldBe empty
+    val row = audit.all.unsafeRunSync().head
+    row.outcome should include("Failed")
+    row.outcome should include("no 'resource' detail")
+  }
+
+  test("Revoke against a non-key resource is captured as Failed in audit") {
+    val rules                = List(AutoResponseRule("X", Severity.High, AutoResponseAction.Revoke))
+    val (resp, _, audit, ks) = fixture(rules)
+    val r                    = rec("X", Severity.High, resource = Some("pattern:foo*"))
+
+    resp.publish(r).unsafeRunSync()
+
+    ks.revokeCalls shouldBe empty
+    audit.all.unsafeRunSync().head.outcome should include("not a key reference")
+  }
+
+  // ── Cooldown ───────────────────────────────────────────────────────────────
+
+  test("cooldown suppresses repeat fires for the same (actor, action) inside the window") {
+    val rules                = List(AutoResponseRule("RateSpike", Severity.High, AutoResponseAction.Revoke))
+    val (resp, _, audit, ks) = fixture(rules, cooldown = 60.seconds)
+
+    resp.publish(rec("RateSpike", Severity.High, eventId = "e1")).unsafeRunSync()
+    resp.publish(rec("RateSpike", Severity.High, eventId = "e2")).unsafeRunSync()
+    resp.publish(rec("RateSpike", Severity.High, eventId = "e3")).unsafeRunSync()
+
+    ks.revokeCalls.size shouldBe 1 // only the first fires; e2 + e3 suppressed
+    audit.all.unsafeRunSync().size shouldBe 1
+  }
+
+  test("cooldown is per-(actor,action) — different actors fire independently") {
+    val rules                = List(AutoResponseRule("RateSpike", Severity.High, AutoResponseAction.Revoke))
+    val (resp, _, audit, ks) = fixture(rules)
+
+    val actorA = Principal.Service("svc-a", TenantId("t"))
+    val actorB = Principal.Service("svc-b", TenantId("t"))
+
+    resp.publish(rec("RateSpike", Severity.High, actor = actorA)).unsafeRunSync()
+    resp.publish(rec("RateSpike", Severity.High, actor = actorB)).unsafeRunSync()
+
+    ks.revokeCalls.size shouldBe 2
+    audit.all.unsafeRunSync().size shouldBe 2
+  }
+
+  // ── Default rules ──────────────────────────────────────────────────────────
+
+  test("DefaultRules cover all five baseline detectors at High → Revoke + Medium → Alert") {
+    val byDetectorAndSeverity =
+      AutoResponder.DefaultRules.map(r => (r.detector, r.severity, r.action)).toSet
+    Seq("ScopeBaseline", "RateSpike", "OpHistogramBaseline", "TimeOfDayBaseline", "SourceIpBaseline")
+      .foreach { d =>
+        byDetectorAndSeverity should contain((d, Severity.High, AutoResponseAction.Revoke))
+        byDetectorAndSeverity should contain((d, Severity.Medium, AutoResponseAction.Alert))
+      }
+  }
+
+  test("SystemPrincipal is a Service named 'aegis-system' (greppable in audit search)") {
+    AutoResponder.SystemPrincipal shouldBe a[Principal.Service]
+    AutoResponder.SystemPrincipal.subject shouldBe "aegis-system"
+  }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, IOApp, Resource}
 import cats.syntax.all.*
 import com.typesafe.config.{Config, ConfigFactory}
 import dev.aegiskms.agent.{
+  AutoResponder,
   BaselineDetector,
   BaselineRiskScorer,
   InMemoryRecommendationSink,
@@ -112,9 +113,24 @@ object Server extends IOApp.Simple:
       authorizing = new AuthorizingKeyService(actorBacked, new DevPolicyEngine)
       metered     = new MeteredKeyService(authorizing, metricsRegistry)
       traced      = new TracingKeyService(metered, tracer)
-      recSink  <- Resource.eval(InMemoryRecommendationSink.make)
+      recStore <- Resource.eval(InMemoryRecommendationSink.make)
       detector <- Resource.eval(BaselineDetector.make())
-      sink = TappedAuditSink(StdoutAuditSink(), detector, recSink)
+      stdoutSink = StdoutAuditSink()
+      // Auto-responder (#17 / W3): decorates the recommendation sink. Every recommendation is first
+      // persisted to `recStore` (full alert history retained), then matched against `DefaultRules`
+      // (High → Revoke, Medium → Alert), then executed with a per-(actor,action) 60 s cooldown. The
+      // responder calls `traced` directly — bypassing the outer Auditing decorator on purpose so a
+      // revoke action doesn't recurse through the detector. It writes its own audit row to
+      // `stdoutSink` with `actor = AutoResponder.SystemPrincipal` so operators can grep the timeline.
+      autoResponder <- Resource.eval(
+        AutoResponder.make(
+          rules = AutoResponder.DefaultRules,
+          inner = recStore,
+          keyService = traced,
+          auditSink = stdoutSink
+        )
+      )
+      sink = TappedAuditSink(stdoutSink, detector, autoResponder)
       // Risk scorer (#15 / W2): reads the same baseline state the tapped sink writes into. Every audit
       // record gets `risk.score` + `risk.factors` stamped.
       riskScorer = BaselineRiskScorer.make(detector)


### PR DESCRIPTION
## Summary
- New `AutoResponder` is a `RecommendationSink` that decorates the in-memory store; persistence always wins, action is best-effort.
- `AutoResponseRule(detector, severity, action)` matches exactly; `AutoResponseAction` is `Alert / Revoke / Deactivate / Freeze`.
- System actor is `Principal.Service("aegis-system", "system")` — greppable in audit log.
- Per-(actor, action) 60s cooldown suppresses repeat fires.
- DefaultRules: 5 detectors x High → Revoke + 5 x Medium → Alert.
- Wired into `Server.boot`.

Closes #17. W3 wedge demo is now end-to-end: detector → recommendation → auto-response → audit.

## Test plan
- [x] `sbt test` — 294 tests pass, 0 failures
- [x] `sbt agentAi/test` — 45 tests including 11 new for the responder
- [x] `sbt scalafmtAll` — formatted
- [ ] Manual: bring up server with an agent token, trigger a scope violation, confirm a Revoke audit row from `aegis-system` appears on stdout