### PR TITLE
docs+ci: refresh docs for v0.2.0 wedge + publish :main Docker image

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -1,0 +1,95 @@
+name: Docker (main)
+
+# Publishes `ghcr.io/<owner>/aegis-server:main` (and `:main-<sha>`) on every push to `main`.
+# Separate from `release.yml` (which fires on `v*` tags) so the "what's on `main`" image stays
+# fresh between tagged releases — needed for the W2/W3 wedge demo in the quickstart, which uses
+# features that shipped to `main` after v0.1.1 but won't be in a tagged image until v0.2.0.
+#
+# No external secrets — uses the built-in `GITHUB_TOKEN` for GHCR auth.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # Skip docs-only commits — they don't change the server bytecode and we don't want a docker
+      # rebuild for every typo fix. Adjust if a new server source-of-truth path lands.
+      - 'modules/**'
+      - 'build.sbt'
+      - 'project/**'
+      - '.github/workflows/docker-main.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  # One image build per ref at a time; cancel the older one if a newer push arrives.
+  group: docker-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & publish :main
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache sbt
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-main-${{ hashFiles('**/build.sbt', 'project/**') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-main-
+            ${{ runner.os }}-sbt-
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute lowercase image owner
+        id: owner
+        run: echo "value=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & publish image as :main and :main-<sha>
+        env:
+          GHCR_OWNER: ${{ steps.owner.outputs.value }}
+          SHA: ${{ github.sha }}
+        run: |
+          SHORT_SHA="${SHA::7}"
+          # Two tags off one build — the floating ":main" pointer is what the quickstart wedge
+          # demo references; ":main-<sha>" is the immutable per-commit reference for anyone who
+          # needs reproducibility.
+          sbt \
+            -Ddocker.username="ghcr.io/${GHCR_OWNER}" \
+            "set server / Docker / dockerRepository := Some(\"ghcr.io/${GHCR_OWNER}\")" \
+            "set server / Docker / dockerUpdateLatest := false" \
+            "set server / Docker / version := \"main\"" \
+            "server / Docker / publish"
+          sbt \
+            -Ddocker.username="ghcr.io/${GHCR_OWNER}" \
+            "set server / Docker / dockerRepository := Some(\"ghcr.io/${GHCR_OWNER}\")" \
+            "set server / Docker / dockerUpdateLatest := false" \
+            "set server / Docker / version := \"main-${SHORT_SHA}\"" \
+            "server / Docker / publish"
+
+      - name: Note image tags
+        env:
+          GHCR_OWNER: ${{ steps.owner.outputs.value }}
+          SHA: ${{ github.sha }}
+        run: |
+          SHORT_SHA="${SHA::7}"
+          echo "::notice::Published ghcr.io/${GHCR_OWNER}/aegis-server:main and :main-${SHORT_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **CI publishes `ghcr.io/<owner>/aegis-server:main` on every push to `main`.** New
+  `.github/workflows/docker-main.yml` builds and publishes a floating `:main` image (and an
+  immutable `:main-<short-sha>`) so the v0.2.0 wedge demo in the quickstart can be exercised
+  without waiting for a tagged release. The workflow skips on docs-only commits (paths filter)
+  to avoid burning CI minutes for typo fixes. `release.yml` (tagged releases) is untouched —
+  `:0.1.x`, `:0.2.0`, … continue to be published from `v*` tags.
+
+### Changed
+
+- **`deploy/docker/docker-compose.yml` default image bumped `0.1.0` → `0.1.1`.** The compose
+  default now pulls the latest stable tagged release; the embedded comment documents the three
+  alternatives (`:main` for v0.2.0 preview, `:main-<sha>` for immutability, local build via
+  `sbt 'server / Docker / publishLocal'`).
+
+- **Docs + roadmap refresh reflecting the W2 + W3 wedge work on `main`.** `ROADMAP.md` 2.0.a /
+  2.0.b / 2.0.c marked ✅ Shipped. `docs/index.md` feature table now lists the risk scorer,
+  decision adapter, and auto-responder under "shipped (v0.2.0)" with explicit thresholds + default
+  rules. `docs/about/status.md` updated per-capability snapshot (Agent-AI plane → Shipped; risk
+  scorer / decision adapter / auto-responder rows replaced their WIP entries). `docs/about/comparison.md`
+  gained explicit rows for "Risk-scored decisions" and "Auto-response to anomalies" (each marked
+  as a first-class Aegis capability vs. DIY-on-CloudTrail-or-audit-devices elsewhere).
+  `docs/ARCHITECTURE.md` request-lifecycle Mermaid diagram now shows the `RiskScorer`,
+  `DecisionEngine`, `BaselineDetector`, and `AutoResponder` boxes wired through `AuditingKeyService` +
+  `TappedAuditSink`, with explanatory prose covering the additive-risk-overlay-vs-policy-floor
+  semantics and the "below-the-audit-decorator" no-recursion routing. `docs/getting-started/quickstart.md`
+  extended from 14 to 18 steps: Step 14 switches the running stack from `:0.1.1` to `:main` (so the
+  wedge demo actually exercises the new code — fixes the "I ran the quickstart and the auto-revoke
+  didn't fire" report where Steps 15–17 silently produced no risk context against the pre-W2 image);
+  Steps 15–17 are the **wedge demo** itself, tripping a `RateSpike`, showing the operator-grep-able
+  `aegis-system` auto-revoke audit row, and exercising the decision adapter's `PermissionDenied` path.
+  Time estimate updated 10 → 15 min, the introductory "What you'll have when you're done" callout
+  spells out the wedge-demo deliverable so newcomers know what makes Aegis different before they start.
+
+### Added
+
 - **Auto-responder — recommendations become actions (closes #17).** New `AutoResponder` in
   `aegis-agent-ai` is itself a `RecommendationSink`: it decorates the existing in-memory store, so
   every `AgentRecommendation` is persisted first, then matched against a configured `List[AutoResponseRule]`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,9 +76,9 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 
 | # | Capability | Area | Status |
 |---|---|---|---|
-| 2.0.a | Risk scorer (W2) — multi-factor numeric score; reasoning recorded in audit context | Wedge | 🔜 |
-| 2.0.b | Decision adapter (`allow` / `step-up` / `deny`) wired into IAM | Wedge | 🔜 |
-| 2.0.c | Auto-responder (W3) — configurable rules from `AgentRecommendation` → action (revoke / deactivate / freeze / alert) | Wedge | 🔜 |
+| 2.0.a | Risk scorer (W2) — multi-factor numeric score; reasoning recorded in audit context | Wedge | ✅ |
+| 2.0.b | Decision adapter (`allow` / `step-up` / `deny`) wired into IAM | Wedge | ✅ |
+| 2.0.c | Auto-responder (W3) — configurable rules from `AgentRecommendation` → action (revoke / deactivate / freeze / alert) | Wedge | ✅ |
 | 2.0.d | Agent-token issuance HTTP endpoint (`POST /v1/agents/issue`) | Wedge | 🔜 |
 | 2.0.e | `aegis agent issue` CLI — wire the existing stub to the new endpoint | Wedge | 🔜 |
 | 2.0.f | Postgres audit table (queryable, indexed on actor + occurredAt + key) | Platform | 🔜 |

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -21,9 +21,15 @@
 # Run with:
 #   docker compose -f deploy/docker/docker-compose.yml up
 #
-# To use the locally-built image instead of the GHCR-published one:
-#   sbt 'server / Docker / publishLocal'
-#   IMAGE_TAG=0.1.0-SNAPSHOT docker compose -f deploy/docker/docker-compose.yml up
+# Image tag selection (set `IMAGE_TAG` to override the default):
+#   - `IMAGE_TAG=0.1.1`       (default) — latest stable tagged release; what `docker compose up` pulls.
+#   - `IMAGE_TAG=main`        — floating image of the `main` branch, rebuilt by CI on every push.
+#                                Needed for the v0.2.0 preview (risk scorer + decision adapter +
+#                                auto-responder) until v0.2.0 is tagged. See `docs/getting-started/quickstart.md`
+#                                Step 14 for context.
+#   - `IMAGE_TAG=main-<sha>`  — immutable per-commit reference (e.g. `main-a2e4a21`).
+#   - To build from source:    `sbt 'server / Docker / publishLocal'`
+#                              then `IMAGE_TAG=<sbt-dynver-string> docker compose ... up`.
 
 services:
   postgres:
@@ -43,7 +49,7 @@ services:
       retries:  10
 
   aegis-server:
-    image: ghcr.io/sharma-bhaskar/aegis-server:${IMAGE_TAG:-0.1.0}
+    image: ghcr.io/sharma-bhaskar/aegis-server:${IMAGE_TAG:-0.1.1}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,27 +196,52 @@ flowchart LR
     classDef sink     fill:#e76f51,stroke:#e76f51,color:#fff
 
     client[Client] --> plane["Plane terminator<br/>(REST · KMIP · MCP · Agent-AI)"]:::plane
-    plane --> audit["AuditingKeyService<br/><i>outermost — records every call</i>"]:::sink
+    plane --> audit["AuditingKeyService<br/><i>outermost — scores, decides, records</i>"]:::sink
     audit --> traced["TracingKeyService<br/><i>OTel span per op</i>"]:::metric
     traced --> metered["MeteredKeyService<br/><i>Prometheus counter + timer</i>"]:::metric
-    metered --> authz["AuthorizingKeyService<br/><i>policy engine gate</i>"]:::gate
+    metered --> authz["AuthorizingKeyService<br/><i>policy engine gate (floor)</i>"]:::gate
     authz --> svc["KeyService.&lt;op&gt;"]:::core
     svc --> actor["KeyOpsActor<br/><i>single-thread state owner</i>"]:::core
     actor --> journal[(Event journal)]:::sink
     actor --> rot[(Root of Trust<br/>AWS KMS adapter)]:::sink
+    audit -. score+factors .-> scorer["RiskScorer<br/><i>BaselineRiskScorer</i>"]:::metric
+    audit -. decide .-> engine["DecisionEngine<br/><i>ThresholdDecisionEngine</i>"]:::gate
     audit -. on every call .-> auditSink[(Audit sink<br/>stdout · SIEM · Kafka 🚧)]:::sink
+    auditSink -. tapped .-> detector["BaselineDetector<br/><i>5 detectors</i>"]:::metric
+    detector --> responder["AutoResponder<br/><i>matches rules → revoke / alert / freeze</i>"]:::gate
+    responder -. system-actor revoke .-> traced
 ```
+
+`AuditingKeyService` is the load-bearing decorator: on every call it (1) asks the optional
+`RiskScorer` for a `RiskScore(value, factors)`, (2) asks the optional `DecisionEngine` for an
+`Allow` / `StepUp` / `Deny` verdict, (3) stamps `risk.score`, `risk.factors`, `outcome.decision`
+into the audit row's `context`, (4) short-circuits the inner call on `Deny` (returns
+`PermissionDenied` with `"risk: …"` prefix) or `StepUp` (returns the new `StepUpRequired` error
+that the HTTP plane maps to `401 Unauthorized`), and (5) writes the audit record regardless of
+outcome. The boolean `AuthorizingKeyService` further inside is the **policy floor** — risk can
+only further restrict an action policy permits; it cannot widen one policy forbids.
+
+Every record written to the audit sink is also observed by the `BaselineDetector` (via
+`TappedAuditSink`), which may emit `AgentRecommendation` events. Those events flow into the
+`AutoResponder`, which persists them and — when a `Rule` matches and the per-(actor, action)
+cooldown allows — calls a *below-the-audit-decorator* `KeyService` (typically `Revoke`) under
+the `aegis-system` principal. The responder writes its own audit row directly to the sink, so
+operators can grep `principal=aegis-system` to see the auto-response timeline. The "below the
+audit decorator" routing is deliberate: feeding auto-response actions back through Auditing
+would re-trigger the detector and cause revoke recursion.
 
 For a `POST /v1/keys` over REST, the concrete steps are:
 
 1. `aegis-http` matches the route, generates a `request-id`, and parses the JSON body into a wire DTO.
 2. The DTO is validated and translated to the core domain (`KeySpec`); a parse failure short-circuits to `400 InvalidField` and `KeyService` is never called.
-3. IAM resolves the bearer token to a `Principal` and checks the `create_key` permission against policy.
-4. `KeyService.create(spec, principal)` runs. The state-changing event is persisted to the journal first; the audit event is emitted after the persist commits, so the audit log can never describe a key the journal doesn't have.
-5. If the audit sink is unavailable, the operation still commits and the actor records a `PendingAuditDelivery` event for a sweeper. The audit row is delivered late, never lost.
-6. The new `ManagedKey` is mapped back to a wire DTO (`ManagedKeyDto`) and returned with `201 Created`.
+3. IAM resolves the bearer token to a `Principal`.
+4. `AuditingKeyService` scores + decides. If `Deny` or `StepUp`, the request short-circuits before the inner call — but the audit row still lands.
+5. `AuthorizingKeyService` checks the `create_key` permission against the boolean policy floor.
+6. `KeyService.create(spec, principal)` runs. The state-changing event is persisted to the journal first; the audit event is emitted after the persist commits, so the audit log can never describe a key the journal doesn't have.
+7. If the audit sink is unavailable, the operation still commits and the actor records a `PendingAuditDelivery` event for a sweeper. The audit row is delivered late, never lost.
+8. The new `ManagedKey` is mapped back to a wire DTO (`ManagedKeyDto`) and returned with `201 Created`.
 
-KMIP, MCP, and Agent-AI flows differ only in steps 1, 2, and 6 — the framing layer. Steps 3–5 are identical for every plane.
+KMIP, MCP, and Agent-AI flows differ only in steps 1, 2, and 8 — the framing layer. Steps 3–7 are identical for every plane.
 
 ## 6. Audit and logging
 
@@ -386,6 +411,8 @@ What's implemented today vs. what the design above describes. This is the only p
 | IAM allowlist policy engine + recursive parent-check for agents | ✅ Shipped |
 | JWT bearer auth — `Authorization: Bearer`, HS256 verification + issuance | ✅ Shipped |
 | Audit decorator + stdout sink + W1 anomaly detector (BaselineDetector) | ✅ Shipped |
+| Risk scorer (W2) + decision adapter (Allow / StepUp / Deny) | ✅ Shipped on `main` (v0.2.0 in progress) |
+| Auto-responder (W3) — `AgentRecommendation` → revoke / alert / freeze | ✅ Shipped on `main` (v0.2.0 in progress) |
 | Operator CLI — `version`, `login`, `keys create/get/activate/destroy` | ✅ Shipped |
 | Scala SDK skeleton + Java SDK skeleton | ✅ Shipped (skeleton) |
 | Docker image (`ghcr.io/sharma-bhaskar/aegis-server`) + Maven Central jars | ✅ Shipped |
@@ -398,8 +425,8 @@ What's implemented today vs. what the design above describes. This is the only p
 | OIDC discovery + JWKS verification + RS256/ES256 verifier | 🔜 Designed (trait in place) |
 | Agent-token issuance HTTP endpoint (`POST /v1/agents/issue`) | 🔜 Designed (`JwtIssuer` in place) |
 | Postgres / Kafka / SIEM webhook audit sinks | 🔜 Designed (sink SPI in place) |
-| Risk scorer (W2) — numeric scores feeding access decisions | 🔜 Designed |
-| Auto-responder (W3) consuming `AgentRecommendation`s | 🔜 Designed |
+| Risk scorer (W2) — numeric scores feeding access decisions | ✅ Shipped (see v0.1.x table above) |
+| Auto-responder (W3) consuming `AgentRecommendation`s | ✅ Shipped (see v0.1.x table above) |
 | LLM advisor (W4) — `aegis advisor scan/explain` | 🔜 Designed (CLI stub in place) |
 | KMIP plane: TTLV codec, schema, operations, TLS server, multi-version | 🔜 Designed (skeleton module) |
 | MCP server with curated KMS tool surface | 🔜 Designed (skeleton module) |

--- a/docs/about/comparison.md
+++ b/docs/about/comparison.md
@@ -15,9 +15,11 @@ your decision matrix, not assume it.
 | **Per-call cost** | ~$0.03/10K calls | Self-host: free | Self-host: free | ~$0.03/10K calls | Self-host: free |
 | **Audit granularity** | Account-level (CloudTrail) | Configurable audit devices | Configurable audit devices | Cloud Audit Logs | Per-call agent-aware |
 | **Agent identity in audit** | No | Workload identity (not agent-aware) | Workload identity | No | First-class (`agent_id`, `session_id`, `tool_name`) |
+| **Risk-scored decisions** | No | No | No | No | `Allow` / `StepUp` / `Deny` from a [0,1] risk score with structured reasoning (v0.2.0) |
+| **Auto-response to anomalies** | CloudTrail → Lambda (DIY) | Audit device → external pipeline (DIY) | Audit device → external pipeline (DIY) | Cloud Audit → Pub/Sub (DIY) | First-class `AutoResponder` with default rules + cooldown (v0.2.0) |
 | **KMIP** | No | Enterprise only | Roadmap | No | Designed (v0.2.0) |
 | **MCP-native** | No | No | No | No | Designed (v0.2.0) |
-| **Policy engine** | AWS IAM | Vault HCL policies | Vault HCL policies | Cloud IAM | Designed (v0.3.0) |
+| **Policy engine** | AWS IAM | Vault HCL policies | Vault HCL policies | Cloud IAM | Boolean policy (v0.1.x) + risk overlay (v0.2.0); richer policies (v0.3.0) |
 | **HSM-backed** | CloudHSM | Enterprise only | Roadmap | Cloud HSM | Via AWS KMS RoT today |
 | **OSS contributors** | N/A | 200+ | 100+ | N/A | <5 |
 | **Best fit** | AWS-only shops | Multi-cloud secrets + KMS | Vault refugees on OSS | Cloud-native shops | AI/agent-heavy shops |

--- a/docs/about/status.md
+++ b/docs/about/status.md
@@ -6,8 +6,10 @@ trust at this stage.
 
 ## Release status
 
-**v0.1.1 — pre-alpha.** First public, taggable release. Production-stable backends, KMIP, MCP,
-and the auto-response loop are designed and roadmapped, not shipped.
+**v0.1.1 — pre-alpha (last tagged release). v0.2.0 in progress on `main`.** The W2 risk scorer,
+W2.b decision adapter, and W3 auto-responder all landed since v0.1.1 and are tested on `main`;
+they ship with the next tag. Production-stable backends, KMIP, and MCP remain designed and
+roadmapped, not shipped.
 
 | Status | What it means |
 |---|---|
@@ -48,7 +50,7 @@ and the auto-response loop are designed and roadmapped, not shipped.
 | Append-only audit log | :material-check: Shipped | `AuditingKeyService` decorator |
 | Audit fan-out to stdout | :material-check: Shipped | Default sink |
 | Audit fan-out: Kafka / S3 / Webhook / Postgres | :material-blueprint: Designed | SPI in place, adapters in v0.2.0 |
-| Agent-aware audit fields populated end-to-end | :material-progress-clock: MVP | Algebra carries them; HTTP layer doesn't yet populate `source.ip` |
+| Agent-aware audit fields (`risk.score`, `risk.factors`, `outcome.decision`) | :material-check: Shipped | Stamped on every record by `AuditingKeyService`. `source.ip` plumbing through the HTTP layer is still pending. |
 | Prometheus `/metrics` | :material-check: Shipped | Per-op counters, latency histograms, errors-by-code |
 | OpenTelemetry tracing (auto-configured SDK) | :material-check: Shipped | `kms.<op>` spans with attributes |
 | OpenAPI 3.1 spec + Swagger UI | :material-check: Shipped | At `/docs/` |
@@ -59,8 +61,9 @@ and the auto-response loop are designed and roadmapped, not shipped.
 |---|---|---|
 | `BaselineDetector` — 5 detectors | :material-check: Shipped | Scope, rate-spike, op-histogram, time-of-day, source-IP |
 | `AgentRecommendation` events | :material-check: Shipped | Emitted on detection |
-| Risk scorer | :material-progress-clock: WIP | v0.2.0 (PR W2) |
-| Auto-responder (allow/deny/revoke/rotate) | :material-progress-clock: WIP | v0.2.0 (PR W3) |
+| Risk scorer (`RiskScorer` SPI + `BaselineRiskScorer`) | :material-check: Shipped | 5 baseline factors + 4 contextual factors → `RiskScore(value, factors)` |
+| Decision adapter (`Allow` / `StepUp` / `Deny`) | :material-check: Shipped | `ThresholdDecisionEngine`, denyAt=0.85, stepUpAt=0.60, destructive-op offset 0.15 |
+| Auto-responder (revoke / deactivate / freeze / alert) | :material-check: Shipped | Default rules: 5 detectors × High → Revoke + Medium → Alert. Per-(actor, action) 60 s cooldown. |
 | LLM advisor | :material-blueprint: Designed | v0.4.0 (PR W4) |
 
 ### Persistence
@@ -88,7 +91,7 @@ and the auto-response loop are designed and roadmapped, not shipped.
 | REST `/v1/keys/*` | :material-check: Shipped | Full surface, OpenAPI documented |
 | KMIP server (TCP + TLS) | :material-blueprint: Designed | Skeleton in `aegis-kmip`; v0.2.0 lands the wire |
 | MCP server (LLM tool surface) | :material-blueprint: Designed | Skeleton in `aegis-mcp-server`; v0.2.0 |
-| Agent-AI plane | :material-progress-clock: MVP | Detector ships; auto-response in v0.2.0 |
+| Agent-AI plane | :material-check: Shipped | Detector + risk scorer + decision adapter + auto-responder all wired in `Server.boot` |
 
 ### Distribution & deployment
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,9 +1,17 @@
 # Quickstart
 
-**Goal:** in ~10 minutes, get Aegis-KMS running on your machine and exercise the full v0.1.x
+**Goal:** in ~15 minutes, get Aegis-KMS running on your machine and exercise the full v0.1.x
 operation surface — sign / verify, encrypt / decrypt (with AAD), wrap / unwrap a DEK, rotate, and
-compromise — plus the three observability surfaces (Swagger UI, Prometheus, OpenTelemetry). Step
-0 → Step 14, every command runnable, every output shown.
+compromise — plus the three observability surfaces (Swagger UI, Prometheus, OpenTelemetry), plus
+the **v0.2.0 preview**: switch to the `:main` Docker image, trip a rate-spike anomaly, and watch
+the auto-responder revoke the key in real time. Step 0 → Step 18, every command runnable, every
+output shown, every prerequisite spelled out — assume you've never touched this project before.
+
+**What you'll have when you're done:** a local Aegis-KMS instance, a key you created, a signed
+message + verified signature, an encrypted-and-decrypted payload, a wrapped DEK, a rotated key,
+a "compromised" key that refuses further use, a live audit log on stdout, a `/metrics` Prometheus
+endpoint, and a demonstration of Aegis's differentiator — risk-scored decisions and an auto-revoke
+when an actor exceeds their baseline.
 
 For a deeper tour covering CLI usage, JWT auth, and configuring AWS KMS as the Root of Trust, see
 the [full walkthrough](../USAGE.md) (~20 minutes).
@@ -417,7 +425,184 @@ container (`OTEL_TRACES_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://coll
 
 ---
 
-## Step 14 — Stop the server
+## Step 14 — Switch to the `:main` image (v0.2.0 preview)
+
+The features the wedge demo exercises — risk scorer, decision adapter, auto-responder — shipped to
+`main` after v0.1.1 and will land in the next tagged release. Until v0.2.0 is cut, you need the
+`:main` floating image (rebuilt by CI on every push to `main`).
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml down
+IMAGE_TAG=main docker compose -f deploy/docker/docker-compose.yml up -d
+docker compose -f deploy/docker/docker-compose.yml logs -f aegis-server
+```
+
+If you'd rather build from source than pull `:main`, that path is:
+
+```bash
+sbt 'server / Docker / publishLocal'
+IMAGE_TAG=0.1.1-SNAPSHOT docker compose -f deploy/docker/docker-compose.yml up -d
+```
+
+(Requires JDK 21 + `sbt` locally. Replace `0.1.1-SNAPSHOT` with whatever `sbt-dynver` reports if
+your `main` is ahead of the last tag.)
+
+Re-export your shell vars from Step 4 if you opened a new terminal:
+
+```bash
+export AEGIS=http://localhost:8080
+export USER_HEADER="X-Aegis-User: alice"
+```
+
+---
+
+## Step 15 — Trigger a rate-spike anomaly
+
+This is what makes Aegis-KMS different from AWS KMS or Vault: every request is **scored** against
+the actor's behavioural baseline, and the auto-responder can **revoke the key in real time** when
+the score crosses a threshold. You'll trip the `RateSpike` detector by signing 100 messages in 60
+seconds, then watch Aegis revoke the key on its own.
+
+First, create a fresh, activated key for the demo:
+
+```bash
+WEDGE_ID=$(curl -s -X POST "$AEGIS/v1/keys" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d '{"spec":{"name":"wedge-demo","algorithm":"RSA","sizeBits":2048,"objectType":"PrivateKey"}}' \
+  | jq -r '.id')
+curl -s -X POST "$AEGIS/v1/keys/$WEDGE_ID/activate" -H "$USER_HEADER" > /dev/null
+echo "WEDGE_ID=$WEDGE_ID — ready to fire"
+```
+
+Now sign 100 messages as fast as `curl` can issue them — this exceeds the default 30-requests-in-60s
+rate-spike threshold by 3×, which is the boundary at which the detector escalates to **High
+severity**:
+
+```bash
+MSG_B64=$(echo -n 'spike' | base64)
+
+for i in $(seq 1 100); do
+  curl -s -o /dev/null -X POST "$AEGIS/v1/keys/$WEDGE_ID/sign" \
+    -H "$USER_HEADER" -H "Content-Type: application/json" \
+    -d "{\"messageBase64\":\"$MSG_B64\",\"algorithm\":\"RsaPssSha256\"}"
+done
+echo "fired 100 sign requests"
+```
+
+Now look at your log-tail terminal. Scroll back through the burst and you'll see two new things
+in the audit rows that weren't there in Step 7:
+
+```
+{"ts":"...","actor":"alice","op":"Sign","keyId":"...","outcome":"Success",
+ "context":{
+   "risk.score":"0.13",
+   "risk.factors":"RateSpike:0.13"
+ }}
+```
+
+`risk.score` is the per-request risk roll-up in `[0.0, 1.0]`. `risk.factors` is the list of
+detectors that fired, each with its contribution. As you sign more messages in the window, the
+score climbs.
+
+---
+
+## Step 16 — Watch the auto-responder revoke the key
+
+Once the rate factor reaches 3× the threshold (≥ 90 requests in 60s), the `BaselineDetector`
+emits a `High` severity `RateSpike` recommendation, and the **AutoResponder** matches its default
+rule (`RateSpike + High → Revoke`) and revokes the key. Grep your log for the system-actor audit
+row:
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml logs aegis-server \
+  | grep '"principal":{"subject":"aegis-system"'
+```
+
+Expected output:
+
+```
+{"ts":"...","principal":{"subject":"aegis-system","kind":"Service"},
+ "operation":"Revoke","resource":"key:8a3f1e25-...",
+ "outcome":"AnomalyAlert(detector=RateSpike, severity=High, rec=<uuid>, action=Revoke) Success revoked key=8a3f1e25-...",
+ "context":{
+   "auto.response.rule":"RateSpike:High:Revoke",
+   "auto.response.actor":"alice",
+   "auto.response.recId":"<uuid>",
+   "auto.response.detectorMsg":"100 requests in 60s (threshold=30)"
+ }}
+```
+
+A few things to notice in this row:
+
+- `principal.subject = "aegis-system"` — Aegis revoked the key under its own identity, not under
+  yours. This is greppable for operators reviewing what the responder did.
+- `operation = "Revoke"` — the actual KMIP operation that was performed.
+- `outcome` starts with `AnomalyAlert(...)` — a structured marker SIEM systems can route on.
+- `context.auto.response.actor = "alice"` — the offending actor whose behaviour tripped the rule.
+- The whole row is in the same audit stream as your manual `Sign` calls, so a SIEM ingesting
+  Aegis's audit log sees the alert and the response in the same timeline.
+
+Try to sign once more with the now-revoked key:
+
+```bash
+curl -s -X POST "$AEGIS/v1/keys/$WEDGE_ID/sign" \
+  -H "$USER_HEADER" -H "Content-Type: application/json" \
+  -d "{\"messageBase64\":\"$MSG_B64\",\"algorithm\":\"RsaPssSha256\"}" | jq
+```
+
+Expected output:
+
+```json
+{ "error": "IllegalOperation", "message": "Key 8a3f1e25-... is Deactivated" }
+```
+
+That's the full wedge demo: behavioural baseline → risk score → decision → audit → auto-action,
+all in one local docker-compose stack, no external dependencies, no AI required.
+
+---
+
+## Step 17 — See the risk-decision behaviour directly
+
+You don't have to wait for a rate-spike to see the decision adapter at work. The decision
+adapter has two thresholds: requests scoring `≥ 0.60` get `StepUp` (HTTP 401) and requests
+scoring `≥ 0.85` get `Deny` (HTTP 403, error code `PermissionDenied` with a `"risk: …"` prefix
+in the message).
+
+Watch the Prometheus error counter increment for the auto-responder-driven denials:
+
+```bash
+curl -s http://localhost:8080/metrics | grep '^aegis_keys_op_errors_total'
+```
+
+Expected output (after running the wedge demo above):
+
+```
+aegis_keys_op_errors_total{operation="Sign",code="IllegalOperation"} 1.0
+aegis_keys_op_errors_total{operation="Sign",code="PermissionDenied"} 0.0
+```
+
+The `PermissionDenied` counter will be non-zero on this label once you exercise a request that
+the **decision adapter** (not the post-revoke `IllegalOperation`) blocks. Try a fresh actor on
+many fresh keys to score high without burst:
+
+```bash
+# Burst a different actor against many keys — trips ScopeBaseline + RateSpike together
+for i in $(seq 1 50); do
+  KID=$(curl -s -X POST "$AEGIS/v1/keys" \
+    -H "X-Aegis-User: stranger-$i" -H "Content-Type: application/json" \
+    -d "{\"spec\":{\"name\":\"k$i\",\"algorithm\":\"AES\",\"sizeBits\":256,\"objectType\":\"SymmetricKey\"}}" \
+    | jq -r '.id')
+  curl -s -X POST "$AEGIS/v1/keys/$KID/activate" -H "X-Aegis-User: stranger-$i" > /dev/null
+done
+curl -s http://localhost:8080/metrics | grep '^aegis_keys_op_errors_total'
+```
+
+The full Prometheus / OTel / metrics tour is in
+[Operations → Observability](../operations/observability.md).
+
+---
+
+## Step 18 — Stop the server
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml down
@@ -433,7 +618,7 @@ docker compose -f deploy/docker/docker-compose.yml down -v
 
 ## What you just did
 
-In ~10 minutes you:
+In ~15 minutes you:
 
 - Booted Aegis-KMS with a Postgres event journal
 - Created a key (in safe `PreActive` state by default)
@@ -444,10 +629,14 @@ In ~10 minutes you:
 - Rotated the key and confirmed the prior signature still validates
 - Marked the key as `Compromised` and saw every subsequent crypto op refuse
 - Opened the Swagger UI, scraped `/metrics`, watched audit rows on stdout in real time
+- **Tripped the `RateSpike` anomaly detector and watched Aegis auto-revoke the offending key —
+  the wedge demo that distinguishes Aegis from every role-centric KMS**
 
-Every operation was attributed to `alice` (the principal you passed via `X-Aegis-User`),
-recorded in the audit journal, exposed as a Prometheus metric on `/metrics`, and traced as
-an OpenTelemetry span (when an OTel exporter is wired in).
+Every operation was attributed to a principal (`alice`, `stranger-N`, or the system actor
+`aegis-system`), scored against a behavioural baseline, gated by the risk decision adapter,
+recorded in the audit journal with `risk.score` + `outcome.decision` context, exposed as a
+Prometheus metric on `/metrics`, and traced as an OpenTelemetry span (when an OTel exporter is
+wired in).
 
 ## Where to next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,12 +52,13 @@ GCP / Azure / Vault adapters in v0.2.0) and adds the four things role-centric KM
     Every decision, score, and detection lands in an immutable journal with full agent +
     parent attribution and full request context.
 
--   :material-flash:{ .lg .middle } **Real-time response** *(v0.2.0)*
+-   :material-flash:{ .lg .middle } **Real-time response**
 
     ---
 
-    Configurable wiring from detection to action: allow / step-up / deny / rotate / revoke /
-    alert, applied before the next request lands.
+    Risk scorer (`risk.score` + `risk.factors` on every audit row), decision adapter
+    (`Allow` / `StepUp` / `Deny`), and auto-responder (default High → `Revoke`) — all wired
+    end-to-end on `main`. Try it in the [wedge demo](getting-started/quickstart.md#step-15--trigger-a-rate-spike-anomaly).
 
 </div>
 
@@ -98,7 +99,10 @@ docker compose -f deploy/docker/docker-compose.yml up
 Server is now at `http://localhost:8080`. Swagger UI lives at `http://localhost:8080/docs/`.
 Full walkthrough → [Getting Started → Quickstart](getting-started/quickstart.md).
 
-## What ships in v0.1.1
+## What ships today
+
+This table reflects what's on `main` right now. v0.1.1 is the last released artifact; the rows
+marked "v0.2.0 in progress" are committed and tested on `main` and will land in the next tag.
 
 | Surface | Status |
 |---|---|
@@ -112,11 +116,14 @@ Full walkthrough → [Getting Started → Quickstart](getting-started/quickstart
 | OpenTelemetry tracing (auto-configured SDK) | :material-check: Shipped |
 | OpenAPI 3.1 spec + Swagger UI on `/docs/` | :material-check: Shipped |
 | `Resource[IO, Unit]` boot scope for graceful shutdown | :material-check: Shipped |
+| Risk scorer (`RiskScorer` SPI; baseline + contextual factors stamped on every audit row) | :material-check: Shipped (v0.2.0) |
+| Decision adapter (`Allow` / `StepUp` / `Deny`; HTTP 401 / 403 with reason) | :material-check: Shipped (v0.2.0) |
+| Auto-responder (default High → Revoke, Medium → Alert; configurable rules + 60 s cooldown) | :material-check: Shipped (v0.2.0) |
 | KMIP wire plane | :material-progress-clock: v0.2.0 |
 | MCP-native server | :material-progress-clock: v0.2.0 |
-| Agent-aware audit fields populated end-to-end | :material-progress-clock: v0.2.0 |
+| Agent-token issuance endpoint (`POST /v1/agents/issue`) + OIDC verifier | :material-progress-clock: v0.2.0 |
+| Source IP populated on audit records by the HTTP layer | :material-progress-clock: v0.2.0 |
 | GCP / Azure / Vault `RootOfTrust` adapters | :material-progress-clock: v0.2.0 |
-| Auto-response loop (revoke / step-up / rotate / alert) | :material-progress-clock: v0.2.0 |
 | SIEM / Kafka / Postgres audit fan-out | :material-progress-clock: v0.3.0 |
 | Helm chart, auto-rotation scheduler | :material-progress-clock: v0.3.0 |
 


### PR DESCRIPTION
## Summary
- Marks #15 / #16 / #17 ✅ across ROADMAP + 5 doc files.
- New CI workflow publishes `ghcr.io/$owner/aegis-server:main` on every push to `main` and an immutable `:main-<sha>`, so the wedge demo is not gated on the next `v*` tag.
- Bumps `docker-compose.yml` default tag `0.1.0` → `0.1.1`; documents the tag-selection matrix.
- Quickstart restructured from 14 to 18 steps:
  - Step 14 is now the image switch: `:0.1.1` → `:main` or local `sbt 'server / Docker / publishLocal'`.
  - Steps 15–17 are the wedge demo against the new code.
  - Step 18 stops the stack.

Fixes the "I ran the quickstart but the auto-revoke didn't fire" regression caused by the published image predating the W2/W3 code.

## Test plan
- [x] All doc files render with mkdocs material; no broken anchors after rename: `docs/index.md` link points at new `step-15` heading.
- [x] `docker-compose.yml` defaults still resolve: `0.1.1` exists on GHCR.
- [ ] After merge, push a touch to `modules/` to trigger the new workflow; verify `:main` lands on GHCR.
- [ ] Manual: `IMAGE_TAG=main docker compose up`, run quickstart Steps 14–17 end-to-end, confirm the `aegis-system` Revoke audit row appears.