### PR TITLE
feat(audit): Postgres audit table + indexed schema + retention (closes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Postgres audit table with indexed schema + retention (closes #19).** New
+  `PostgresAuditSink` in `aegis-audit` writes every `AuditRecord` into a Doobie-backed
+  `aegis_audit_events` table with one composite index per #20 audit-read filter
+  (`actor_subject`, `resource`, `operation`, each paired with `occurred_at DESC`) plus a plain
+  `occurred_at` index for retention scans. `context` is stored as JSONB so the existing
+  `risk.score` / `outcome.decision` / `agent.jti` / etc. context keys survive without DDL churn —
+  SIEM consumers query individual fields via `context->>'risk.score'`. Schema bootstraps on
+  startup via `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` (idempotent; no Flyway
+  dep yet). `actor_kind` column denormalises the `Principal` ADT discriminator
+  (`Human` / `Service` / `Agent`) for fast filter scans. Retention via a `pruneBefore(cutoff)`
+  method on the sink; `Server.boot` starts a background fiber that runs once daily and deletes
+  rows older than `aegis.audit.retention.days` (default 365). Set `AEGIS_AUDIT_KIND=postgres` to
+  enable; the existing `AEGIS_JDBC_URL` / `_USERNAME` / `_PASSWORD` env vars are reused (audit
+  table lives in the same database as the event journal — operators configure one set of
+  credentials). New `PostgresAuditSinkSpec` covers 8 Testcontainers cases (idempotent bootstrap,
+  every-column write fidelity, principal-kind discrimination, empty-context default,
+  insertion-order preservation, retention `pruneBefore` with strict `<` cutoff semantics +
+  empty-table case, JSONB round-trip with newlines / quotes / unicode / long strings),
+  Docker-gated via the existing `assume(dockerAvailable, ...)` pattern.
+
 - **Agent-token issuance endpoint `POST /v1/agents/issue` (closes #18).** Exposes the existing
   `JwtIssuer` over REST so operators (and the upcoming `aegis agent issue` CLI) can mint
   short-lived agent JWTs programmatically. New `AgentTokenIssuer` in `aegis-iam` wraps the issuer

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,11 @@ lazy val audit = (project in file("modules/aegis-audit"))
     commonSettings,
     name := "aegis-audit",
     description :=
-      "Append-only audit sink SPI for Aegis-KMS plus the stdout / in-memory implementations."
+      "Append-only audit sink SPI for Aegis-KMS plus the stdout / in-memory / Postgres implementations.",
+    // Doobie is available transitively via `persistence`, but the Postgres audit sink (#19) reads
+    // doobie types in its own .scala file — declaring them explicitly here makes the dependency
+    // load-bearing rather than incidental.
+    libraryDependencies ++= Dependencies.persistence ++ Dependencies.testcontainersPostgres
   )
 
 lazy val sdkScala = (project in file("modules/aegis-sdk-scala"))

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/PostgresAuditSink.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/PostgresAuditSink.scala
@@ -1,0 +1,161 @@
+package dev.aegiskms.audit
+
+import cats.effect.{IO, Resource}
+import cats.syntax.all.*
+import dev.aegiskms.core.Principal
+import dev.aegiskms.persistence.PostgresJournalConfig
+import doobie.*
+import doobie.hikari.HikariTransactor
+import doobie.implicits.*
+import doobie.postgres.circe.jsonb.implicits.*
+import doobie.postgres.implicits.*
+import io.circe.Json
+import io.circe.syntax.*
+
+import java.time.Instant
+
+/** Doobie-backed Postgres implementation of `AuditSink[IO]` plus retention.
+  *
+  * Schema:
+  * {{{
+  *   aegis_audit_events (
+  *     seq            BIGSERIAL    PRIMARY KEY,    -- monotonic insertion order
+  *     correlation_id VARCHAR(64)  NOT NULL,       -- AuditRecord.correlationId
+  *     occurred_at    TIMESTAMPTZ  NOT NULL,       -- AuditRecord.at (decision time)
+  *     actor_subject  VARCHAR(256) NOT NULL,       -- Principal.subject
+  *     actor_kind     VARCHAR(16)  NOT NULL,       -- 'Human' | 'Service' | 'Agent'
+  *     operation      VARCHAR(32)  NOT NULL,       -- KMIP Operation enum name
+  *     resource       VARCHAR(512) NOT NULL,       -- 'key:<id>' | 'agent:<id>' | 'pattern:...'
+  *     outcome        TEXT         NOT NULL,
+  *     context        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  *     inserted_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+  *   )
+  * }}}
+  *
+  * Indexes match the four #20 audit-read API filters: `actor`, `key` (resource), `op`, `since`. Time is
+  * included in every actor/resource/op index so range scans stay cheap as the table grows.
+  *
+  * Why JSONB for `context`: `AuditRecord.context` is a `Map[String, String]` that downstream consumers (the
+  * risk scorer, decision adapter, auto-responder, agent-issue endpoint) populate with arbitrary keys
+  * (`risk.score`, `outcome.decision`, `agent.jti`, …). Keeping it as JSONB lets the surface grow without DDL
+  * churn; SIEM consumers can pull individual keys via `context->>'risk.score'`.
+  *
+  * **Retention.** `pruneBefore(cutoff)` deletes rows with `occurred_at < cutoff`, returning the row count.
+  * Operators wire a recurring `IO.sleep(24h) *> pruneBefore(now - retention)` fiber in `Server.boot` — see
+  * `Server.scala` for the schedule.
+  *
+  * **Backpressure.** Writes are synchronous (the underlying `AuditingKeyService` calls `sink.write` inside
+  * the request path). For high-throughput deployments add a buffered/batched fan-out sink in front of this
+  * one (a `QueuedAuditSink` is on the roadmap behind #21).
+  */
+object PostgresAuditSink:
+
+  /** Resource-managed Postgres-backed audit sink. Acquires its own HikariCP pool — the sink's pool is
+    * separate from the journal's because audit writes and journal writes have independent lifecycles and rate
+    * profiles (every request produces an audit row; only state-changing ops produce a journal entry).
+    */
+  def make(config: PostgresJournalConfig): Resource[IO, PostgresAuditSink] =
+    for
+      ec <- ExecutionContexts.fixedThreadPool[IO](config.poolSize)
+      xa <- HikariTransactor.newHikariTransactor[IO](
+        driverClassName = "org.postgresql.Driver",
+        url = config.jdbcUrl,
+        user = config.username,
+        pass = config.password,
+        connectEC = ec
+      )
+      _ <- Resource.eval(bootstrap(xa))
+    yield new PostgresAuditSink(xa)
+
+  /** Test seam — take an externally-owned `Transactor`, run the bootstrap, yield the sink. */
+  def bootstrappedFor(xa: Transactor[IO]): IO[PostgresAuditSink] =
+    bootstrap(xa).as(new PostgresAuditSink(xa))
+
+  // ── Migration ─────────────────────────────────────────────────────────────
+
+  private val createTable: doobie.ConnectionIO[Int] =
+    sql"""
+      CREATE TABLE IF NOT EXISTS aegis_audit_events (
+        seq            BIGSERIAL    PRIMARY KEY,
+        correlation_id VARCHAR(64)  NOT NULL,
+        occurred_at    TIMESTAMPTZ  NOT NULL,
+        actor_subject  VARCHAR(256) NOT NULL,
+        actor_kind     VARCHAR(16)  NOT NULL,
+        operation      VARCHAR(32)  NOT NULL,
+        resource       VARCHAR(512) NOT NULL,
+        outcome        TEXT         NOT NULL,
+        context        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+        inserted_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+      )
+    """.update.run
+
+  // One composite index per (#20) query path. `occurred_at DESC` matches the common "most recent
+  // first" pagination shape; the leading column scopes the scan.
+  private val createActorIndex: doobie.ConnectionIO[Int] =
+    sql"""
+      CREATE INDEX IF NOT EXISTS aegis_audit_events_actor_idx
+      ON aegis_audit_events(actor_subject, occurred_at DESC)
+    """.update.run
+
+  private val createResourceIndex: doobie.ConnectionIO[Int] =
+    sql"""
+      CREATE INDEX IF NOT EXISTS aegis_audit_events_resource_idx
+      ON aegis_audit_events(resource, occurred_at DESC)
+    """.update.run
+
+  private val createOperationIndex: doobie.ConnectionIO[Int] =
+    sql"""
+      CREATE INDEX IF NOT EXISTS aegis_audit_events_operation_idx
+      ON aegis_audit_events(operation, occurred_at DESC)
+    """.update.run
+
+  private val createOccurredIndex: doobie.ConnectionIO[Int] =
+    sql"""
+      CREATE INDEX IF NOT EXISTS aegis_audit_events_occurred_idx
+      ON aegis_audit_events(occurred_at)
+    """.update.run
+
+  private def bootstrap(xa: Transactor[IO]): IO[Unit] =
+    (createTable *> createActorIndex *> createResourceIndex *> createOperationIndex *> createOccurredIndex)
+      .transact(xa)
+      .void
+
+  // ── Principal kind discriminator ──────────────────────────────────────────
+
+  private def kindOf(p: Principal): String = p match
+    case _: Principal.Human   => "Human"
+    case _: Principal.Service => "Service"
+    case _: Principal.Agent   => "Agent"
+
+/** Doobie-backed `AuditSink[IO]` with a `pruneBefore` retention method.
+  *
+  * Constructed via `PostgresAuditSink.make(config)` (Resource-managed pool) or
+  * `PostgresAuditSink.bootstrappedFor(xa)` (caller-owned transactor; used by tests).
+  */
+final class PostgresAuditSink private[audit] (xa: Transactor[IO]) extends AuditSink[IO]:
+
+  import PostgresAuditSink.*
+
+  def write(record: AuditRecord): IO[Unit] =
+    val contextJson: Json = record.context.asJson
+    sql"""
+      INSERT INTO aegis_audit_events
+        (correlation_id, occurred_at, actor_subject, actor_kind,
+         operation, resource, outcome, context)
+      VALUES
+        (${record.correlationId}, ${record.at}, ${record.principal.subject}, ${kindOf(record.principal)},
+         ${record.operation.toString}, ${record.resource}, ${record.outcome}, $contextJson)
+    """.update.run.transact(xa).void
+
+  /** Retention helper: delete rows whose `occurred_at` is strictly before `cutoff`. Returns the number of
+    * rows deleted so the scheduler can log progress.
+    *
+    * Implementation note: this is a single `DELETE … WHERE occurred_at < ?` statement, which on a table
+    * indexed by `occurred_at` is an index-scan delete — fast even on multi-million-row tables. If retention
+    * deletes ever become slow, the next step is partitioning by month, but that's premature until we measure
+    * it.
+    */
+  def pruneBefore(cutoff: Instant): IO[Long] =
+    sql"""
+      DELETE FROM aegis_audit_events WHERE occurred_at < $cutoff
+    """.update.run.transact(xa).map(_.toLong)

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
@@ -81,17 +81,20 @@ final class PostgresAuditSinkSpec extends AnyFunSuite with Matchers:
 
   // ── Schema + basic write ─────────────────────────────────────────────────
 
-  test("bootstrap creates table + 4 indexes idempotently") {
+  test("bootstrap creates table + 4 explicit indexes idempotently") {
     withPostgres { xa =>
       val program =
         for
           _    <- PostgresAuditSink.bootstrappedFor(xa) // first time creates
           _    <- PostgresAuditSink.bootstrappedFor(xa) // second time is a no-op
           rows <- sql"SELECT COUNT(*) FROM aegis_audit_events".query[Int].unique.transact(xa)
+          // Filter on the `_idx` suffix so we count ONLY our four explicit composite indexes.
+          // Postgres auto-creates a PRIMARY KEY index named `aegis_audit_events_pkey` which would
+          // otherwise be picked up by a plain `LIKE 'aegis_audit_events_%'` filter.
           idxCnt <- sql"""
                       SELECT COUNT(*) FROM pg_indexes
                       WHERE tablename = 'aegis_audit_events'
-                        AND indexname LIKE 'aegis_audit_events_%'
+                        AND indexname LIKE 'aegis_audit_events_%\_idx' ESCAPE '\'
                     """.query[Int].unique.transact(xa)
         yield (rows, idxCnt)
 
@@ -119,25 +122,31 @@ final class PostgresAuditSinkSpec extends AnyFunSuite with Matchers:
             )
           )
           _ <- sink.write(rec)
+          // Read context as JSONB (round-trip via circe) instead of `::text` substring matching.
+          // Postgres's `jsonb::text` cast inserts a space after `:` (`"risk.score": "0.42"`) which
+          // is annoying to assert against and brittle. Parsing the JSON and asserting on values
+          // is robust against future Postgres formatting tweaks.
           row <- sql"""
                    SELECT correlation_id, actor_subject, actor_kind, operation,
-                          resource, outcome, context::text
+                          resource, outcome, context
                    FROM aegis_audit_events
                  """
-            .query[(String, String, String, String, String, String, String)]
+            .query[(String, String, String, String, String, String, io.circe.Json)]
             .unique
             .transact(xa)
         yield (rec, row)
 
-      val (rec, (corr, actor, kind, op, res, outcome, ctx)) = program.unsafeRunSync()
+      val (rec, (corr, actor, kind, op, res, outcome, ctxJson)) = program.unsafeRunSync()
       corr shouldBe rec.correlationId
       actor shouldBe "alice@org"
       kind shouldBe "Human"
       op shouldBe "Sign"
       res shouldBe "key:abc-123"
       outcome should include("Success alg=RsaPssSha256")
-      ctx should include(""""risk.score":"0.42"""")
-      ctx should include(""""outcome.decision":"Allow"""")
+      ctxJson.hcursor.downField("risk.score").as[String].toOption shouldBe Some("0.42")
+      ctxJson.hcursor.downField("risk.factors").as[String].toOption shouldBe
+        Some("AgentPrincipal:0.2;DestructiveOp:0.1")
+      ctxJson.hcursor.downField("outcome.decision").as[String].toOption shouldBe Some("Allow")
     }
   }
 
@@ -169,10 +178,13 @@ final class PostgresAuditSinkSpec extends AnyFunSuite with Matchers:
         for
           sink <- PostgresAuditSink.bootstrappedFor(xa)
           _    <- sink.write(record(baseTs, alice, Operation.Get, "key:k1")) // context = Map.empty
-          ctx  <- sql"SELECT context::text FROM aegis_audit_events".query[String].unique.transact(xa)
+          ctx  <- sql"SELECT context FROM aegis_audit_events".query[io.circe.Json].unique.transact(xa)
         yield ctx
 
-      program.unsafeRunSync() shouldBe "{}"
+      // Parsed JSON shape rather than a stringly comparison — survives any future Postgres
+      // JSONB text-cast formatting change.
+      val ctxJson = program.unsafeRunSync()
+      ctxJson.asObject.map(_.isEmpty) shouldBe Some(true)
     }
   }
 

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
@@ -1,0 +1,253 @@
+package dev.aegiskms.audit
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import dev.aegiskms.core.{Operation, Principal, TenantId}
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.circe.jsonb.implicits.*
+import doobie.postgres.implicits.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.utility.DockerImageName
+
+import java.time.Instant
+import scala.util.Try
+
+/** Integration tests for [[PostgresAuditSink]] against a real Postgres in Docker.
+  *
+  * Container lifecycle is managed manually (matching `PostgresEventJournalSpec`) so the suite skips cleanly
+  * via `assume(...)` on machines without Docker.
+  */
+final class PostgresAuditSinkSpec extends AnyFunSuite with Matchers:
+
+  given IORuntime = IORuntime.global
+
+  private val dockerAvailable: Boolean =
+    Try(org.testcontainers.DockerClientFactory.instance().isDockerAvailable).getOrElse(false)
+
+  private def withPostgres(body: Transactor[IO] => Unit): Unit =
+    assume(dockerAvailable, "Docker is not available; skipping Postgres audit sink integration test")
+    val container = PostgreSQLContainer(
+      dockerImageNameOverride = DockerImageName.parse("postgres:16-alpine"),
+      databaseName = "aegis_audit_test",
+      username = "aegis",
+      password = "aegis"
+    )
+    container.start()
+    try
+      val xa = Transactor.fromDriverManager[IO](
+        driver = "org.postgresql.Driver",
+        url = container.jdbcUrl,
+        user = container.username,
+        password = container.password,
+        logHandler = None
+      )
+      body(xa)
+    finally container.stop()
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+  private val agent: Principal = Principal.Agent(
+    subject = "agent-7a3",
+    operator = alice,
+    purpose = "invoice-signing",
+    issuedAt = Instant.parse("2026-05-20T10:00:00Z"),
+    ttl = scala.concurrent.duration.FiniteDuration(1, scala.concurrent.duration.HOURS),
+    allowedOps = Set(Operation.Sign),
+    parent = None
+  )
+  private val system: Principal = Principal.Service("aegis-system", TenantId("system"))
+
+  private val baseTs = Instant.parse("2026-05-20T10:00:00Z")
+
+  private def record(
+      at: Instant,
+      principal: Principal,
+      op: Operation,
+      resource: String,
+      outcome: String = "Success",
+      context: Map[String, String] = Map.empty
+  ): AuditRecord =
+    AuditRecord(
+      at = at,
+      principal = principal,
+      operation = op,
+      resource = resource,
+      outcome = outcome,
+      correlationId = java.util.UUID.randomUUID().toString,
+      context = context
+    )
+
+  // ── Schema + basic write ─────────────────────────────────────────────────
+
+  test("bootstrap creates table + 4 indexes idempotently") {
+    withPostgres { xa =>
+      val program =
+        for
+          _    <- PostgresAuditSink.bootstrappedFor(xa) // first time creates
+          _    <- PostgresAuditSink.bootstrappedFor(xa) // second time is a no-op
+          rows <- sql"SELECT COUNT(*) FROM aegis_audit_events".query[Int].unique.transact(xa)
+          idxCnt <- sql"""
+                      SELECT COUNT(*) FROM pg_indexes
+                      WHERE tablename = 'aegis_audit_events'
+                        AND indexname LIKE 'aegis_audit_events_%'
+                    """.query[Int].unique.transact(xa)
+        yield (rows, idxCnt)
+
+      val (rowsAfter, idxAfter) = program.unsafeRunSync()
+      rowsAfter shouldBe 0
+      idxAfter shouldBe 4 // actor, resource, operation, occurred_at
+    }
+  }
+
+  test("write persists every column with the expected values") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          rec = record(
+            at = baseTs,
+            principal = alice,
+            op = Operation.Sign,
+            resource = "key:abc-123",
+            outcome = "Success alg=RsaPssSha256 msgLen=5",
+            context = Map(
+              "risk.score"       -> "0.42",
+              "risk.factors"     -> "AgentPrincipal:0.2;DestructiveOp:0.1",
+              "outcome.decision" -> "Allow"
+            )
+          )
+          _ <- sink.write(rec)
+          row <- sql"""
+                   SELECT correlation_id, actor_subject, actor_kind, operation,
+                          resource, outcome, context::text
+                   FROM aegis_audit_events
+                 """
+            .query[(String, String, String, String, String, String, String)]
+            .unique
+            .transact(xa)
+        yield (rec, row)
+
+      val (rec, (corr, actor, kind, op, res, outcome, ctx)) = program.unsafeRunSync()
+      corr shouldBe rec.correlationId
+      actor shouldBe "alice@org"
+      kind shouldBe "Human"
+      op shouldBe "Sign"
+      res shouldBe "key:abc-123"
+      outcome should include("Success alg=RsaPssSha256")
+      ctx should include(""""risk.score":"0.42"""")
+      ctx should include(""""outcome.decision":"Allow"""")
+    }
+  }
+
+  test("actor_kind correctly discriminates Human, Service, Agent principals") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs, alice, Operation.Get, "key:k1"))
+          _    <- sink.write(record(baseTs, agent, Operation.Sign, "key:k2"))
+          _    <- sink.write(record(baseTs, system, Operation.Revoke, "key:k3"))
+          rows <- sql"""
+                    SELECT actor_subject, actor_kind FROM aegis_audit_events
+                    ORDER BY seq ASC
+                  """.query[(String, String)].to[List].transact(xa)
+        yield rows
+
+      program.unsafeRunSync() shouldBe List(
+        ("alice@org", "Human"),
+        ("agent-7a3", "Agent"),
+        ("aegis-system", "Service")
+      )
+    }
+  }
+
+  test("write accepts an empty context map (default empty JSONB object)") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs, alice, Operation.Get, "key:k1")) // context = Map.empty
+          ctx  <- sql"SELECT context::text FROM aegis_audit_events".query[String].unique.transact(xa)
+        yield ctx
+
+      program.unsafeRunSync() shouldBe "{}"
+    }
+  }
+
+  test("multiple writes are persisted in insertion order via seq") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs.plusSeconds(0), alice, Operation.Create, "key:a"))
+          _    <- sink.write(record(baseTs.plusSeconds(1), alice, Operation.Activate, "key:a"))
+          _    <- sink.write(record(baseTs.plusSeconds(2), alice, Operation.Sign, "key:a"))
+          ops <- sql"""
+                   SELECT operation FROM aegis_audit_events ORDER BY seq ASC
+                 """.query[String].to[List].transact(xa)
+        yield ops
+
+      program.unsafeRunSync() shouldBe List("Create", "Activate", "Sign")
+    }
+  }
+
+  // ── Retention ─────────────────────────────────────────────────────────────
+
+  test("pruneBefore deletes only rows with occurred_at strictly before the cutoff") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs.minusSeconds(7200), alice, Operation.Get, "key:old1"))
+          _    <- sink.write(record(baseTs.minusSeconds(3600), alice, Operation.Get, "key:old2"))
+          _    <- sink.write(record(baseTs, alice, Operation.Get, "key:boundary"))
+          _    <- sink.write(record(baseTs.plusSeconds(3600), alice, Operation.Get, "key:new"))
+          // Cutoff is exactly baseTs → strictly-before excludes the boundary row.
+          deleted <- sink.pruneBefore(baseTs)
+          remaining <- sql"""
+                         SELECT resource FROM aegis_audit_events ORDER BY occurred_at ASC
+                       """.query[String].to[List].transact(xa)
+        yield (deleted, remaining)
+
+      val (deleted, remaining) = program.unsafeRunSync()
+      deleted shouldBe 2L
+      remaining shouldBe List("key:boundary", "key:new")
+    }
+  }
+
+  test("pruneBefore on an empty table returns 0 rows deleted") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink    <- PostgresAuditSink.bootstrappedFor(xa)
+          deleted <- sink.pruneBefore(Instant.now())
+        yield deleted
+
+      program.unsafeRunSync() shouldBe 0L
+    }
+  }
+
+  test("write tolerates large context maps + special characters (JSONB round-trip)") {
+    withPostgres { xa =>
+      val tricky = Map(
+        "newline"                      -> "line1\nline2",
+        "quotes"                       -> "she said \"hi\"",
+        "unicode"                      -> "café — açaí — 漢字",
+        "very.long.key.name.with.dots" -> ("x" * 1000)
+      )
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs, alice, Operation.Get, "key:k1", context = tricky))
+          ctx  <- sql"SELECT context::jsonb FROM aegis_audit_events".query[io.circe.Json].unique.transact(xa)
+        yield ctx
+
+      val back = program.unsafeRunSync()
+      back.hcursor.downField("newline").as[String].toOption shouldBe Some("line1\nline2")
+      back.hcursor.downField("quotes").as[String].toOption shouldBe Some("she said \"hi\"")
+      back.hcursor.downField("unicode").as[String].toOption shouldBe Some("café — açaí — 漢字")
+      back.hcursor.downField("very.long.key.name.with.dots").as[String].toOption.get.length shouldBe 1000
+    }
+  }

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -38,6 +38,24 @@ aegis {
       }
     }
   }
+
+  audit {
+    # "stdout"   — write every AuditRecord to stdout (default; what the docs/demos use).
+    # "postgres" — write every AuditRecord to the `aegis_audit_events` table, indexed for the
+    #              audit-read API (#20). Schema bootstraps on startup. Reuses the journal's
+    #              Postgres credentials so operators only configure one set of DB env vars.
+    kind = "stdout"
+    kind = ${?AEGIS_AUDIT_KIND}
+
+    retention {
+      # Days of audit history to retain. `pruneBefore(now - days)` runs daily inside
+      # `Server.boot`'s background fiber. Set to 0 to disable pruning entirely (audit grows
+      # unbounded — fine for low-volume demos, NOT for production). Compliance regimes typically
+      # require 365 days (SOC 2) or 7 years for SOX; tune accordingly.
+      days = 365
+      days = ${?AEGIS_AUDIT_RETENTION_DAYS}
+    }
+  }
 }
 
 pekko {

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -12,7 +12,7 @@ import dev.aegiskms.agent.{
   TappedAuditSink,
   ThresholdDecisionEngine
 }
-import dev.aegiskms.audit.{AuditingKeyService, StdoutAuditSink}
+import dev.aegiskms.audit.{AuditSink, AuditingKeyService, PostgresAuditSink, StdoutAuditSink}
 import dev.aegiskms.http.HttpRoutes
 import dev.aegiskms.iam.{AgentTokenIssuer, AuthorizingKeyService, JwtIssuer, JwtVerifier, PrincipalResolver}
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
@@ -115,7 +115,11 @@ object Server extends IOApp.Simple:
       traced      = new TracingKeyService(metered, tracer)
       recStore <- Resource.eval(InMemoryRecommendationSink.make)
       detector <- Resource.eval(BaselineDetector.make())
-      stdoutSink = StdoutAuditSink()
+      // Audit sink (#19): `aegis.audit.kind=stdout` (default) writes to console; `postgres`
+      // persists to the indexed `aegis_audit_events` table backing the audit-read API (#20).
+      // `stdoutSink` is kept as the variable name across both modes so the existing references
+      // downstream (auto-responder, HttpRoutes auditSink) stay readable — only the impl changes.
+      stdoutSink <- auditSinkResource(rootConfig)
       // Auto-responder (#17 / W3): decorates the recommendation sink. Every recommendation is first
       // persisted to `recStore` (full alert history retained), then matched against `DefaultRules`
       // (High → Revoke, Medium → Alert), then executed with a per-(actor,action) 60 s cooldown. The
@@ -270,6 +274,68 @@ object Server extends IOApp.Simple:
       password = pg.getString("password"),
       poolSize = pg.getInt("pool-size")
     )
+
+  /** Build the audit sink (#19). Resource-scoped so a Postgres-backed sink's connection pool is released
+    * cleanly on shutdown. Also starts the retention fiber if the sink supports `pruneBefore` (Postgres does;
+    * stdout doesn't).
+    *
+    *   - `aegis.audit.kind=stdout` — `StdoutAuditSink` writes to console. No retention.
+    *   - `aegis.audit.kind=postgres` — `PostgresAuditSink` against the configured journal credentials (the
+    *     audit table lives in the same database as the event journal). A daily retention fiber prunes rows
+    *     older than `aegis.audit.retention.days`.
+    */
+  private def auditSinkResource(config: Config): Resource[IO, AuditSink[IO]] =
+    config.getString("aegis.audit.kind") match
+      case "stdout" =>
+        Resource.eval(IO {
+          logger.info("audit: stdout (set aegis.audit.kind=postgres to enable indexed audit storage)")
+          StdoutAuditSink()
+        })
+      case "postgres" =>
+        val pgConfig   = readPostgresJournalConfig(config)
+        val retentionD = config.getInt("aegis.audit.retention.days")
+        for
+          _ <- Resource.eval(IO(logger.info(
+            s"audit: postgres at ${pgConfig.jdbcUrl} (retention=${retentionD}d)"
+          )))
+          sink <- PostgresAuditSink.make(pgConfig)
+          // Retention fiber: every 24h, delete rows older than `retentionD` days. Skip when
+          // retentionD <= 0 (operator opt-out — audit grows unbounded). The fiber lives for the
+          // life of the boot Resource and is cancelled when the server shuts down.
+          _ <- retentionFiberResource(sink, retentionD)
+        yield sink
+      case other =>
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          s"Unknown aegis.audit.kind=$other (expected 'stdout' or 'postgres')"
+        )))
+
+  /** Background fiber that prunes audit rows older than `retentionDays` once a day. No-op when `retentionDays
+    * <= 0`. Cancellation on Resource release stops the fiber cleanly.
+    */
+  private def retentionFiberResource(
+      sink: PostgresAuditSink,
+      retentionDays: Int
+  ): Resource[IO, Unit] =
+    if retentionDays <= 0 then
+      Resource.eval(IO(logger.warn(
+        "audit retention disabled (aegis.audit.retention.days=0) — table will grow unbounded"
+      )))
+    else
+      val loop: IO[Unit] =
+        val tick: IO[Unit] =
+          for
+            now <- IO.realTimeInstant
+            cutoff = now.minus(java.time.Duration.ofDays(retentionDays.toLong))
+            deleted <- sink.pruneBefore(cutoff).handleErrorWith { t =>
+              IO(logger.warn(s"audit retention prune failed: ${t.getMessage}", t)).as(0L)
+            }
+            _ <- IO(logger.info(s"audit retention: pruned $deleted rows older than $cutoff"))
+          yield ()
+        // Forever loop: 24h sleep, then prune. Initial delay so the first prune doesn't compete
+        // with the rest of boot.
+        (IO.sleep(scala.concurrent.duration.FiniteDuration(24L, scala.concurrent.duration.HOURS))
+          *> tick).foreverM
+      Resource.make(loop.start)(fiber => fiber.cancel).void
 
   /** Build the `AgentTokenIssuer` that backs `POST /v1/agents/issue`.
     *


### PR DESCRIPTION
## Summary
- New \`PostgresAuditSink\` in \`aegis-audit\` persists every \`AuditRecord\` to \`aegis_audit_events\` (Doobie + Hikari, schema bootstraps on startup).
- Indexes match the four #20 audit-read filters: \`actor\`, \`key\` (resource), \`op\`, \`since\`. Time included in every composite so range scans stay cheap.
- \`context\` stored as JSONB so the existing \`risk.score\` / \`outcome.decision\` / \`agent.jti\` / \`auto.response.*\` context keys survive without DDL churn; SIEM consumers query via \`context->>'risk.score'\`.
- \`actor_kind\` column denormalises the \`Principal\` ADT discriminator (\`Human\` / \`Service\` / \`Agent\`).
- Retention: \`pruneBefore(cutoff)\` on the sink; \`Server.boot\` starts a daily background fiber that deletes rows older than \`aegis.audit.retention.days\` (default 365). Set 0 to disable.
- Enabled via \`AEGIS_AUDIT_KIND=postgres\`; reuses the existing \`AEGIS_JDBC_URL\` / \`_USERNAME\` / \`_PASSWORD\` env vars (audit table lives in the same DB as the journal).

Closes #19. Unblocks #20 (audit-read REST API).

## Test plan
- [x] \`sbt audit/test\` — 22 pass, 8 pending locally (Docker-gated). All 8 will run on CI.
- [x] \`sbt test\` — 337 pass, 0 failures
- [x] \`sbt scalafmtCheckAll scalafmtSbtCheck \"scalafixAll --check\"\` — all green
- [ ] CI: 8 Testcontainers cases for PostgresAuditSinkSpec run against a real Postgres 16 container
- [ ] Manual against \`:main\` image post-merge: set \`AEGIS_AUDIT_KIND=postgres\`, hit a few \`/v1/keys\` endpoints, verify rows land in \`aegis_audit_events\` with the expected context JSONB

🤖 Generated with [Claude Code](https://claude.com/claude-code)