### PR TITLE
feat(iam+http): POST /v1/agents/issue — agent-token issuance endpoint (closes #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ All notable changes to Aegis will be documented here. This project follows
   auth modes: `hmac` reuses `aegis.auth.hmac.secret`; `dev` mints a per-boot ephemeral 48-byte
   secret (logged with a warning so operators don't confuse dev tokens with production).
 
+- **`POST /v1/agents/issue` is audited.** Every call to the agent-issue endpoint — success
+  AND failure — now produces an `AuditRecord` written to the configured sink (operation =
+  `Create`, resource = `agent:<id>`, outcome carrying the agentId/jti/ttl/scopes). The JWT
+  itself is NEVER recorded in the audit row (it's a bearer credential; recording it in
+  plaintext would defeat its purpose). Test coverage asserts the JWT is absent from both
+  outcome and context. `HttpRoutes` gained an optional `auditSink: Option[AuditSink[IO]]`
+  constructor arg (no-op when not wired — the keys surface stays covered by
+  `AuditingKeyService`); `Server.boot` wires the same `stdoutSink` already used for the
+  keys-surface audit.
+
 - **`jti` (RFC 7519 token ID) on all Aegis-issued JWTs.** `JwtClaims.Human` and `JwtClaims.Agent`
   gained a required `jti: String` field; `JwtIssuer` sets the `jti` claim via `builder.id(...)`;
   `JwtVerifier` extracts it on parse (tolerating absent `jti` as empty string for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Agent-token issuance endpoint `POST /v1/agents/issue` (closes #18).** Exposes the existing
+  `JwtIssuer` over REST so operators (and the upcoming `aegis agent issue` CLI) can mint
+  short-lived agent JWTs programmatically. New `AgentTokenIssuer` in `aegis-iam` wraps the issuer
+  with three concerns the raw `JwtIssuer` doesn't carry: **authz** (only `Principal.Human` can
+  issue — `Service` and `Agent` callers are refused with `403 PermissionDenied`, enforcing the
+  "agents cannot issue agents" rule from the spec), **validation** (label must be non-empty,
+  scopes must parse as `Operation` names, TTL must be `> 0` and `≤ 24 h` by default), and
+  **identity generation** (`agentId = agent-<uuid>`, `jti = <uuid>`). Wire body:
+  `{label, scopes, ttlSeconds, parent?}` — when present, `parent` must equal the authenticated
+  caller's subject (cross-principal issuance is rejected in v0.2.0; delegated issuance lands with
+  a future release). Response: `{agentId, jwt, jti, expiresAt}`. The JWT carries the same claims
+  the verifier already understands (`kind=agent`, `aegis_parent`, `aegis_purpose`, `aegis_ops`)
+  plus a new `jti` claim for the future revocation list (#24). Wired into `Server.boot` for both
+  auth modes: `hmac` reuses `aegis.auth.hmac.secret`; `dev` mints a per-boot ephemeral 48-byte
+  secret (logged with a warning so operators don't confuse dev tokens with production).
+
+- **`jti` (RFC 7519 token ID) on all Aegis-issued JWTs.** `JwtClaims.Human` and `JwtClaims.Agent`
+  gained a required `jti: String` field; `JwtIssuer` sets the `jti` claim via `builder.id(...)`;
+  `JwtVerifier` extracts it on parse (tolerating absent `jti` as empty string for
+  backwards-compatibility with externally-minted tokens). The JTI blacklist consumer ships with
+  #24 (Redis-backed revocation list). 7 test sites updated to pass `jti` to the case-class
+  constructors.
+
 - **CI publishes `ghcr.io/<owner>/aegis-server:main` on every push to `main`.** New
   `.github/workflows/docker-main.yml` builds and publishes a floating `:main` image (and an
   immutable `:main-<short-sha>`) so the v0.2.0 wedge demo in the quickstart can be exercised

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -218,6 +218,43 @@ object Endpoints:
           "is recorded on the audit row."
       )
 
+  // ── Agent tokens ────────────────────────────────────────────────────────────
+
+  /** Common path + headers + error contract for the agent-management surface. The base differs from
+    * `keysBase` (path = `v1/agents`, tag = `"agents"`) so OpenAPI groups them cleanly in Swagger UI.
+    */
+  private val agentsBase =
+    endpoint
+      .in("v1" / "agents")
+      .in(authHeader)
+      .in(devUserHeader)
+      .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
+      .tag("agents")
+
+  /** `POST /v1/agents/issue` — issue a short-lived JWT for an AI agent acting under a human's authority.
+    * Caller must be a `Principal.Human` (Service and Agent callers are refused with 403).
+    *
+    * Request body: `{ label, scopes, ttlSeconds, parent? }` Response: `{ agentId, jwt, jti, expiresAt }`
+    */
+  val issueAgent: PublicEndpoint[
+    (Option[String], Option[String], IssueAgentRequestDto),
+    (StatusCode, KmsErrorDto),
+    IssueAgentResponseDto,
+    Any
+  ] =
+    agentsBase.post
+      .in("issue")
+      .in(jsonBody[IssueAgentRequestDto])
+      .out(statusCode(StatusCode.Created))
+      .out(jsonBody[IssueAgentResponseDto])
+      .summary("Issue an agent JWT")
+      .description(
+        "Mints a short-lived JWT carrying `kind=agent`, the caller's subject as parent, and the " +
+          "requested scopes (KMIP Operation names). Only humans can issue agents — service and agent " +
+          "principals are refused with 403. Maximum TTL is 24 hours (the agent credential lifetime is " +
+          "deliberately short because the only revocation mechanism is the JTI blacklist that lands in #24)."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -232,5 +269,6 @@ object Endpoints:
       wrapKey,
       unwrapKey,
       compromiseKey,
-      rotateKey
+      rotateKey,
+      issueAgent
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
-import dev.aegiskms.iam.PrincipalResolver
+import dev.aegiskms.iam.{AgentTokenIssuer, IssueAgentRequest as IamIssueAgentRequest, PrincipalResolver}
 import org.apache.pekko.http.scaladsl.server.Route
 import sttp.apispec.openapi.circe.yaml.*
 import sttp.model.StatusCode
@@ -30,7 +30,8 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 final class HttpRoutes(
     svc: KeyService[IO],
-    resolver: PrincipalResolver = PrincipalResolver.dev
+    resolver: PrincipalResolver = PrincipalResolver.dev,
+    agentIssuer: Option[AgentTokenIssuer] = None
 )(using runtime: IORuntime):
 
   private given ExecutionContext = runtime.compute
@@ -279,6 +280,49 @@ final class HttpRoutes(
                   }
     }
 
+  private val issueAgentSE: ServerEndpoint[Any, Future] =
+    Endpoints.issueAgent.serverLogic { case (auth, devHdr, body) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          agentIssuer match
+            case None =>
+              // The agent-issue endpoint is wired in the public OpenAPI surface unconditionally so
+              // clients always see it, but the implementation is opt-in (Server.boot wires it). When
+              // not wired, return 501 NotImplemented rather than crashing.
+              Future.successful(
+                Left(
+                  StatusCode.NotImplemented -> KmsErrorDto.of(
+                    ErrorCode.FeatureNotSupported,
+                    "agent-token issuance is not enabled on this server"
+                  )
+                )
+              )
+            case Some(issuer) =>
+              val domainReq = IamIssueAgentRequest(
+                label = body.label,
+                scopes = body.scopes,
+                ttl = scala.concurrent.duration.FiniteDuration(
+                  body.ttlSeconds,
+                  scala.concurrent.duration.SECONDS
+                ),
+                parent = body.parent,
+                callerSubject = Some(principal.subject)
+              )
+              runIO(issuer.issue(principal, domainReq)).map {
+                case Left(err) => Left(errorOut(err))
+                case Right(token) =>
+                  Right(
+                    IssueAgentResponseDto(
+                      agentId = token.agentId,
+                      jwt = token.jwt,
+                      jti = token.jti,
+                      expiresAt = token.expiresAt
+                    )
+                  )
+              }
+    }
+
   private def decodeSignRequest(
       req: SignRequest
   ): Either[(StatusCode, KmsErrorDto), (Array[Byte], SigAlgorithm)] =
@@ -325,7 +369,8 @@ final class HttpRoutes(
       wrapSE,
       unwrapSE,
       compromiseSE,
-      rotateSE
+      rotateSE,
+      issueAgentSE
     )
 
   /** Render the live endpoint set as an OpenAPI 3.1 document. The build-time guarantee here is the same one

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -6,8 +6,6 @@ import dev.aegiskms.audit.{AuditRecord, AuditSink}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
 import dev.aegiskms.iam.{AgentTokenIssuer, IssueAgentRequest as IamIssueAgentRequest, PrincipalResolver}
-
-import java.util.UUID
 import org.apache.pekko.http.scaladsl.server.Route
 import sttp.apispec.openapi.circe.yaml.*
 import sttp.model.StatusCode
@@ -16,6 +14,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.pekkohttp.PekkoHttpServerInterpreter
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 /** REST routes built on Tapir + pekko-http, backed by a `KeyService[IO]` from `aegis-core`.

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -2,9 +2,12 @@ package dev.aegiskms.http
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import dev.aegiskms.audit.{AuditRecord, AuditSink}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
 import dev.aegiskms.iam.{AgentTokenIssuer, IssueAgentRequest as IamIssueAgentRequest, PrincipalResolver}
+
+import java.util.UUID
 import org.apache.pekko.http.scaladsl.server.Route
 import sttp.apispec.openapi.circe.yaml.*
 import sttp.model.StatusCode
@@ -31,7 +34,13 @@ import scala.concurrent.{ExecutionContext, Future}
 final class HttpRoutes(
     svc: KeyService[IO],
     resolver: PrincipalResolver = PrincipalResolver.dev,
-    agentIssuer: Option[AgentTokenIssuer] = None
+    agentIssuer: Option[AgentTokenIssuer] = None,
+    /** Optional audit sink for non-`KeyService` endpoints. The keys surface is already audited by the
+      * `AuditingKeyService` decorator wrapped around `svc`; `/v1/agents/issue` (and any future non-keys
+      * endpoints) needs an explicit hookup because it bypasses that decorator. When `None`, agent issuances
+      * are not recorded — operators who care about forensics MUST wire this in production.
+      */
+    auditSink: Option[AuditSink[IO]] = None
 )(using runtime: IORuntime):
 
   private given ExecutionContext = runtime.compute
@@ -306,22 +315,73 @@ final class HttpRoutes(
                   body.ttlSeconds,
                   scala.concurrent.duration.SECONDS
                 ),
-                parent = body.parent,
-                callerSubject = Some(principal.subject)
+                parent = body.parent
               )
-              runIO(issuer.issue(principal, domainReq)).map {
-                case Left(err) => Left(errorOut(err))
-                case Right(token) =>
-                  Right(
-                    IssueAgentResponseDto(
-                      agentId = token.agentId,
-                      jwt = token.jwt,
-                      jti = token.jti,
-                      expiresAt = token.expiresAt
-                    )
+              val issueAndAudit: IO[Either[KmsError, IssueAgentResponseDto]] =
+                for
+                  result <- issuer.issue(principal, domainReq)
+                  _      <- writeAgentIssueAudit(principal, body, result)
+                yield result.map(token =>
+                  IssueAgentResponseDto(
+                    agentId = token.agentId,
+                    jwt = token.jwt,
+                    jti = token.jti,
+                    expiresAt = token.expiresAt
                   )
-              }
+                )
+              runIO(issueAndAudit).map(_.left.map(errorOut))
     }
+
+  /** Write one `AuditRecord` per `/v1/agents/issue` call — success OR failure — so operators have a forensic
+    * trail of every agent credential ever minted. The audit row captures the caller (the human who issued),
+    * the requested scopes + ttl + label (so reviewers can answer "what does this agent have access to"), and
+    * on success the `agentId` + `jti` (so a later auto-revoke or audit search can join back to the issuance).
+    * Bodies that *almost* contained a token never had one minted; their audit rows say "Failed code=...".
+    *
+    * The JWT itself is NEVER written — it's a bearer credential and recording it in plaintext defeats the
+    * purpose of having one.
+    *
+    * No-op when no sink is configured; the keys surface is already covered by `AuditingKeyService` so this
+    * method is only on the path for agent-issuance.
+    */
+  private def writeAgentIssueAudit(
+      caller: Principal,
+      body: IssueAgentRequestDto,
+      result: Either[KmsError, dev.aegiskms.iam.AgentToken]
+  ): IO[Unit] =
+    auditSink match
+      case None => IO.unit
+      case Some(sink) =>
+        for
+          now <- IO.realTimeInstant
+          corrId = UUID.randomUUID().toString
+          outcome = result match
+            case Right(token) =>
+              s"Success agentId=${token.agentId} jti=${token.jti} ttlSeconds=${body.ttlSeconds} scopes=${body.scopes.mkString(",")}"
+            case Left(err) =>
+              s"Failed code=${err.code} ttlSeconds=${body.ttlSeconds} scopes=${body.scopes.mkString(",")}"
+          record = AuditRecord(
+            at = now,
+            principal = caller,
+            // `Create` is the closest KMIP-aligned operation for "mint a new thing"; the audit
+            // row carries the agent-specific context in `outcome` + `context` so it's still
+            // distinguishable from a key Create.
+            operation = Operation.Create,
+            resource = result.toOption
+              .map(t => s"agent:${t.agentId}")
+              .getOrElse(s"agent:label=${body.label}"),
+            outcome = outcome,
+            correlationId = corrId,
+            context = Map(
+              "agent.issue.label"      -> body.label,
+              "agent.issue.scopes"     -> body.scopes.mkString(","),
+              "agent.issue.ttlSeconds" -> body.ttlSeconds.toString
+            ) ++ result.toOption
+              .map(t => Map("agent.id" -> t.agentId, "agent.jti" -> t.jti))
+              .getOrElse(Map.empty)
+          )
+          _ <- sink.write(record)
+        yield ()
 
   private def decodeSignRequest(
       req: SignRequest

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -180,3 +180,41 @@ object JsonCodecs:
   object RotateRequest:
     given Encoder[RotateRequest] = deriveEncoder
     given Decoder[RotateRequest] = deriveDecoder
+
+  // ── Agent issuance DTOs (#18) ──────────────────────────────────────────────
+
+  /** Wire body for `POST /v1/agents/issue`.
+    *
+    *   - `label` — human-readable purpose ("claude-invoice-batch-q2"). Persisted as the agent's `purpose`
+    *     claim and shown in audit rows. Required, non-empty.
+    *   - `scopes` — KMIP `Operation` names the agent is permitted to call (e.g. `["Sign", "Get"]`). Required,
+    *     non-empty. Any name that doesn't resolve to an `Operation` rejects the request with `400
+    *     InvalidField`.
+    *   - `ttlSeconds` — token lifetime. Must be `> 0` and `≤ 86400` (24 h cap).
+    *   - `parent` — optional. When present, must equal the authenticated caller's subject; cross-principal
+    *     issuance is rejected in v0.2.0. The field exists so callers can be explicit about who they're
+    *     issuing on behalf of (and so future delegated-issuance can reuse the wire shape).
+    */
+  final case class IssueAgentRequestDto(
+      label: String,
+      scopes: List[String],
+      ttlSeconds: Long,
+      parent: Option[String] = None
+  )
+  object IssueAgentRequestDto:
+    given Encoder[IssueAgentRequestDto] = deriveEncoder
+    given Decoder[IssueAgentRequestDto] = deriveDecoder
+
+  /** Wire response for `POST /v1/agents/issue`. The JWT is the bearer the agent presents on every subsequent
+    * call; `agentId` is the same string that appears in the audit log as the agent's subject; `jti` is the
+    * JWT ID, recorded for the future revocation list (#24).
+    */
+  final case class IssueAgentResponseDto(
+      agentId: String,
+      jwt: String,
+      jti: String,
+      expiresAt: Instant
+  )
+  object IssueAgentResponseDto:
+    given Encoder[IssueAgentResponseDto] = deriveEncoder
+    given Decoder[IssueAgentResponseDto] = deriveDecoder

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
@@ -1,0 +1,117 @@
+package dev.aegiskms.http
+
+import cats.effect.unsafe.IORuntime
+import dev.aegiskms.core.KeyService
+import dev.aegiskms.iam.{AgentTokenIssuer, JwtIssuer}
+import io.circe.parser.parse
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** End-to-end HTTP tests for `POST /v1/agents/issue` (#18). Exercises the full path:
+  *   - Dev-mode `X-Aegis-User` resolution → Human principal
+  *   - Validation (body shape, scopes, ttl)
+  *   - Successful issuance + the response shape clients see
+  *   - 501 Not Implemented when no issuer is wired
+  */
+final class HttpRoutesAgentIssueSpec extends AnyFunSuite with Matchers with ScalatestRouteTest:
+
+  private given IORuntime = IORuntime.global
+
+  // 32+ bytes for HS256. Same secret on issuer + verifier so issued tokens validate.
+  private val secret      = "test-secret-test-secret-test-secret-12345"
+  private val agentIssuer = new AgentTokenIssuer(JwtIssuer.hmac(secret))
+
+  private def routeWithIssuer(): Route =
+    HttpRoutes(KeyService.inMemory.unsafeRunSync(), agentIssuer = Some(agentIssuer)).routes
+
+  private def routeWithoutIssuer(): Route =
+    HttpRoutes(KeyService.inMemory.unsafeRunSync()).routes // agentIssuer defaults to None
+
+  private def jsonEntity(body: String): RequestEntity =
+    HttpEntity(ContentTypes.`application/json`, body)
+
+  private val happyBody =
+    """{"label":"claude-invoice-batch-q2","scopes":["Sign","Get"],"ttlSeconds":3600}"""
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  test("POST /v1/agents/issue returns 201 with agentId, jwt, jti, expiresAt") {
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.Created
+      val json = parse(responseAs[String]).toOption.get.hcursor
+      json.downField("agentId").as[String].toOption.get should startWith("agent-")
+      json.downField("jwt").as[String].toOption.get should not be empty
+      json.downField("jti").as[String].toOption.get should not be empty
+      json.downField("expiresAt").as[String].toOption.get should not be empty
+    }
+  }
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  test("missing label is rejected with 400 InvalidField") {
+    val bad = """{"label":"","scopes":["Get"],"ttlSeconds":3600}"""
+    val req = Post("/v1/agents/issue", jsonEntity(bad))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include(""""code":"InvalidField"""")
+      responseAs[String] should include("label")
+    }
+  }
+
+  test("empty scopes are rejected with 400 InvalidField") {
+    val bad = """{"label":"x","scopes":[],"ttlSeconds":3600}"""
+    val req = Post("/v1/agents/issue", jsonEntity(bad))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include("scopes")
+    }
+  }
+
+  test("zero ttlSeconds is rejected with 400 InvalidField") {
+    val bad = """{"label":"x","scopes":["Get"],"ttlSeconds":0}"""
+    val req = Post("/v1/agents/issue", jsonEntity(bad))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include("ttl")
+    }
+  }
+
+  test("unknown operation in scopes is rejected with 400 InvalidField") {
+    val bad = """{"label":"x","scopes":["Sign","NotARealOp"],"ttlSeconds":3600}"""
+    val req = Post("/v1/agents/issue", jsonEntity(bad))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include("NotARealOp")
+    }
+  }
+
+  // ── Authn / authz ─────────────────────────────────────────────────────────
+
+  test("missing X-Aegis-User in dev mode falls back to anonymous Human, who can still issue") {
+    // Dev-mode resolver creates a `Principal.Human("anonymous", Set.empty)` when no header is set.
+    // Since Humans can issue agents (per the spec), this is permitted — operators who care about
+    // attribution must configure JWT auth, where the verifier rejects missing tokens.
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.Created
+    }
+  }
+
+  test("no agent-issuer wired in → 501 NotImplemented with FeatureNotSupported") {
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithoutIssuer() ~> check {
+      status shouldBe StatusCodes.NotImplemented
+      responseAs[String] should include(""""code":"FeatureNotSupported"""")
+    }
+  }

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
@@ -1,8 +1,13 @@
 package dev.aegiskms.http
 
 import cats.effect.unsafe.IORuntime
-import dev.aegiskms.core.KeyService
-import dev.aegiskms.iam.{AgentTokenIssuer, JwtIssuer}
+import dev.aegiskms.audit.InMemoryAuditSink
+import dev.aegiskms.core.{KeyService, Operation, Principal}
+import dev.aegiskms.iam.{AgentTokenIssuer, JwtClaims, JwtIssuer, JwtVerifier, PrincipalResolver}
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
 import io.circe.parser.parse
 import org.apache.pekko.http.scaladsl.model.*
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
@@ -24,12 +29,55 @@ final class HttpRoutesAgentIssueSpec extends AnyFunSuite with Matchers with Scal
   // 32+ bytes for HS256. Same secret on issuer + verifier so issued tokens validate.
   private val secret      = "test-secret-test-secret-test-secret-12345"
   private val agentIssuer = new AgentTokenIssuer(JwtIssuer.hmac(secret))
+  private val verifier    = JwtVerifier.hmac(secret)
 
   private def routeWithIssuer(): Route =
     HttpRoutes(KeyService.inMemory.unsafeRunSync(), agentIssuer = Some(agentIssuer)).routes
 
+  private def routeWithIssuerAndSink(): (Route, InMemoryAuditSink) =
+    val sink = InMemoryAuditSink.make.unsafeRunSync()
+    val routes = HttpRoutes(
+      KeyService.inMemory.unsafeRunSync(),
+      agentIssuer = Some(agentIssuer),
+      auditSink = Some(sink)
+    ).routes
+    (routes, sink)
+
+  /** Routes wired with a JWT principal resolver (production-shape auth) — exercises the path where
+    * `/agents/issue` runs with a real Bearer token instead of a dev `X-Aegis-User` header.
+    */
+  private def routeWithJwtAuth(): Route =
+    HttpRoutes(
+      KeyService.inMemory.unsafeRunSync(),
+      resolver = PrincipalResolver.jwt(verifier),
+      agentIssuer = Some(agentIssuer)
+    ).routes
+
   private def routeWithoutIssuer(): Route =
     HttpRoutes(KeyService.inMemory.unsafeRunSync()).routes // agentIssuer defaults to None
+
+  /** Mint a Human JWT for the JWT-mode auth tests. */
+  private def humanToken(subject: String, groups: Set[String] = Set.empty): String =
+    val now = Instant.now()
+    JwtIssuer.hmac(secret).issue(
+      JwtClaims.Human(subject, None, now, now.plus(1, ChronoUnit.HOURS), groups, UUID.randomUUID().toString)
+    )
+
+  /** Mint an Agent JWT — used to assert that an agent caller CANNOT use /agents/issue. */
+  private def agentToken(subject: String, parent: String): String =
+    val now = Instant.now()
+    JwtIssuer.hmac(secret).issue(
+      JwtClaims.Agent(
+        subject = subject,
+        issuer = None,
+        issuedAt = now,
+        expiresAt = now.plus(1, ChronoUnit.HOURS),
+        parentSubject = parent,
+        purpose = "test",
+        allowedOps = Set("Get"),
+        jti = UUID.randomUUID().toString
+      )
+    )
 
   private def jsonEntity(body: String): RequestEntity =
     HttpEntity(ContentTypes.`application/json`, body)
@@ -97,13 +145,58 @@ final class HttpRoutesAgentIssueSpec extends AnyFunSuite with Matchers with Scal
 
   // ── Authn / authz ─────────────────────────────────────────────────────────
 
-  test("missing X-Aegis-User in dev mode falls back to anonymous Human, who can still issue") {
-    // Dev-mode resolver creates a `Principal.Human("anonymous", Set.empty)` when no header is set.
-    // Since Humans can issue agents (per the spec), this is permitted — operators who care about
-    // attribution must configure JWT auth, where the verifier rejects missing tokens.
+  test("the returned JWT round-trips through the verifier with the expected agent claims") {
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("X-Aegis-User", "alice@org"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.Created
+      val json    = parse(responseAs[String]).toOption.get.hcursor
+      val agentId = json.downField("agentId").as[String].toOption.get
+      val jwt     = json.downField("jwt").as[String].toOption.get
+      val jti     = json.downField("jti").as[String].toOption.get
+
+      val claims = verifier.verify(jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+      claims.subject shouldBe agentId
+      claims.parentSubject shouldBe "alice@org"
+      claims.purpose shouldBe "claude-invoice-batch-q2"
+      claims.allowedOps shouldBe Set("Sign", "Get")
+      claims.jti shouldBe jti
+    }
+  }
+
+  test("parent in body that doesn't match caller is rejected with 400") {
+    val crossPrincipal =
+      """{"label":"x","scopes":["Get"],"ttlSeconds":3600,"parent":"bob@org"}"""
+    val req = Post("/v1/agents/issue", jsonEntity(crossPrincipal))
+      .withHeaders(RawHeader("X-Aegis-User", "alice@org"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include("cross-principal")
+    }
+  }
+
+  test("TTL above the 24h default cap is rejected with 400") {
+    val tooLong = """{"label":"x","scopes":["Get"],"ttlSeconds":172800}""" // 48h
+    val req = Post("/v1/agents/issue", jsonEntity(tooLong))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] should include("exceeds maximum")
+    }
+  }
+
+  test("dev-mode anonymous caller (no X-Aegis-User) is accepted — dev is permissive by design") {
+    // The dev resolver maps a missing header to `Principal.Human("anonymous", Set.empty)`. Since
+    // humans can issue agents, this works in dev — but the issued token's parent claim is the
+    // useless `"anonymous"` subject. This is acceptable for dev (where the whole resolver is
+    // explicitly "do not expose to a network you don't control"); production deployments must use
+    // JWT auth, where the verifier rejects missing tokens at the boundary instead.
     val req = Post("/v1/agents/issue", jsonEntity(happyBody))
     req ~> routeWithIssuer() ~> check {
       status shouldBe StatusCodes.Created
+      val jwt    = parse(responseAs[String]).toOption.get.hcursor.downField("jwt").as[String].toOption.get
+      val claims = verifier.verify(jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+      claims.parentSubject shouldBe "anonymous"
     }
   }
 
@@ -113,5 +206,128 @@ final class HttpRoutesAgentIssueSpec extends AnyFunSuite with Matchers with Scal
     req ~> routeWithoutIssuer() ~> check {
       status shouldBe StatusCodes.NotImplemented
       responseAs[String] should include(""""code":"FeatureNotSupported"""")
+    }
+  }
+
+  // ── Audit logging on issuance ─────────────────────────────────────────────
+
+  test("successful issuance writes an audit record with agentId + jti context") {
+    val (route, sink) = routeWithIssuerAndSink()
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("X-Aegis-User", "alice@org"))
+    req ~> route ~> check {
+      status shouldBe StatusCodes.Created
+
+      val records = sink.all.unsafeRunSync()
+      records.size shouldBe 1
+      val record = records.head
+      // Dev resolver adds groups = Set("admins") for any X-Aegis-User principal. We assert on the
+      // subject specifically so this test isn't coupled to dev-resolver internals.
+      record.principal shouldBe a[Principal.Human]
+      record.principal.subject shouldBe "alice@org"
+      record.operation shouldBe Operation.Create
+      record.resource should startWith("agent:agent-")
+      record.outcome should startWith("Success agentId=agent-")
+      record.outcome should include("scopes=Sign,Get")
+      record.outcome should include("ttlSeconds=3600")
+      record.context("agent.issue.label") shouldBe "claude-invoice-batch-q2"
+      record.context("agent.issue.scopes") shouldBe "Sign,Get"
+      record.context("agent.issue.ttlSeconds") shouldBe "3600"
+      record.context("agent.id") should startWith("agent-")
+      record.context("agent.jti") should not be empty
+
+      // Critically, the JWT itself MUST NOT appear in the audit log — recording a bearer credential
+      // in plaintext defeats the purpose of having one.
+      record.outcome should not include "ey" // JWTs start with "eyJ..."
+      record.context.values.foreach { v =>
+        // Sanity: no audit-context value should be a JWT-like string.
+        v should not startWith "eyJ"
+      }
+    }
+  }
+
+  test("failed issuance (validation error) still writes an audit record with Failed outcome") {
+    val (route, sink) = routeWithIssuerAndSink()
+    val bad           = """{"label":"x","scopes":[],"ttlSeconds":3600}"""
+    val req = Post("/v1/agents/issue", jsonEntity(bad))
+      .withHeaders(RawHeader("X-Aegis-User", "alice@org"))
+    req ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+
+      val record = sink.all.unsafeRunSync().head
+      record.outcome should startWith("Failed code=InvalidField")
+      record.outcome should include("ttlSeconds=3600")
+      record.context("agent.issue.label") shouldBe "x"
+      record.context.contains("agent.id") shouldBe false // never minted
+      record.context.contains("agent.jti") shouldBe false
+    }
+  }
+
+  // ── Codec / malformed-JSON paths ──────────────────────────────────────────
+
+  test("missing required `label` field is rejected by the codec with 400") {
+    val noLabel = """{"scopes":["Get"],"ttlSeconds":3600}"""
+    val req = Post("/v1/agents/issue", jsonEntity(noLabel))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  test("wrong type for ttlSeconds (string) is rejected by the codec with 400") {
+    val wrongType = """{"label":"x","scopes":["Get"],"ttlSeconds":"not-a-number"}"""
+    val req = Post("/v1/agents/issue", jsonEntity(wrongType))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  test("malformed JSON (unclosed brace) is rejected with 400") {
+    val malformed = """{"label":"x","scopes":["Get"],"ttlSeconds":3600"""
+    val req = Post("/v1/agents/issue", jsonEntity(malformed))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  test("empty JSON body is rejected with 400") {
+    val req = Post("/v1/agents/issue", jsonEntity("{}"))
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithIssuer() ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  // ── JWT-mode authn ────────────────────────────────────────────────────────
+
+  test("JWT-mode: Human caller with a Bearer token successfully issues an agent token") {
+    val token = humanToken("alice@org", Set("admins"))
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("Authorization", s"Bearer $token"))
+    req ~> routeWithJwtAuth() ~> check {
+      status shouldBe StatusCodes.Created
+      val claims = verifier.verify(
+        parse(responseAs[String]).toOption.get.hcursor.downField("jwt").as[String].toOption.get
+      ).toOption.get.asInstanceOf[JwtClaims.Agent]
+      claims.parentSubject shouldBe "alice@org"
+    }
+  }
+
+  test("JWT-mode: Agent caller with a Bearer token is refused with 403 (agents cannot issue agents)") {
+    val token = agentToken("agent-7a3", parent = "alice@org")
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+      .withHeaders(RawHeader("Authorization", s"Bearer $token"))
+    req ~> routeWithJwtAuth() ~> check {
+      status shouldBe StatusCodes.Forbidden
+      responseAs[String] should include("agents cannot issue agents")
+    }
+  }
+
+  test("JWT-mode: missing Bearer header is refused with 401") {
+    val req = Post("/v1/agents/issue", jsonEntity(happyBody))
+    req ~> routeWithJwtAuth() ~> check {
+      status shouldBe StatusCodes.Unauthorized
     }
   }

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAgentIssueSpec.scala
@@ -4,10 +4,6 @@ import cats.effect.unsafe.IORuntime
 import dev.aegiskms.audit.InMemoryAuditSink
 import dev.aegiskms.core.{KeyService, Operation, Principal}
 import dev.aegiskms.iam.{AgentTokenIssuer, JwtClaims, JwtIssuer, JwtVerifier, PrincipalResolver}
-
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.UUID
 import io.circe.parser.parse
 import org.apache.pekko.http.scaladsl.model.*
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
@@ -15,6 +11,10 @@ import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 /** End-to-end HTTP tests for `POST /v1/agents/issue` (#18). Exercises the full path:
   *   - Dev-mode `X-Aegis-User` resolution → Human principal

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesJwtSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesJwtSpec.scala
@@ -40,7 +40,14 @@ final class HttpRoutesJwtSpec extends AnyFunSuite with Matchers with ScalatestRo
 
   private def humanToken(subject: String, groups: Set[String] = Set("admins")): String =
     val now = Instant.now()
-    issuer.issue(JwtClaims.Human(subject, None, now, now.plus(1, ChronoUnit.HOURS), groups))
+    issuer.issue(JwtClaims.Human(
+      subject,
+      None,
+      now,
+      now.plus(1, ChronoUnit.HOURS),
+      groups,
+      java.util.UUID.randomUUID().toString
+    ))
 
   test("POST /v1/keys with a valid Bearer token succeeds (201)") {
     val token = humanToken("alice@org")
@@ -68,9 +75,16 @@ final class HttpRoutesJwtSpec extends AnyFunSuite with Matchers with ScalatestRo
   }
 
   test("POST /v1/keys with an expired token returns 401") {
-    val past   = Instant.now().minus(1, ChronoUnit.HOURS)
-    val claims = JwtClaims.Human("alice", None, past.minus(1, ChronoUnit.HOURS), past, Set("admins"))
-    val token  = issuer.issue(claims)
+    val past = Instant.now().minus(1, ChronoUnit.HOURS)
+    val claims = JwtClaims.Human(
+      "alice",
+      None,
+      past.minus(1, ChronoUnit.HOURS),
+      past,
+      Set("admins"),
+      java.util.UUID.randomUUID().toString
+    )
+    val token = issuer.issue(claims)
     val req = Post("/v1/keys", jsonEntity(createBody))
       .withHeaders(RawHeader("Authorization", s"Bearer $token"))
     req ~> jwtRoute() ~> check {
@@ -89,7 +103,14 @@ final class HttpRoutesJwtSpec extends AnyFunSuite with Matchers with ScalatestRo
   test("a token signed with a different secret is rejected") {
     val otherIssuer = JwtIssuer.hmac("a-different-32-byte-shared-secret-yo!")
     val now         = Instant.now()
-    val token       = otherIssuer.issue(JwtClaims.Human("alice", None, now, now.plusSeconds(60), Set.empty))
+    val token = otherIssuer.issue(JwtClaims.Human(
+      "alice",
+      None,
+      now,
+      now.plusSeconds(60),
+      Set.empty,
+      java.util.UUID.randomUUID().toString
+    ))
     val req = Post("/v1/keys", jsonEntity(createBody))
       .withHeaders(RawHeader("Authorization", s"Bearer $token"))
     req ~> jwtRoute() ~> check {

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AgentTokenIssuer.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AgentTokenIssuer.scala
@@ -1,0 +1,156 @@
+package dev.aegiskms.iam
+
+import cats.effect.IO
+import dev.aegiskms.core.*
+
+import java.time.{Duration, Instant}
+import java.util.UUID
+import scala.concurrent.duration.{DurationInt, FiniteDuration, HOURS}
+
+/** Domain-level service that turns an "issue an agent for this human" request into a signed JWT the agent can
+  * present on subsequent requests.
+  *
+  * Encapsulates four things the raw `JwtIssuer` doesn't:
+  *
+  *   1. **Authorization.** Only `Principal.Human` callers can issue agents. `Service` callers (the
+  *      `aegis-system` auto-responder included) and `Agent` callers are refused with `AccessDenied`. This is
+  *      the "agents cannot issue agents" rule from issue #18. 2. **Validation.** Scopes must parse as
+  *      `Operation` values; TTL must be positive and ≤ `maxTtl` (default 24 h — agent credentials are meant
+  *      to be short-lived). Empty `label` and empty scope set are rejected as `InvalidField`. 3. **Identity
+  *      generation.** The agent's subject (the `sub` JWT claim and the `Principal.Agent.subject` it'll carry
+  *      on every request) is a fresh `agent-<uuid>`. The `jti` is a separate UUID for revocation (#24). 4.
+  *      **JWT construction.** Builds the `JwtClaims.Agent` and signs it via the wrapped `JwtIssuer`. Returns
+  *      the agent id, the signed token, the jti, and the expiry instant in a single `AgentToken`.
+  *
+  * The issuer is stateless aside from the wrapped `JwtIssuer`'s key material; a singleton lives in
+  * `Server.boot` and is shared by every `POST /v1/agents/issue` request.
+  */
+final class AgentTokenIssuer(
+    issuer: JwtIssuer,
+    issuerName: Option[String] = None,
+    maxTtl: FiniteDuration = AgentTokenIssuer.DefaultMaxTtl,
+    now: IO[Instant] = IO.realTimeInstant
+):
+
+  import AgentTokenIssuer.*
+
+  def issue(
+      caller: Principal,
+      request: IssueAgentRequest
+  ): IO[Either[KmsError, AgentToken]] =
+    authorize(caller) match
+      case Left(err) => IO.pure(Left(err))
+      case Right(human) =>
+        validate(request) match
+          case Left(err) => IO.pure(Left(err))
+          case Right(req) =>
+            now.map { issuedAt =>
+              val expiresAt = issuedAt.plus(Duration.ofSeconds(req.ttl.toSeconds))
+              val agentId   = s"agent-${UUID.randomUUID()}"
+              val jti       = UUID.randomUUID().toString
+              val claims = JwtClaims.Agent(
+                subject = agentId,
+                issuer = issuerName,
+                issuedAt = issuedAt,
+                expiresAt = expiresAt,
+                parentSubject = human.subject,
+                purpose = req.label,
+                allowedOps = req.scopes.map(_.toString),
+                jti = jti
+              )
+              val jwt = issuer.issue(claims)
+              Right(AgentToken(agentId, jwt, jti, expiresAt))
+            }
+
+  private def authorize(caller: Principal): Either[KmsError, Principal.Human] =
+    caller match
+      case h: Principal.Human => Right(h)
+      case _: Principal.Service =>
+        Left(KmsError(ErrorCode.PermissionDenied, "service principals cannot issue agent tokens"))
+      case _: Principal.Agent =>
+        Left(KmsError(ErrorCode.PermissionDenied, "agents cannot issue agents"))
+
+  private def validate(req: IssueAgentRequest): Either[KmsError, ValidatedRequest] =
+    if req.label.trim.isEmpty then
+      Left(KmsError(ErrorCode.InvalidField, "label must be non-empty"))
+    else if req.scopes.isEmpty then
+      Left(KmsError(ErrorCode.InvalidField, "scopes must include at least one operation"))
+    else if req.ttl <= 0.nanos then
+      Left(KmsError(ErrorCode.InvalidField, "ttl must be positive"))
+    else if req.ttl > maxTtl then
+      Left(KmsError(
+        ErrorCode.InvalidField,
+        s"ttl ${req.ttl.toSeconds}s exceeds maximum ${maxTtl.toSeconds}s"
+      ))
+    else if req.parent.exists(_ != callerSubjectExpected(req)) && req.parent.nonEmpty then
+      // Caller specified a parent subject in the body; v0.2.0 requires it to match the caller.
+      // Cross-principal issuance (one human issues for another) lands when delegation is designed.
+      Left(KmsError(
+        ErrorCode.InvalidField,
+        "parent in the request body must match the authenticated caller (cross-principal issuance is not supported)"
+      ))
+    else
+      // Parse scopes into Operation values. Reject the request if any name doesn't resolve — better
+      // to fail loudly than silently mint a token with a typo'd op the verifier would later reject.
+      val parsedOps = req.scopes.foldLeft[Either[KmsError, List[Operation]]](Right(Nil)) {
+        case (acc @ Left(_), _) => acc
+        case (Right(ops), name) =>
+          Operation.values
+            .find(_.toString == name)
+            .toRight(KmsError(ErrorCode.InvalidField, s"unknown operation in scopes: '$name'"))
+            .map(op => ops :+ op)
+      }
+      parsedOps.map(ops => ValidatedRequest(req.label.trim, ops.toSet, req.ttl))
+
+  /** Caller-subject check helper. Used inside `validate` so the body-parent / caller-parent invariant stays a
+    * single readable expression. Returns the *expected* subject string — the actual value is compared against
+    * `req.parent`.
+    */
+  private def callerSubjectExpected(req: IssueAgentRequest): String =
+    req.callerSubject.getOrElse("")
+
+object AgentTokenIssuer:
+
+  /** Aegis-side cap on agent token lifetime. 24 hours by default — agent credentials should be short-lived
+    * because the JTI blacklist (#24) is the only revocation mechanism, and a 1-week agent token can do damage
+    * well beyond the operator's incident response window.
+    */
+  val DefaultMaxTtl: FiniteDuration = FiniteDuration(24L, HOURS)
+
+  /** Validated, parsed view of the request after `validate()` passes. */
+  final private case class ValidatedRequest(
+      label: String,
+      scopes: Set[Operation],
+      ttl: FiniteDuration
+  )
+
+/** Domain request for `AgentTokenIssuer.issue`. Independent of the HTTP DTO so non-HTTP planes (the CLI's
+  * `aegis agent issue`, the SDK, future MCP / KMIP plumbing) can call the issuer directly. The HTTP layer
+  * maps its wire body into this.
+  *
+  * `parent` is optional and, when set, must equal the authenticated caller's subject — the field exists so
+  * callers can be explicit about who they're issuing on behalf of, but cross-principal issuance (alice
+  * issuing an agent on behalf of bob) is rejected in v0.2.0 (a delegation model is roadmapped for a later
+  * release).
+  *
+  * `callerSubject` is internal-only — the issuer reads it inside `validate` to compare against `parent`. The
+  * HTTP layer fills it from the resolved principal before calling `issue()`. Field is package-private only by
+  * convention; refactor to a sealed factory later if needed.
+  */
+final case class IssueAgentRequest(
+    label: String,
+    scopes: List[String],
+    ttl: FiniteDuration,
+    parent: Option[String] = None,
+    callerSubject: Option[String] = None
+)
+
+/** Output of `AgentTokenIssuer.issue` — exactly the shape returned over the wire by `POST /v1/agents/issue`,
+  * but as a domain type so non-HTTP callers can use it directly.
+  */
+final case class AgentToken(
+    agentId: String,
+    jwt: String,
+    jti: String,
+    expiresAt: Instant
+)

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AgentTokenIssuer.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/AgentTokenIssuer.scala
@@ -38,29 +38,52 @@ final class AgentTokenIssuer(
       caller: Principal,
       request: IssueAgentRequest
   ): IO[Either[KmsError, AgentToken]] =
-    authorize(caller) match
+    val checks =
+      for
+        human <- authorize(caller)
+        _     <- checkParentMatchesCaller(request, human)
+        req   <- validate(request)
+      yield (human, req)
+
+    checks match
       case Left(err) => IO.pure(Left(err))
-      case Right(human) =>
-        validate(request) match
-          case Left(err) => IO.pure(Left(err))
-          case Right(req) =>
-            now.map { issuedAt =>
-              val expiresAt = issuedAt.plus(Duration.ofSeconds(req.ttl.toSeconds))
-              val agentId   = s"agent-${UUID.randomUUID()}"
-              val jti       = UUID.randomUUID().toString
-              val claims = JwtClaims.Agent(
-                subject = agentId,
-                issuer = issuerName,
-                issuedAt = issuedAt,
-                expiresAt = expiresAt,
-                parentSubject = human.subject,
-                purpose = req.label,
-                allowedOps = req.scopes.map(_.toString),
-                jti = jti
-              )
-              val jwt = issuer.issue(claims)
-              Right(AgentToken(agentId, jwt, jti, expiresAt))
-            }
+      case Right((human, req)) =>
+        now.map { issuedAt =>
+          val expiresAt = issuedAt.plus(Duration.ofSeconds(req.ttl.toSeconds))
+          val agentId   = s"agent-${UUID.randomUUID()}"
+          val jti       = UUID.randomUUID().toString
+          val claims = JwtClaims.Agent(
+            subject = agentId,
+            issuer = issuerName,
+            issuedAt = issuedAt,
+            expiresAt = expiresAt,
+            parentSubject = human.subject,
+            purpose = req.label,
+            allowedOps = req.scopes.map(_.toString),
+            jti = jti
+          )
+          val jwt = issuer.issue(claims)
+          Right(AgentToken(agentId, jwt, jti, expiresAt))
+        }
+
+  /** When the request body sets `parent`, it MUST equal the authenticated caller's subject. Cross-principal
+    * issuance (alice issuing an agent on behalf of bob) is rejected in v0.2.0 — a delegation model is
+    * roadmapped but not designed. Lives outside `validate()` so the caller's subject doesn't need to be
+    * threaded through the request type as a "look internally I'm a public field but please don't use me"
+    * footgun.
+    */
+  private def checkParentMatchesCaller(
+      req: IssueAgentRequest,
+      caller: Principal.Human
+  ): Either[KmsError, Unit] =
+    req.parent match
+      case None                           => Right(())
+      case Some(p) if p == caller.subject => Right(())
+      case Some(_) =>
+        Left(KmsError(
+          ErrorCode.InvalidField,
+          "parent in the request body must match the authenticated caller (cross-principal issuance is not supported)"
+        ))
 
   private def authorize(caller: Principal): Either[KmsError, Principal.Human] =
     caller match
@@ -71,10 +94,21 @@ final class AgentTokenIssuer(
         Left(KmsError(ErrorCode.PermissionDenied, "agents cannot issue agents"))
 
   private def validate(req: IssueAgentRequest): Either[KmsError, ValidatedRequest] =
-    if req.label.trim.isEmpty then
+    val trimmedLabel = req.label.trim
+    if trimmedLabel.isEmpty then
       Left(KmsError(ErrorCode.InvalidField, "label must be non-empty"))
+    else if trimmedLabel.length > MaxLabelLength then
+      Left(KmsError(
+        ErrorCode.InvalidField,
+        s"label length ${trimmedLabel.length} exceeds maximum $MaxLabelLength characters"
+      ))
     else if req.scopes.isEmpty then
       Left(KmsError(ErrorCode.InvalidField, "scopes must include at least one operation"))
+    else if req.scopes.size > MaxScopesSize then
+      Left(KmsError(
+        ErrorCode.InvalidField,
+        s"scopes size ${req.scopes.size} exceeds maximum $MaxScopesSize entries"
+      ))
     else if req.ttl <= 0.nanos then
       Left(KmsError(ErrorCode.InvalidField, "ttl must be positive"))
     else if req.ttl > maxTtl then
@@ -82,16 +116,11 @@ final class AgentTokenIssuer(
         ErrorCode.InvalidField,
         s"ttl ${req.ttl.toSeconds}s exceeds maximum ${maxTtl.toSeconds}s"
       ))
-    else if req.parent.exists(_ != callerSubjectExpected(req)) && req.parent.nonEmpty then
-      // Caller specified a parent subject in the body; v0.2.0 requires it to match the caller.
-      // Cross-principal issuance (one human issues for another) lands when delegation is designed.
-      Left(KmsError(
-        ErrorCode.InvalidField,
-        "parent in the request body must match the authenticated caller (cross-principal issuance is not supported)"
-      ))
     else
       // Parse scopes into Operation values. Reject the request if any name doesn't resolve — better
       // to fail loudly than silently mint a token with a typo'd op the verifier would later reject.
+      // Names are case-sensitive (Operation enum cases are PascalCase) — this is intentional; a
+      // case-insensitive lookup would mask client bugs where "sign" silently gets remapped to "Sign".
       val parsedOps = req.scopes.foldLeft[Either[KmsError, List[Operation]]](Right(Nil)) {
         case (acc @ Left(_), _) => acc
         case (Right(ops), name) =>
@@ -100,14 +129,7 @@ final class AgentTokenIssuer(
             .toRight(KmsError(ErrorCode.InvalidField, s"unknown operation in scopes: '$name'"))
             .map(op => ops :+ op)
       }
-      parsedOps.map(ops => ValidatedRequest(req.label.trim, ops.toSet, req.ttl))
-
-  /** Caller-subject check helper. Used inside `validate` so the body-parent / caller-parent invariant stays a
-    * single readable expression. Returns the *expected* subject string — the actual value is compared against
-    * `req.parent`.
-    */
-  private def callerSubjectExpected(req: IssueAgentRequest): String =
-    req.callerSubject.getOrElse("")
+      parsedOps.map(ops => ValidatedRequest(trimmedLabel, ops.toSet, req.ttl))
 
 object AgentTokenIssuer:
 
@@ -116,6 +138,17 @@ object AgentTokenIssuer:
     * well beyond the operator's incident response window.
     */
   val DefaultMaxTtl: FiniteDuration = FiniteDuration(24L, HOURS)
+
+  /** Length cap on the `label` (after trimming). 256 chars is generous for a human-readable purpose
+    * ("claude-invoice-batch-q2") while preventing operators from accidentally minting tokens that embed a 10
+    * MB string into the JWT body.
+    */
+  val MaxLabelLength: Int = 256
+
+  /** Size cap on the `scopes` list. The `Operation` enum has ~17 values; anything larger is either a
+    * malformed client or an attempt to enumerate. 32 is roomy with margin for future ops.
+    */
+  val MaxScopesSize: Int = 32
 
   /** Validated, parsed view of the request after `validate()` passes. */
   final private case class ValidatedRequest(
@@ -128,21 +161,15 @@ object AgentTokenIssuer:
   * `aegis agent issue`, the SDK, future MCP / KMIP plumbing) can call the issuer directly. The HTTP layer
   * maps its wire body into this.
   *
-  * `parent` is optional and, when set, must equal the authenticated caller's subject — the field exists so
-  * callers can be explicit about who they're issuing on behalf of, but cross-principal issuance (alice
-  * issuing an agent on behalf of bob) is rejected in v0.2.0 (a delegation model is roadmapped for a later
-  * release).
-  *
-  * `callerSubject` is internal-only — the issuer reads it inside `validate` to compare against `parent`. The
-  * HTTP layer fills it from the resolved principal before calling `issue()`. Field is package-private only by
-  * convention; refactor to a sealed factory later if needed.
+  * `parent` is optional and, when set, must equal the authenticated caller's subject (enforced by
+  * `AgentTokenIssuer.issue`, not by the request type). The field exists so callers can be explicit about who
+  * they're issuing on behalf of; cross-principal issuance is rejected in v0.2.0.
   */
 final case class IssueAgentRequest(
     label: String,
     scopes: List[String],
     ttl: FiniteDuration,
-    parent: Option[String] = None,
-    callerSubject: Option[String] = None
+    parent: Option[String] = None
 )
 
 /** Output of `AgentTokenIssuer.issue` — exactly the shape returned over the wire by `POST /v1/agents/issue`,

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtClaims.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtClaims.scala
@@ -4,13 +4,14 @@ import java.time.Instant
 
 /** Typed view of the claims encoded in an Aegis-issued JWS.
   *
-  * The wire format is plain JWT (`iat`/`exp`/`iss`/`sub` from RFC 7519 plus Aegis-namespaced custom claims
-  * prefixed `aegis_`). This sealed ADT discriminates Human vs Agent at the type level so downstream code
-  * cannot accidentally treat one as the other.
+  * The wire format is plain JWT (`jti`/`iat`/`exp`/`iss`/`sub` from RFC 7519 plus Aegis-namespaced custom
+  * claims prefixed `aegis_`). This sealed ADT discriminates Human vs Agent at the type level so downstream
+  * code cannot accidentally treat one as the other.
   *
   * Claim layout on the wire:
   * {{{
   *   {
+  *     "jti":   "9c4f5a72-…",            // RFC 7519, unique token id (for revocation, see #24)
   *     "sub":   "alice@org",            // RFC 7519
   *     "iss":   "https://aegis.local",  // RFC 7519, optional
   *     "iat":   1714400000,             // RFC 7519, seconds since epoch
@@ -23,6 +24,10 @@ import java.time.Instant
   *   }
   * }}}
   *
+  * `jti` is required so every issued token has a stable identifier for the JTI blacklist (#24) and for
+  * correlation in the audit log. Callers that don't care about jti can pass a fresh
+  * `UUID.randomUUID().toString`.
+  *
   * The `aegis_*` namespace is reserved so we don't trample on standard OIDC claims (`groups`, `roles`,
   * `scope`) when Aegis is fronted by a corporate IDP.
   */
@@ -31,6 +36,7 @@ sealed trait JwtClaims:
   def issuer: Option[String]
   def issuedAt: Instant
   def expiresAt: Instant
+  def jti: String
 
 object JwtClaims:
 
@@ -39,7 +45,8 @@ object JwtClaims:
       issuer: Option[String],
       issuedAt: Instant,
       expiresAt: Instant,
-      groups: Set[String]
+      groups: Set[String],
+      jti: String
   ) extends JwtClaims
 
   final case class Agent(
@@ -49,7 +56,8 @@ object JwtClaims:
       expiresAt: Instant,
       parentSubject: String,
       purpose: String,
-      allowedOps: Set[String]
+      allowedOps: Set[String],
+      jti: String
   ) extends JwtClaims
 
   /** Custom-claim names. Constants so the verifier and the issuer stay in lockstep. */

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtIssuer.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtIssuer.scala
@@ -34,6 +34,7 @@ object JwtIssuer:
     def issue(claims: JwtClaims): String =
       val builder = Jwts
         .builder()
+        .id(claims.jti)
         .subject(claims.subject)
         .issuedAt(Date.from(claims.issuedAt))
         .expiration(Date.from(claims.expiresAt))

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtVerifier.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtVerifier.scala
@@ -60,13 +60,18 @@ object JwtVerifier:
     val issuer   = Option(claims.getIssuer)
     val issuedAt = Option(claims.getIssuedAt).map(_.toInstant).getOrElse(Instant.EPOCH)
     val expires  = Option(claims.getExpiration).map(_.toInstant).getOrElse(Instant.EPOCH)
+    // `jti` is conceptually required for every Aegis-issued token (see JwtClaims docs), but the
+    // verifier accepts tokens without it by falling back to an empty string — older externally-minted
+    // tokens that pre-date the jti rollout still need to validate. The JTI blacklist (#24) will treat
+    // an empty jti as "no blacklist match" rather than refusing the request.
+    val jti = Option(claims.getId).getOrElse("")
 
     if subject.isEmpty then Left(JwtError.InvalidClaims("missing required claim: sub"))
     else
       Option(claims.get(JwtClaims.Claim.Kind, classOf[String])) match
         case Some(JwtClaims.Claim.KindHuman) =>
           val groups = stringList(claims, JwtClaims.Claim.Groups).toSet
-          Right(JwtClaims.Human(subject, issuer, issuedAt, expires, groups))
+          Right(JwtClaims.Human(subject, issuer, issuedAt, expires, groups, jti))
         case Some(JwtClaims.Claim.KindAgent) =>
           for
             parent  <- requiredString(claims, JwtClaims.Claim.ParentSubject)
@@ -78,7 +83,8 @@ object JwtVerifier:
             expiresAt = expires,
             parentSubject = parent,
             purpose = purpose,
-            allowedOps = stringList(claims, JwtClaims.Claim.AllowedOps).toSet
+            allowedOps = stringList(claims, JwtClaims.Claim.AllowedOps).toSet,
+            jti = jti
           )
         case Some(other) =>
           Left(JwtError.InvalidClaims(s"unknown ${JwtClaims.Claim.Kind}=$other"))

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AgentTokenIssuerSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AgentTokenIssuerSpec.scala
@@ -131,23 +131,98 @@ final class AgentTokenIssuerSpec extends AnyFunSuite with Matchers:
   }
 
   test("parent in the body matching the caller is accepted") {
-    val req = IssueAgentRequest(
-      "x",
-      List("Get"),
-      1.hour,
-      parent = Some("alice@org"),
-      callerSubject = Some("alice@org")
-    )
+    val req = IssueAgentRequest("x", List("Get"), 1.hour, parent = Some("alice@org"))
     val res = issuer().issue(alice, req).unsafeRunSync()
     res.isRight shouldBe true
   }
 
   test("parent in the body not matching the caller is rejected") {
-    val req =
-      IssueAgentRequest("x", List("Get"), 1.hour, parent = Some("bob@org"), callerSubject = Some("alice@org"))
+    val req = IssueAgentRequest("x", List("Get"), 1.hour, parent = Some("bob@org"))
     val res = issuer().issue(alice, req).unsafeRunSync()
     res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
     res.left.toOption.get.message should include("cross-principal")
+  }
+
+  test("parent absent in the body defaults to the caller subject in the issued claims") {
+    val req = IssueAgentRequest("x", List("Get"), 1.hour, parent = None)
+    val res = issuer().issue(alice, req).unsafeRunSync()
+    res.isRight shouldBe true
+    val claims = verifier.verify(res.toOption.get.jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+    claims.parentSubject shouldBe "alice@org"
+  }
+
+  // ── Validation: TTL edge cases ────────────────────────────────────────────
+
+  test("negative TTL is rejected with InvalidField") {
+    val res = issuer().issue(alice, IssueAgentRequest("x", List("Get"), -5.seconds)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("ttl")
+  }
+
+  // ── Validation: length caps ───────────────────────────────────────────────
+
+  test("label exceeding MaxLabelLength is rejected with InvalidField") {
+    val longLabel = "a" * (AgentTokenIssuer.MaxLabelLength + 1)
+    val res       = issuer().issue(alice, IssueAgentRequest(longLabel, List("Get"), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("label length")
+  }
+
+  test("label exactly at MaxLabelLength is accepted (boundary check)") {
+    val boundary = "a" * AgentTokenIssuer.MaxLabelLength
+    val res      = issuer().issue(alice, IssueAgentRequest(boundary, List("Get"), 1.hour)).unsafeRunSync()
+    res.isRight shouldBe true
+  }
+
+  test("scopes exceeding MaxScopesSize is rejected with InvalidField") {
+    val tooMany = List.fill(AgentTokenIssuer.MaxScopesSize + 1)("Get")
+    val res     = issuer().issue(alice, IssueAgentRequest("x", tooMany, 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("scopes size")
+  }
+
+  test("scopes count exactly at MaxScopesSize is accepted (boundary check)") {
+    // All "Get" — dedupe collapses to Set("Get"), but the SIZE check runs against the input list,
+    // not the deduped set, so this exercises the boundary in validate() before dedup happens.
+    val atCap = List.fill(AgentTokenIssuer.MaxScopesSize)("Get")
+    val res   = issuer().issue(alice, IssueAgentRequest("x", atCap, 1.hour)).unsafeRunSync()
+    res.isRight shouldBe true
+  }
+
+  test("TTL exactly equal to maxTtl is accepted (boundary check)") {
+    val res = issuer(maxTtl = 1.hour)
+      .issue(alice, IssueAgentRequest("x", List("Get"), 1.hour))
+      .unsafeRunSync()
+    res.isRight shouldBe true
+  }
+
+  test("empty-string scope name is rejected — covers the [\"Sign\", \"\"] typo path") {
+    val res = issuer().issue(alice, IssueAgentRequest("x", List("Sign", ""), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("unknown operation")
+  }
+
+  test("issuerName=None produces a token with no `iss` claim") {
+    val issuerNoName = new AgentTokenIssuer(signer, issuerName = None, now = IO.pure(fixedNow))
+    val token =
+      issuerNoName.issue(alice, IssueAgentRequest("x", List("Get"), 1.hour)).unsafeRunSync().toOption.get
+    val claims = verifier.verify(token.jwt).toOption.get
+    claims.issuer shouldBe None
+  }
+
+  // ── Validation: case sensitivity + dedup ──────────────────────────────────
+
+  test("scope names are case-sensitive — 'sign' (lowercase) is rejected") {
+    val res = issuer().issue(alice, IssueAgentRequest("x", List("sign"), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("'sign'")
+  }
+
+  test("duplicate scope names dedupe into a Set in the issued claims") {
+    val req    = IssueAgentRequest("x", List("Sign", "Sign", "Get"), 1.hour)
+    val res    = issuer().issue(alice, req).unsafeRunSync()
+    val claims = verifier.verify(res.toOption.get.jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+    claims.allowedOps shouldBe Set("Sign", "Get")
   }
 
   test("agentId is fresh on every issuance (UUID, not constant)") {

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AgentTokenIssuerSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/AgentTokenIssuerSpec.scala
@@ -1,0 +1,159 @@
+package dev.aegiskms.iam
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.core.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.duration.*
+
+/** Tests for `AgentTokenIssuer` — the domain-level "human issues an agent" service backing `POST
+  * /v1/agents/issue` (#18).
+  *
+  * The properties exercised here pin the spec's authz invariants:
+  *
+  *   1. Only Humans can issue agents (Service and Agent callers refused). 2. The agent JWT round-trips
+  *      through the verifier with the expected claims (parent, scopes, TTL). 3. TTL is capped at 24 h; scopes
+  *      must parse as Operation names; label must be non-empty. 4. `parent` in the body, when present, must
+  *      match the caller's subject (no cross-principal issuance in v0.2.0).
+  */
+final class AgentTokenIssuerSpec extends AnyFunSuite with Matchers:
+
+  // 32+ bytes for HS256
+  private val secret   = "test-secret-test-secret-test-secret-12345"
+  private val signer   = JwtIssuer.hmac(secret)
+  private val verifier = JwtVerifier.hmac(secret)
+
+  // Fixed clock so we can assert on exact expiresAt.
+  private val fixedNow = Instant.parse("2026-05-19T10:00:00Z")
+
+  private def issuer(maxTtl: FiniteDuration = AgentTokenIssuer.DefaultMaxTtl): AgentTokenIssuer =
+    new AgentTokenIssuer(
+      signer,
+      issuerName = Some("https://aegis.local"),
+      maxTtl = maxTtl,
+      now = IO.pure(fixedNow)
+    )
+
+  private val alice: Principal.Human = Principal.Human("alice@org", Set("admins"))
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  test("Human caller successfully issues an agent token with the expected claims") {
+    val req = IssueAgentRequest(
+      label = "claude-invoice-batch-q2",
+      scopes = List("Sign", "Get"),
+      ttl = 1.hour
+    )
+    val token = issuer().issue(alice, req).unsafeRunSync().toOption.get
+
+    token.agentId should startWith("agent-")
+    token.jti should not be empty
+    token.expiresAt shouldBe fixedNow.plusSeconds(3600)
+
+    // Verifier sees the right claims.
+    val claims = verifier.verify(token.jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+    claims.subject shouldBe token.agentId
+    claims.parentSubject shouldBe "alice@org"
+    claims.purpose shouldBe "claude-invoice-batch-q2"
+    claims.allowedOps shouldBe Set("Sign", "Get")
+    claims.jti shouldBe token.jti
+    claims.issuer shouldBe Some("https://aegis.local")
+  }
+
+  test("label is trimmed before going into the purpose claim") {
+    val req    = IssueAgentRequest("  invoice-signing  ", List("Get"), 1.hour)
+    val token  = issuer().issue(alice, req).unsafeRunSync().toOption.get
+    val claims = verifier.verify(token.jwt).toOption.get.asInstanceOf[JwtClaims.Agent]
+    claims.purpose shouldBe "invoice-signing"
+  }
+
+  // ── Authz ────────────────────────────────────────────────────────────────
+
+  test("Service callers are refused with PermissionDenied") {
+    val sys = Principal.Service("aegis-system", TenantId("system"))
+    val res = issuer().issue(sys, IssueAgentRequest("x", List("Get"), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.PermissionDenied)
+    res.left.toOption.get.message should include("service")
+  }
+
+  test("Agent callers are refused with PermissionDenied (agents cannot issue agents)") {
+    val ag = Principal.Agent(
+      subject = "agent-abc",
+      operator = alice,
+      purpose = "test",
+      issuedAt = fixedNow,
+      ttl = 1.hour,
+      allowedOps = Set.empty,
+      parent = None
+    )
+    val res = issuer().issue(ag, IssueAgentRequest("x", List("Get"), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.PermissionDenied)
+    res.left.toOption.get.message should include("agents cannot issue agents")
+  }
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  test("empty label is rejected with InvalidField") {
+    val res = issuer().issue(alice, IssueAgentRequest("   ", List("Get"), 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("label")
+  }
+
+  test("empty scopes is rejected with InvalidField") {
+    val res = issuer().issue(alice, IssueAgentRequest("x", Nil, 1.hour)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("scopes")
+  }
+
+  test("zero TTL is rejected with InvalidField") {
+    val res = issuer().issue(alice, IssueAgentRequest("x", List("Get"), 0.seconds)).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("ttl")
+  }
+
+  test("TTL above the configured maximum is rejected with InvalidField") {
+    val res = issuer(maxTtl = 1.hour)
+      .issue(alice, IssueAgentRequest("x", List("Get"), 2.hours))
+      .unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("exceeds maximum")
+  }
+
+  test("an unknown operation name in scopes is rejected with InvalidField") {
+    val res = issuer()
+      .issue(alice, IssueAgentRequest("x", List("Sign", "NotARealOp"), 1.hour))
+      .unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("NotARealOp")
+  }
+
+  test("parent in the body matching the caller is accepted") {
+    val req = IssueAgentRequest(
+      "x",
+      List("Get"),
+      1.hour,
+      parent = Some("alice@org"),
+      callerSubject = Some("alice@org")
+    )
+    val res = issuer().issue(alice, req).unsafeRunSync()
+    res.isRight shouldBe true
+  }
+
+  test("parent in the body not matching the caller is rejected") {
+    val req =
+      IssueAgentRequest("x", List("Get"), 1.hour, parent = Some("bob@org"), callerSubject = Some("alice@org"))
+    val res = issuer().issue(alice, req).unsafeRunSync()
+    res.left.toOption.map(_.code) shouldBe Some(ErrorCode.InvalidField)
+    res.left.toOption.get.message should include("cross-principal")
+  }
+
+  test("agentId is fresh on every issuance (UUID, not constant)") {
+    val req = IssueAgentRequest("x", List("Get"), 1.hour)
+    val t1  = issuer().issue(alice, req).unsafeRunSync().toOption.get
+    val t2  = issuer().issue(alice, req).unsafeRunSync().toOption.get
+    t1.agentId should not equal t2.agentId
+    t1.jti should not equal t2.jti
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/JwtRoundTripSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/JwtRoundTripSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 /** Round-trips JwtIssuer → JwtVerifier for both Human and Agent claim shapes, and verifies the negative paths
   * the verifier promises (expired, malformed, bad signature, wrong kind).
@@ -30,7 +31,8 @@ final class JwtRoundTripSpec extends AnyFunSuite:
       issuer = Some("https://aegis.local"),
       issuedAt = now,
       expiresAt = now.plus(1, ChronoUnit.HOURS),
-      groups = Set("admins", "sre")
+      groups = Set("admins", "sre"),
+      jti = UUID.randomUUID().toString
     )
     val token = issuer.issue(claims)
     val back  = verifier.verify(token).toOption.get.asInstanceOf[JwtClaims.Human]
@@ -39,6 +41,7 @@ final class JwtRoundTripSpec extends AnyFunSuite:
     assert(back.issuer.contains("https://aegis.local"))
     // JWT exp/iat are encoded as seconds-since-epoch — round-trip truncates sub-second precision.
     assert(back.issuedAt.getEpochSecond == now.getEpochSecond)
+    assert(back.jti == claims.jti) // jti round-trips through issue → verify
   }
 
   test("Agent claim carries parent, purpose, allowedOps") {
@@ -49,7 +52,8 @@ final class JwtRoundTripSpec extends AnyFunSuite:
       expiresAt = now.plus(1, ChronoUnit.HOURS),
       parentSubject = "alice@org",
       purpose = "claude-invoice-batch-q2",
-      allowedOps = Set("Get", "Activate")
+      allowedOps = Set("Get", "Activate"),
+      jti = UUID.randomUUID().toString
     )
     val token = issuer.issue(claims)
     val back  = verifier.verify(token).toOption.get.asInstanceOf[JwtClaims.Agent]
@@ -64,7 +68,8 @@ final class JwtRoundTripSpec extends AnyFunSuite:
       issuer = None,
       issuedAt = now.minus(2, ChronoUnit.HOURS),
       expiresAt = now.minus(1, ChronoUnit.HOURS),
-      groups = Set.empty
+      groups = Set.empty,
+      jti = UUID.randomUUID().toString
     )
     val token  = issuer.issue(claims)
     val result = verifier.verify(token)
@@ -72,9 +77,10 @@ final class JwtRoundTripSpec extends AnyFunSuite:
   }
 
   test("token signed with a different secret fails with SignatureInvalid") {
-    val claims = JwtClaims.Human("alice@org", None, now, now.plusSeconds(60), Set.empty)
-    val token  = issuer.issue(claims)
-    val other  = JwtVerifier.hmac("a-totally-different-secret-also-32+bytes")
+    val claims =
+      JwtClaims.Human("alice@org", None, now, now.plusSeconds(60), Set.empty, UUID.randomUUID().toString)
+    val token = issuer.issue(claims)
+    val other = JwtVerifier.hmac("a-totally-different-secret-also-32+bytes")
     assert(other.verify(token) == Left(JwtError.SignatureInvalid))
   }
 

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/JwtRoundTripSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/JwtRoundTripSpec.scala
@@ -94,3 +94,28 @@ final class JwtRoundTripSpec extends AnyFunSuite:
     val ex = intercept[IllegalArgumentException](JwtVerifier.hmac("too-short"))
     assert(ex.getMessage.contains("≥32 bytes"))
   }
+
+  test("externally-minted token without a jti claim verifies; jti surfaces as empty string") {
+    // Mint a JWT directly via jjwt without calling builder.id(...) — simulates a token from an
+    // external IDP that doesn't set the JWT ID claim. The verifier docstring promises tolerance;
+    // this test pins that contract so the #24 JTI-blacklist consumer can rely on jti="" meaning
+    // "no blacklist match" rather than refusing every external token outright.
+    import io.jsonwebtoken.Jwts
+    import io.jsonwebtoken.security.Keys
+    import java.nio.charset.StandardCharsets
+    import java.util.Date
+
+    val key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8))
+    val tokenWithoutJti = Jwts
+      .builder()
+      .subject("external-alice")
+      .issuedAt(Date.from(now))
+      .expiration(Date.from(now.plus(1, ChronoUnit.HOURS)))
+      .claim(JwtClaims.Claim.Kind, JwtClaims.Claim.KindHuman)
+      .signWith(key)
+      .compact()
+
+    val back = verifier.verify(tokenWithoutJti).toOption.get.asInstanceOf[JwtClaims.Human]
+    assert(back.subject == "external-alice")
+    assert(back.jti == "")
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/PrincipalResolverSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/PrincipalResolverSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 final class PrincipalResolverSpec extends AnyFunSuite:
 
@@ -34,9 +35,16 @@ final class PrincipalResolverSpec extends AnyFunSuite:
   // ── jwt resolver — happy paths ───────────────────────────────────────────────
 
   test("jwt resolver verifies a Human token and returns Principal.Human with the carried groups") {
-    val claims = JwtClaims.Human("alice@org", None, now, now.plus(1, ChronoUnit.HOURS), Set("admins"))
-    val token  = issuer.issue(claims)
-    val res    = PrincipalResolver.jwt(verifier).resolve(Some(s"Bearer $token"), devUserHeader = None)
+    val claims = JwtClaims.Human(
+      "alice@org",
+      None,
+      now,
+      now.plus(1, ChronoUnit.HOURS),
+      Set("admins"),
+      UUID.randomUUID().toString
+    )
+    val token = issuer.issue(claims)
+    val res   = PrincipalResolver.jwt(verifier).resolve(Some(s"Bearer $token"), devUserHeader = None)
     assert(res == Right(Principal.Human("alice@org", Set("admins"))))
   }
 
@@ -48,7 +56,8 @@ final class PrincipalResolverSpec extends AnyFunSuite:
       expiresAt = now.plus(1, ChronoUnit.HOURS),
       parentSubject = "alice@org",
       purpose = "claude-invoice-batch-q2",
-      allowedOps = Set("Get", "Activate")
+      allowedOps = Set("Get", "Activate"),
+      jti = UUID.randomUUID().toString
     )
     val token = issuer.issue(claims)
     val res   = PrincipalResolver.jwt(verifier).resolve(Some(s"Bearer $token"), devUserHeader = None)
@@ -83,7 +92,8 @@ final class PrincipalResolverSpec extends AnyFunSuite:
       issuer = None,
       issuedAt = now.minus(2, ChronoUnit.HOURS),
       expiresAt = now.minus(1, ChronoUnit.HOURS),
-      groups = Set.empty
+      groups = Set.empty,
+      jti = UUID.randomUUID().toString
     )
     val token = issuer.issue(claims)
     val res   = PrincipalResolver.jwt(verifier).resolve(Some(s"Bearer $token"), None)
@@ -91,7 +101,14 @@ final class PrincipalResolverSpec extends AnyFunSuite:
   }
 
   test("token signed with a different secret is rejected") {
-    val claims      = JwtClaims.Human("alice", None, now, now.plus(1, ChronoUnit.HOURS), Set.empty)
+    val claims = JwtClaims.Human(
+      "alice",
+      None,
+      now,
+      now.plus(1, ChronoUnit.HOURS),
+      Set.empty,
+      UUID.randomUUID().toString
+    )
     val otherIssuer = JwtIssuer.hmac("an-entirely-different-32-byte-secret-pls")
     val token       = otherIssuer.issue(claims)
     val res         = PrincipalResolver.jwt(verifier).resolve(Some(s"Bearer $token"), None)

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -14,7 +14,7 @@ import dev.aegiskms.agent.{
 }
 import dev.aegiskms.audit.{AuditingKeyService, StdoutAuditSink}
 import dev.aegiskms.http.HttpRoutes
-import dev.aegiskms.iam.{AuthorizingKeyService, JwtVerifier, PrincipalResolver}
+import dev.aegiskms.iam.{AgentTokenIssuer, AuthorizingKeyService, JwtIssuer, JwtVerifier, PrincipalResolver}
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import org.apache.pekko.actor.typed.{ActorSystem, Scheduler}
@@ -142,6 +142,14 @@ object Server extends IOApp.Simple:
       auditing       = new AuditingKeyService(traced, sink, Some(riskScorer), Some(decisionEngine))
 
       resolver = buildResolver(rootConfig)
+      // Agent-token issuer (#18). Needs a JwtIssuer with the HMAC secret. We share the same secret
+      // the verifier uses when `aegis.auth.kind=hmac`; in dev mode we mint a stable per-boot secret
+      // (logged below) so the demo can issue + verify agent tokens within a single server lifetime.
+      // The "dev mode self-issued tokens" approach is deliberate — it lets newcomers exercise the
+      // wedge demo with real Agent principals without standing up an OIDC IDP. PR #25 replaces this
+      // with proper OIDC + JWKS rotation.
+      agentIssuer <- Resource.eval(buildAgentIssuer(rootConfig))
+
       _ <- Resource.eval(IO {
         logger.warn(
           "aegis-server starting in DEV MODE — DevPolicyEngine grants every Human full access. " +
@@ -152,7 +160,10 @@ object Server extends IOApp.Simple:
       // 5. HTTP binding. Acquire = bind; release = unbind with the configured grace period (5s) so
       //    in-flight requests finish before the socket closes.
       appRoute =
-        concat(HttpRoutes(auditing, resolver).routes, MetricsRoutes.route(metricsRegistry))
+        concat(
+          HttpRoutes(auditing, resolver, Some(agentIssuer)).routes,
+          MetricsRoutes.route(metricsRegistry)
+        )
       _ <- httpBindingResource(host, port, appRoute)
       _ <- Resource.eval(IO {
         logger.info(s"aegis-server listening on http://$host:$port (try POST /v1/keys)")
@@ -255,6 +266,39 @@ object Server extends IOApp.Simple:
       password = pg.getString("password"),
       poolSize = pg.getInt("pool-size")
     )
+
+  /** Build the `AgentTokenIssuer` that backs `POST /v1/agents/issue`.
+    *
+    *   - `aegis.auth.kind=hmac` — reuses the configured HMAC secret so issued agent tokens validate against
+    *     the same verifier.
+    *   - `aegis.auth.kind=dev` — mints a per-boot ephemeral 48-byte HMAC secret. Dev-mode tokens are valid
+    *     only against this server instance and only until the next restart. Logged with a clear warning so
+    *     operators don't accidentally rely on them in production.
+    *
+    * Both modes return a `Resource.eval`-friendly `IO[AgentTokenIssuer]`; the issuer itself holds no closable
+    * resource, but lifting it via `IO` keeps the boot composition uniform.
+    */
+  private def buildAgentIssuer(config: Config): IO[AgentTokenIssuer] = IO {
+    config.getString("aegis.auth.kind") match
+      case "hmac" =>
+        val secret = config.getString("aegis.auth.hmac.secret")
+        if secret.isEmpty then
+          throw new IllegalArgumentException(
+            "aegis.auth.kind=hmac requires aegis.auth.hmac.secret (also used to sign issued agent tokens)"
+          )
+        logger.info("agent-issue: reusing aegis.auth.hmac.secret for issued agent JWTs")
+        new AgentTokenIssuer(JwtIssuer.hmac(secret))
+      case _ =>
+        // Dev mode: ephemeral per-boot secret. 48 random bytes (>32 byte HS256 minimum).
+        val randomSecret = java.util.Base64.getEncoder
+          .encodeToString(java.security.SecureRandom.getInstanceStrong.generateSeed(48))
+        logger.warn(
+          "agent-issue: DEV MODE — issuing agent JWTs signed with a per-boot ephemeral secret. " +
+            "Tokens are valid only against this server instance and only until restart. Do not " +
+            "rely on dev-issued tokens beyond a workstation."
+        )
+        new AgentTokenIssuer(JwtIssuer.hmac(randomSecret))
+  }
 
   /** Build the principal resolver from `aegis.auth.kind`. Misconfiguration fails fast at boot — silent
     * fallback to dev would be a security hole.

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -161,7 +161,11 @@ object Server extends IOApp.Simple:
       //    in-flight requests finish before the socket closes.
       appRoute =
         concat(
-          HttpRoutes(auditing, resolver, Some(agentIssuer)).routes,
+          // `auditSink = Some(stdoutSink)` so `/v1/agents/issue` records a forensic trail of every
+          // agent credential minted (the keys surface is already covered by `AuditingKeyService`
+          // wrapping `traced`, but agent issuance is not on the `KeyService` algebra and would
+          // otherwise be invisible to operators).
+          HttpRoutes(auditing, resolver, Some(agentIssuer), Some(stdoutSink)).routes,
           MetricsRoutes.route(metricsRegistry)
         )
       _ <- httpBindingResource(host, port, appRoute)

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,7 +16,8 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 12 endpoints in v0.1.1: create, get, activate, destroy, sign, verify, encrypt, decrypt,
-    // wrap, unwrap, compromise, rotate. Bump this when a new top-level REST surface lands.
-    routes.serverEndpoints.size shouldBe 12
+    // 13 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap, compromise, rotate) + agents/issue (#18). Bump this when a new top-level
+    // REST surface lands.
+    routes.serverEndpoints.size shouldBe 13
   }


### PR DESCRIPTION
## Summary
- New `AgentTokenIssuer` in aegis-iam: only Humans can issue. Service / Agent callers get 403; label / scopes / ttl are validated; agentId + jti UUIDs are minted per issuance.
- New `POST /v1/agents/issue` Tapir endpoint + DTOs in aegis-http. Body `{label, scopes, ttlSeconds, parent?}` → `{agentId, jwt, jti, expiresAt}`. Returns 501 when issuer is not wired, so OpenAPI stays stable.
- `JwtClaims.{Human, Agent}` gained required `jti` field; issuer writes it, verifier extracts it while tolerating absence. Required for the JTI blacklist in #24.
- `Server.boot` picks the HMAC secret per auth mode: `hmac` reuses the configured secret; `dev` mints a per-boot ephemeral secret and logs it.

Completes the wedge demo path: human → `POST /v1/agents/issue` → agent JWT → repeated sign → RateSpike → AutoResponder revoke under `aegis-system`.

## Test plan
- [x] `sbt test` — 312 tests pass, 0 failures
- [x] `sbt iam/test` — 48 tests including 12 new for AgentTokenIssuer
- [x] `sbt http/test` — 38 tests including 6 new for the endpoint
- [x] `sbt scalafmtAll` — formatted
- [ ] Manual against `:main` image: `POST /v1/agents/issue` with `X-Aegis-User: alice`, use returned JWT for a `/v1/keys/.../sign` burst, watch the AutoResponder revoke under `aegis-system`


