### PR TITLE
chore(gitignore): add CLAUDE.md and marketing/ to ignored paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ site/
 .venv-docs/
 __pycache__/
 *.pyc
+
+# Internal / non-public paths — never push these to the public repo.
+# `CLAUDE.md` is the Claude Code project guide (assistant-only context, not user docs).
+# `marketing/` holds internal investor + launch content (pitch decks, target lists, draft posts);
+# files stay in the working tree for local editing but must never land in the public repo.
+CLAUDE.md
+marketing/


### PR DESCRIPTION
## What I found
Did a full audit of the repo for anything that shouldn't be tracked or pushed:

- **.gitignore already covers** sbt build output (\`target/\`, \`.bsp/\`, \`.bloop/\`, \`.metals/\`), IDE files (\`.idea/\`, \`.vscode/\`, \`*.iml\`), OS junk (\`.DS_Store\`, \`Thumbs.db\`), build artifacts (\`*.class\`, \`*.jar\`, \`*.log\`), local env (\`.env\`, \`.envrc\`, \`local.conf\`), secrets (\`*.pem\`, \`*.key\`, \`*.p12\`, \`*.pfx\`, \`*.jks\`, \`secrets/\`), and docs-site artifacts (\`site/\`, \`.venv-docs/\`, \`__pycache__/\`, \`*.pyc\`). Solid baseline.
- **No build / binary junk in \`git ls-files\`.** The largest tracked files are all legitimate (CHANGELOG, docs, source, tests; one 32 KB shell script for issue bootstrapping).
- **No real secrets in tracked files.** The two \`password = \"aegis\"\` matches in \`PostgresAuditSinkSpec\` + \`PostgresEventJournalSpec\` are throwaway Testcontainers credentials — not actual secrets.

## What I'm fixing
**\`CLAUDE.md\` and \`marketing/\` were NOT in \`.gitignore\`.** Both have been intentionally untracked under a standing \"internal — don't push\" rule, but that's been enforced only by us never running \`git add\` on them. A future \`git add -A\` or \`git add .\` would silently stage 17 internal files including:

- \`marketing/investor/aegis-pitch-deck.pdf\` + \`.pptx\`
- \`marketing/investor/deck-review-and-rewrites.md\`
- \`marketing/investor/investor-target-list.md\`
- \`marketing/launch/*\` — Medium drafts, social posts, HN / Reddit launch text

This PR codifies the rule in \`.gitignore\` so the standing convention can't be bypassed by accident.

## Test plan
- [x] After the change, \`git status\` no longer lists \`CLAUDE.md\` / \`marketing/\` as untracked.
- [x] \`git check-ignore -v CLAUDE.md marketing/investor/aegis-pitch-deck.pdf\` confirms both are matched by the new rules.
- [x] Both files remain present in the local working tree (gitignore doesn't delete; it just stops git from seeing them).