### PR TITLE
fix(ci): install sbt in docker-main workflow

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -34,24 +34,26 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          # sbt-dynver derives the version from `git describe`; full history avoids the
+          # "fatal: no names found" warning that otherwise spams the build log.
+          fetch-depth: 0
 
-      - uses: actions/setup-java@v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: 21
+          # Built-in sbt-aware cache (sbt + ivy2 + coursier). Matches release.yml so both
+          # workflows share the same cache key shape.
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-main-${{ hashFiles('**/build.sbt', 'project/**') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-main-
-            ${{ runner.os }}-sbt-
+      - name: Set up sbt
+        # GitHub-hosted runners no longer ship sbt by default; without this step every
+        # `sbt …` invocation below would fail with `sbt: command not found` (which is
+        # exactly what the v1 of this workflow did on the merge of #69).
+        uses: sbt/setup-sbt@v1
 
       - name: Log in to GHCR
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
The `.github/workflows/docker-main.yml` workflow added in #69 fired on the merge but failed with `sbt: command not found`. GitHub-hosted runners don't ship sbt by default.

- Adds `sbt/setup-sbt@v1` step, the missing piece.
- Aligns with `release.yml` setup style: `checkout@v6` with `fetch-depth: 0`, and `cache: sbt` on `setup-java` instead of a standalone cache step.

## Test plan
- [ ] After merge, the workflow fires on the merge commit. Verify `:main` lands on GHCR at `ghcr.io/sharma-bhaskar/aegis-server:main`.
- [ ] `IMAGE_TAG=main docker compose -f deploy/docker/docker-compose.yml up`, then run quickstart Steps 14–17.


