### PR TITLE
feat(audit+http): GET /v1/audit audit-read REST API (closes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Audit-read REST API: `GET /v1/audit` (closes #20).** New `AuditQuery[F[_]]` SPI in
+  `aegis-audit` with `Filter` (since / until / actor / resource / operation / limit / offset)
+  and `Page` (records / limit / offset / hasMore). `PostgresAuditSink` now implements both
+  `AuditSink` AND `AuditQuery` — one impl, two responsibilities. The query composes optional
+  filters with `AND`, uses the "LIMIT n+1" trick to derive `hasMore` without a separate
+  `COUNT(*)`, clamps `limit` to `[1, 1000]` and `offset` to `>= 0` defensively, and rebuilds
+  `AuditRecord` instances from the row (including JSONB `context` round-trip back to
+  `Map[String, String]`). New Tapir endpoint
+  `GET /v1/audit?since&until&actor&key&op&limit&offset` returns
+  `{records, limit, offset, hasMore}`. Authz: human principals only — agents and services are
+  refused with `403 PermissionDenied` (v0.2.0 simplification of the future "audit:read permission
+  via policy engine" model). Unknown `op` names reject with `400 InvalidField` rather than
+  silently producing an empty result. When the server isn't wired with a query-capable sink
+  (`aegis.audit.kind=stdout`), the endpoint returns `501 FeatureNotSupported` — same pattern as
+  `/v1/agents/issue` when its dependency is missing. New tests: 8 Postgres-backed cases in
+  `PostgresAuditSinkSpec` (filter by actor / resource / op / since-until, AND composition,
+  pagination with `hasMore`, defensive clamping, JSONB round-trip) + 8 HTTP-level cases in
+  `HttpRoutesAuditQuerySpec` (response shape, record round-trip, filter parsing, op-name
+  validation, human JWT happy path, agent 403, no-reader 501, pagination propagation). Backs
+  the `aegis audit tail` CLI stub that ships next.
+
 - **Postgres audit table with indexed schema + retention (closes #19).** New
   `PostgresAuditSink` in `aegis-audit` writes every `AuditRecord` into a Doobie-backed
   `aegis_audit_events` table with one composite index per #20 audit-read filter

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditQuery.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditQuery.scala
@@ -1,0 +1,61 @@
+package dev.aegiskms.audit
+
+import dev.aegiskms.core.Operation
+
+import java.time.Instant
+
+/** Query SPI for reading from a queryable audit sink — the read side of the audit pipeline.
+  *
+  * `AuditSink[F]` writes records; `AuditQuery[F]` reads them back with filter + pagination. Implementations
+  * that support both (notably `PostgresAuditSink`) extend both traits; sinks that are write-only
+  * (`StdoutAuditSink`, the future `SiemWebhookAuditSink`) implement only `AuditSink`. The HTTP audit-read
+  * endpoint takes an `Option[AuditQuery[IO]]` and returns 501 NotImplemented when none is configured (mirrors
+  * how `agentIssuer` is wired).
+  *
+  * Filters compose with AND (all supplied filters must match). The endpoint maps each filter to a column with
+  * a backing index in `aegis_audit_events`, so even on a multi-million-row table the common filter
+  * combinations are fast.
+  *
+  * Pagination is offset-based for v0.2.0. Cursor-based pagination is a later optimisation when we have a
+  * customer pulling enough data to feel the cost of `LIMIT … OFFSET …` over deep pages.
+  */
+trait AuditQuery[F[_]]:
+  def query(filter: AuditQuery.Filter): F[AuditQuery.Page]
+
+object AuditQuery:
+
+  /** Hard-cap on the per-request page size. 1 000 is generous for an operator triage UI; SIEM exporters that
+    * need more should poll incrementally rather than asking for one giant page.
+    */
+  val MaxLimit: Int = 1000
+
+  /** Default page size when the client doesn't specify one. */
+  val DefaultLimit: Int = 100
+
+  /** All filters are optional; absent ones are not part of the WHERE clause. `limit` is clamped to `[1,
+    * MaxLimit]` at the route layer, and `offset` is clamped to `[0, ∞)`.
+    *
+    *   - `since` / `until` — half-open interval on `occurred_at` (`since <= ts < until`).
+    *   - `actor` — exact match on `actor_subject`. (Future: prefix match via a `LIKE` overload.)
+    *   - `resource` — exact match on `resource` (e.g. `"key:abc-123"` or `"agent:agent-7a3"`).
+    *   - `operation` — exact match on the KMIP `Operation` enum name (`Sign`, `Get`, …).
+    */
+  final case class Filter(
+      since: Option[Instant] = None,
+      until: Option[Instant] = None,
+      actor: Option[String] = None,
+      resource: Option[String] = None,
+      operation: Option[Operation] = None,
+      limit: Int = DefaultLimit,
+      offset: Int = 0
+  )
+
+  /** A page of audit records. `hasMore` is true iff there's at least one more matching record past the
+    * current window — useful for "show more" UIs without forcing a separate COUNT query.
+    */
+  final case class Page(
+      records: List[AuditRecord],
+      limit: Int,
+      offset: Int,
+      hasMore: Boolean
+  )

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/PostgresAuditSink.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/PostgresAuditSink.scala
@@ -2,13 +2,14 @@ package dev.aegiskms.audit
 
 import cats.effect.{IO, Resource}
 import cats.syntax.all.*
-import dev.aegiskms.core.Principal
+import dev.aegiskms.core.{Operation, Principal, TenantId}
 import dev.aegiskms.persistence.PostgresJournalConfig
 import doobie.*
 import doobie.hikari.HikariTransactor
 import doobie.implicits.*
 import doobie.postgres.circe.jsonb.implicits.*
 import doobie.postgres.implicits.*
+import doobie.util.fragment.Fragment
 import io.circe.Json
 import io.circe.syntax.*
 
@@ -132,7 +133,8 @@ object PostgresAuditSink:
   * Constructed via `PostgresAuditSink.make(config)` (Resource-managed pool) or
   * `PostgresAuditSink.bootstrappedFor(xa)` (caller-owned transactor; used by tests).
   */
-final class PostgresAuditSink private[audit] (xa: Transactor[IO]) extends AuditSink[IO]:
+final class PostgresAuditSink private[audit] (xa: Transactor[IO])
+    extends AuditSink[IO] with AuditQuery[IO]:
 
   import PostgresAuditSink.*
 
@@ -159,3 +161,90 @@ final class PostgresAuditSink private[audit] (xa: Transactor[IO]) extends AuditS
     sql"""
       DELETE FROM aegis_audit_events WHERE occurred_at < $cutoff
     """.update.run.transact(xa).map(_.toLong)
+
+  // ── Query (read side, backs GET /v1/audit) ────────────────────────────────
+
+  /** Composes a parameterised `WHERE` clause from the filter's optional fields and runs a single SELECT. The
+    * "limit + 1 trick" fetches one extra row so we can set `hasMore` without a follow-up COUNT query — fine
+    * for offset-based pagination, would change for cursor-based.
+    *
+    * Filter columns line up 1:1 with the composite indexes created at bootstrap, so the common paths
+    * (filter-by-actor, filter-by-resource, filter-by-operation, filter-by-since) are index-scans even on a
+    * million-row table. A query with no filters at all is a full-table `ORDER BY occurred_at DESC LIMIT n
+    * OFFSET m`, supported by the `aegis_audit_events_occurred_idx` (DESC ordering is read backwards through
+    * the ascending index — Postgres handles this).
+    */
+  def query(filter: AuditQuery.Filter): IO[AuditQuery.Page] =
+    val safeLimit  = math.max(1, math.min(filter.limit, AuditQuery.MaxLimit))
+    val safeOffset = math.max(0, filter.offset)
+
+    val whereFrags: List[Fragment] = List(
+      filter.since.map(s => fr"occurred_at >= $s"),
+      filter.until.map(u => fr"occurred_at < $u"),
+      filter.actor.map(a => fr"actor_subject = $a"),
+      filter.resource.map(r => fr"resource = $r"),
+      filter.operation.map(o => fr"operation = ${o.toString}")
+    ).flatten
+
+    val whereSql: Fragment =
+      if whereFrags.isEmpty then Fragment.empty
+      else fr"WHERE " ++ whereFrags.intercalate(fr" AND ")
+
+    // limit + 1 so hasMore is derivable without a COUNT(*) round-trip.
+    val q =
+      fr"""
+        SELECT correlation_id, occurred_at, actor_subject, actor_kind,
+               operation, resource, outcome, context
+        FROM aegis_audit_events
+      """ ++ whereSql ++ fr" ORDER BY occurred_at DESC, seq DESC " ++
+        fr" LIMIT ${safeLimit + 1} OFFSET $safeOffset"
+
+    q.query[(String, Instant, String, String, String, String, String, Json)]
+      .to[List]
+      .transact(xa)
+      .map { rows =>
+        val hasMore   = rows.size > safeLimit
+        val displayed = if hasMore then rows.take(safeLimit) else rows
+        val records = displayed.map { case (corrId, at, subj, kind, op, res, outcome, ctx) =>
+          AuditRecord(
+            at = at,
+            principal = principalFor(kind, subj),
+            operation = Operation.values.find(_.toString == op).getOrElse(Operation.Query),
+            resource = res,
+            outcome = outcome,
+            correlationId = corrId,
+            context = contextFromJson(ctx)
+          )
+        }
+        AuditQuery.Page(records, safeLimit, safeOffset, hasMore)
+      }
+
+  /** Reconstruct a `Principal` from the denormalised `(actor_kind, actor_subject)` columns. We lose fidelity
+    * here — the original `Principal.Agent` carries parent/purpose/allowedOps/jti which we don't round-trip
+    * (those fields, if needed by audit consumers, live in the `context` JSONB under `agent.*` keys). For
+    * `Agent` we synthesise a placeholder operator subject of `"unknown"`; readers who need the real chain
+    * should query the context map.
+    */
+  private def principalFor(kind: String, subject: String): Principal = kind match
+    case "Human"   => Principal.Human(subject, Set.empty)
+    case "Service" => Principal.Service(subject, TenantId("audit-query"))
+    case "Agent" =>
+      Principal.Agent(
+        subject = subject,
+        operator = Principal.Human("unknown", Set.empty),
+        purpose = "(reconstructed from audit row; see context map for original details)",
+        issuedAt = Instant.EPOCH,
+        ttl = scala.concurrent.duration.Duration.Zero,
+        allowedOps = Set.empty,
+        parent = None
+      )
+    case other => Principal.Service(subject, TenantId(s"unknown-kind=$other"))
+
+  /** Decode the JSONB context column back into a `Map[String, String]`. Non-string values are dropped
+    * (defensive — the writer always serialises strings, but if a future writer logs e.g. a number or array
+    * we'd rather drop the entry than fail the whole query).
+    */
+  private def contextFromJson(json: Json): Map[String, String] =
+    json.asObject
+      .map(_.toMap.flatMap { case (k, v) => v.asString.map(k -> _) })
+      .getOrElse(Map.empty)

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/PostgresAuditSinkSpec.scala
@@ -2,6 +2,7 @@ package dev.aegiskms.audit
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import cats.syntax.all.*
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import dev.aegiskms.core.{Operation, Principal, TenantId}
 import doobie.*
@@ -261,5 +262,180 @@ final class PostgresAuditSinkSpec extends AnyFunSuite with Matchers:
       back.hcursor.downField("quotes").as[String].toOption shouldBe Some("she said \"hi\"")
       back.hcursor.downField("unicode").as[String].toOption shouldBe Some("café — açaí — 漢字")
       back.hcursor.downField("very.long.key.name.with.dots").as[String].toOption.get.length shouldBe 1000
+    }
+  }
+
+  // ── Query (#20: GET /v1/audit) ────────────────────────────────────────────
+
+  /** Seed `n` records spread evenly between three actors + four operations so each filter has something to
+    * match. Returns the seeded list in insertion order so tests can compare.
+    */
+  private def seedRecords(sink: PostgresAuditSink): IO[List[AuditRecord]] =
+    val recs = List(
+      record(baseTs.plusSeconds(0), alice, Operation.Sign, "key:invoice-2026"),
+      record(baseTs.plusSeconds(1), alice, Operation.Get, "key:invoice-2026"),
+      record(baseTs.plusSeconds(2), agent, Operation.Sign, "key:invoice-2026"),
+      record(baseTs.plusSeconds(3), agent, Operation.Get, "key:paystubs-2026"),
+      record(baseTs.plusSeconds(4), system, Operation.Revoke, "key:paystubs-2026"),
+      record(baseTs.plusSeconds(5), alice, Operation.Activate, "key:tax-2026"),
+      record(baseTs.plusSeconds(6), agent, Operation.Sign, "key:tax-2026")
+    )
+    recs.traverse_(sink.write).as(recs)
+
+  test("query with no filters returns all rows ordered by occurred_at DESC") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter())
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 7
+      page.hasMore shouldBe false
+      page.limit shouldBe AuditQuery.DefaultLimit
+      page.offset shouldBe 0
+      // DESC ordering on occurred_at — last seeded row comes first.
+      page.records.head.resource shouldBe "key:tax-2026"
+      page.records.head.operation shouldBe Operation.Sign
+      page.records.last.resource shouldBe "key:invoice-2026"
+    }
+  }
+
+  test("query filters by actor (exact match on actor_subject)") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter(actor = Some("alice@org")))
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 3
+      page.records.forall(_.principal.subject == "alice@org") shouldBe true
+    }
+  }
+
+  test("query filters by resource (exact match)") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter(resource = Some("key:paystubs-2026")))
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 2
+      page.records.forall(_.resource == "key:paystubs-2026") shouldBe true
+    }
+  }
+
+  test("query filters by operation") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter(operation = Some(Operation.Sign)))
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 3
+      page.records.forall(_.operation == Operation.Sign) shouldBe true
+    }
+  }
+
+  test("query filters by since (half-open) and until (exclusive)") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter(
+            since = Some(baseTs.plusSeconds(2)),
+            until = Some(baseTs.plusSeconds(5))
+          ))
+        yield page
+
+      // since is inclusive, until is exclusive → rows at +2, +3, +4 only (3 rows).
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 3
+      page.records.map(_.resource).toSet shouldBe Set("key:invoice-2026", "key:paystubs-2026")
+    }
+  }
+
+  test("query composes filters with AND") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          // actor=agent AND operation=Sign → 2 matching rows (key:invoice-2026 and key:tax-2026).
+          page <- sink.query(AuditQuery.Filter(
+            actor = Some("agent-7a3"),
+            operation = Some(Operation.Sign)
+          ))
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 2
+      page.records.forall(r =>
+        r.principal.subject == "agent-7a3" && r.operation == Operation.Sign
+      ) shouldBe true
+    }
+  }
+
+  test("query honours limit + offset and reports hasMore correctly") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink  <- PostgresAuditSink.bootstrappedFor(xa)
+          _     <- seedRecords(sink) // 7 records
+          page1 <- sink.query(AuditQuery.Filter(limit = 3, offset = 0))
+          page2 <- sink.query(AuditQuery.Filter(limit = 3, offset = 3))
+          page3 <- sink.query(AuditQuery.Filter(limit = 3, offset = 6))
+        yield (page1, page2, page3)
+
+      val (p1, p2, p3) = program.unsafeRunSync()
+      p1.records.size shouldBe 3
+      p1.hasMore shouldBe true
+      p2.records.size shouldBe 3
+      p2.hasMore shouldBe true
+      p3.records.size shouldBe 1
+      p3.hasMore shouldBe false
+    }
+  }
+
+  test("query clamps limit to MaxLimit and offset to >= 0 (defensive against client input)") {
+    withPostgres { xa =>
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- seedRecords(sink)
+          page <- sink.query(AuditQuery.Filter(limit = 10000, offset = -5))
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.limit shouldBe AuditQuery.MaxLimit
+      page.offset shouldBe 0
+    }
+  }
+
+  test("query round-trips the context JSONB back into Map[String, String]") {
+    withPostgres { xa =>
+      val ctx = Map("risk.score" -> "0.42", "outcome.decision" -> "Allow")
+      val program =
+        for
+          sink <- PostgresAuditSink.bootstrappedFor(xa)
+          _    <- sink.write(record(baseTs, alice, Operation.Sign, "key:k1", context = ctx))
+          page <- sink.query(AuditQuery.Filter())
+        yield page
+
+      val page = program.unsafeRunSync()
+      page.records.size shouldBe 1
+      page.records.head.context shouldBe ctx
     }
   }

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -6,6 +6,8 @@ import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 
+import java.time.Instant
+
 /** Pure Tapir endpoint definitions. No server logic, no Pekko types — these can be reused by the OpenAPI
   * generator, by sttp clients in `aegis-sdk-scala`, and by the test stub interpreter.
   *
@@ -255,6 +257,65 @@ object Endpoints:
           "deliberately short because the only revocation mechanism is the JTI blacklist that lands in #24)."
       )
 
+  // ── Audit read (#20) ──────────────────────────────────────────────────────
+
+  /** Common base for the audit-read surface — `/v1/audit`, same auth headers, same error contract, distinct
+    * OpenAPI tag so Swagger groups the endpoint with future audit-read additions.
+    */
+  private val auditBase =
+    endpoint
+      .in("v1" / "audit")
+      .in(authHeader)
+      .in(devUserHeader)
+      .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
+      .tag("audit")
+
+  /** `GET /v1/audit` — paginated read of `aegis_audit_events`. Filters compose with AND. Only
+    * `Principal.Human` callers are permitted (Service and Agent return 403); this is a deliberate v0.2.0
+    * simplification of the future "audit:read permission via policy engine" model.
+    *
+    * Query parameters:
+    *   - `since` — ISO-8601 instant; rows with `occurred_at >= since` (inclusive).
+    *   - `until` — ISO-8601 instant; rows with `occurred_at < until` (exclusive).
+    *   - `actor` — exact match on `actor_subject`.
+    *   - `key` — exact match on `resource` (e.g. `"key:abc-123"` or `"agent:agent-7a3"`).
+    *   - `op` — KMIP Operation enum name (`Sign`, `Get`, …).
+    *   - `limit` — page size, default 100, max 1000.
+    *   - `offset` — starting row offset, default 0.
+    */
+  val queryAudit: PublicEndpoint[
+    (
+        Option[String],
+        Option[String],
+        Option[Instant],
+        Option[Instant],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[Int],
+        Option[Int]
+    ),
+    (StatusCode, KmsErrorDto),
+    AuditQueryResponseDto,
+    Any
+  ] =
+    auditBase.get
+      .in(query[Option[Instant]]("since").description("ISO-8601 lower bound (inclusive) on occurred_at"))
+      .in(query[Option[Instant]]("until").description("ISO-8601 upper bound (exclusive) on occurred_at"))
+      .in(query[Option[String]]("actor").description(
+        "Exact match on actor_subject (e.g. 'alice@org', 'agent-7a3', 'aegis-system')"
+      ))
+      .in(query[Option[String]]("key").description("Exact match on resource (e.g. 'key:abc-123')"))
+      .in(query[Option[String]]("op").description("KMIP Operation enum name (Sign / Get / Encrypt / …)"))
+      .in(query[Option[Int]]("limit").description("Page size; defaults to 100, capped at 1000"))
+      .in(query[Option[Int]]("offset").description("Starting row offset for paging; defaults to 0"))
+      .out(jsonBody[AuditQueryResponseDto])
+      .summary("Query the audit log")
+      .description(
+        "Paginated read of `aegis_audit_events`. Filters compose with AND. Caller must be a " +
+          "human principal — service and agent principals are refused with 403."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -270,5 +331,6 @@ object Endpoints:
       unwrapKey,
       compromiseKey,
       rotateKey,
-      issueAgent
+      issueAgent,
+      queryAudit
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -2,7 +2,7 @@ package dev.aegiskms.http
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import dev.aegiskms.audit.{AuditRecord, AuditSink}
+import dev.aegiskms.audit.{AuditQuery, AuditRecord, AuditSink}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
 import dev.aegiskms.iam.{AgentTokenIssuer, IssueAgentRequest as IamIssueAgentRequest, PrincipalResolver}
@@ -39,7 +39,12 @@ final class HttpRoutes(
       * endpoints) needs an explicit hookup because it bypasses that decorator. When `None`, agent issuances
       * are not recorded — operators who care about forensics MUST wire this in production.
       */
-    auditSink: Option[AuditSink[IO]] = None
+    auditSink: Option[AuditSink[IO]] = None,
+    /** Optional `AuditQuery` backing the `GET /v1/audit` audit-read endpoint. Provided by `Server.boot` only
+      * when `aegis.audit.kind=postgres` (the only sink that implements `AuditQuery`). When `None`, `GET
+      * /v1/audit` returns `501 FeatureNotSupported`.
+      */
+    auditReader: Option[AuditQuery[IO]] = None
 )(using runtime: IORuntime):
 
   private given ExecutionContext = runtime.compute
@@ -331,6 +336,71 @@ final class HttpRoutes(
               runIO(issueAndAudit).map(_.left.map(errorOut))
     }
 
+  /** `GET /v1/audit` — paginated read of `aegis_audit_events`. Caller must be a `Principal.Human` (Service +
+    * Agent return 403). When the server isn't wired with an `AuditQuery` (i.e. audit kind ≠ postgres), this
+    * returns 501 NotImplemented.
+    */
+  private val queryAuditSE: ServerEndpoint[Any, Future] =
+    Endpoints.queryAudit.serverLogic { case (auth, devHdr, since, until, actor, key, op, limit, offset) =>
+      principalOf(auth, devHdr) match
+        case Left(e) => Future.successful(Left(e))
+        case Right(principal) =>
+          principal match
+            case _: Principal.Human =>
+              auditReader match
+                case None =>
+                  // Audit-read isn't wired (e.g. aegis.audit.kind=stdout). Surface the same way
+                  // we do for /agents/issue when its dependency is missing.
+                  Future.successful(Left(
+                    StatusCode.NotImplemented -> KmsErrorDto.of(
+                      ErrorCode.FeatureNotSupported,
+                      "audit query is not enabled on this server (set aegis.audit.kind=postgres)"
+                    )
+                  ))
+                case Some(reader) =>
+                  // Parse the optional `op` filter. Unknown op names are user error → 400, not
+                  // an empty result (silent empty would mask the typo).
+                  val parsedOp: Either[(StatusCode, KmsErrorDto), Option[Operation]] = op match
+                    case None => Right(None)
+                    case Some(name) =>
+                      Operation.values
+                        .find(_.toString == name)
+                        .toRight(StatusCode.BadRequest -> KmsErrorDto.of(
+                          ErrorCode.InvalidField,
+                          s"unknown op '$name'; expected one of: ${Operation.values.map(_.toString).mkString(", ")}"
+                        ))
+                        .map(Some(_))
+                  parsedOp match
+                    case Left(e) => Future.successful(Left(e))
+                    case Right(opVal) =>
+                      val filter = AuditQuery.Filter(
+                        since = since,
+                        until = until,
+                        actor = actor,
+                        resource = key,
+                        operation = opVal,
+                        limit = limit.getOrElse(AuditQuery.DefaultLimit),
+                        offset = offset.getOrElse(0)
+                      )
+                      runIO(reader.query(filter)).map { page =>
+                        Right(AuditQueryResponseDto(
+                          records = page.records.map(AuditRecordDto.fromCore),
+                          limit = page.limit,
+                          offset = page.offset,
+                          hasMore = page.hasMore
+                        ))
+                      }
+            case _ =>
+              // Service + Agent are refused. v0.2.0 simplification of the future
+              // "audit:read permission via policy engine" model.
+              Future.successful(Left(
+                StatusCode.Forbidden -> KmsErrorDto.of(
+                  ErrorCode.PermissionDenied,
+                  "audit read is restricted to human principals"
+                )
+              ))
+    }
+
   /** Write one `AuditRecord` per `/v1/agents/issue` call — success OR failure — so operators have a forensic
     * trail of every agent credential ever minted. The audit row captures the caller (the human who issued),
     * the requested scopes + ttl + label (so reviewers can answer "what does this agent have access to"), and
@@ -429,7 +499,8 @@ final class HttpRoutes(
       unwrapSE,
       compromiseSE,
       rotateSE,
-      issueAgentSE
+      issueAgentSE,
+      queryAuditSE
     )
 
   /** Render the live endpoint set as an OpenAPI 3.1 document. The build-time guarantee here is the same one

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -218,3 +218,54 @@ object JsonCodecs:
   object IssueAgentResponseDto:
     given Encoder[IssueAgentResponseDto] = deriveEncoder
     given Decoder[IssueAgentResponseDto] = deriveDecoder
+
+  // ── Audit-read DTOs (#20) ─────────────────────────────────────────────────
+
+  /** One audit row over the wire. Mirrors `AuditRecord` minus the typed `Principal` (which doesn't round-trip
+    * cleanly — the wire format flattens to `actor` + `actorKind` strings) and the typed `Operation` (rendered
+    * as its enum-name string for symmetry with `actorKind`).
+    */
+  final case class AuditRecordDto(
+      at: Instant,
+      actor: String,
+      actorKind: String,
+      operation: String,
+      resource: String,
+      outcome: String,
+      correlationId: String,
+      context: Map[String, String]
+  )
+  object AuditRecordDto:
+    def fromCore(r: dev.aegiskms.audit.AuditRecord): AuditRecordDto =
+      val kind = r.principal match
+        case _: dev.aegiskms.core.Principal.Human   => "Human"
+        case _: dev.aegiskms.core.Principal.Service => "Service"
+        case _: dev.aegiskms.core.Principal.Agent   => "Agent"
+      AuditRecordDto(
+        at = r.at,
+        actor = r.principal.subject,
+        actorKind = kind,
+        operation = r.operation.toString,
+        resource = r.resource,
+        outcome = r.outcome,
+        correlationId = r.correlationId,
+        context = r.context
+      )
+
+    given Encoder[AuditRecordDto] = deriveEncoder
+    given Decoder[AuditRecordDto] = deriveDecoder
+
+  /** Wire response for `GET /v1/audit`. `hasMore = true` means at least one more matching row exists past
+    * `offset + limit`; clients can paginate by repeating with `offset = offset + limit`. No total-count field
+    * — that would force a separate (expensive) `COUNT(*)` per page; the existence flag is enough for "Load
+    * more" UX.
+    */
+  final case class AuditQueryResponseDto(
+      records: List[AuditRecordDto],
+      limit: Int,
+      offset: Int,
+      hasMore: Boolean
+  )
+  object AuditQueryResponseDto:
+    given Encoder[AuditQueryResponseDto] = deriveEncoder
+    given Decoder[AuditQueryResponseDto] = deriveDecoder

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAuditQuerySpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesAuditQuerySpec.scala
@@ -1,0 +1,198 @@
+package dev.aegiskms.http
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import dev.aegiskms.audit.{AuditQuery, AuditRecord}
+import dev.aegiskms.core.{KeyService, Operation, Principal}
+import dev.aegiskms.iam.{JwtClaims, JwtIssuer, JwtVerifier, PrincipalResolver}
+import io.circe.parser.parse
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+/** End-to-end HTTP tests for `GET /v1/audit` (#20). The query layer itself is exercised against real Postgres
+  * in `PostgresAuditSinkSpec`; here we stub out `AuditQuery` and focus on the route's filter parsing, authz,
+  * and response shape.
+  */
+final class HttpRoutesAuditQuerySpec extends AnyFunSuite with Matchers with ScalatestRouteTest:
+
+  private given IORuntime = IORuntime.global
+
+  // Captures the most recent `Filter` so we can assert on what the route sent to the query layer.
+  final private class CapturingQuery extends AuditQuery[IO]:
+    @volatile var lastFilter: Option[AuditQuery.Filter] = None
+    @volatile var nextPage: AuditQuery.Page             = AuditQuery.Page(Nil, 100, 0, false)
+
+    def query(filter: AuditQuery.Filter): IO[AuditQuery.Page] =
+      IO {
+        lastFilter = Some(filter)
+        nextPage
+      }
+
+  private val secret   = "test-secret-test-secret-test-secret-12345"
+  private val verifier = JwtVerifier.hmac(secret)
+  private val issuer   = JwtIssuer.hmac(secret)
+
+  private def routeWithReader(reader: AuditQuery[IO]): Route =
+    HttpRoutes(KeyService.inMemory.unsafeRunSync(), auditReader = Some(reader)).routes
+
+  private def routeWithoutReader(): Route =
+    HttpRoutes(KeyService.inMemory.unsafeRunSync()).routes
+
+  private def jwtRouteWithReader(reader: AuditQuery[IO]): Route =
+    HttpRoutes(
+      KeyService.inMemory.unsafeRunSync(),
+      resolver = PrincipalResolver.jwt(verifier),
+      auditReader = Some(reader)
+    ).routes
+
+  private def humanToken(subject: String): String =
+    val now = Instant.now()
+    issuer.issue(JwtClaims.Human(
+      subject = subject,
+      issuer = None,
+      issuedAt = now,
+      expiresAt = now.plus(1, ChronoUnit.HOURS),
+      groups = Set.empty,
+      jti = UUID.randomUUID().toString
+    ))
+
+  private def agentToken(subject: String): String =
+    val now = Instant.now()
+    issuer.issue(JwtClaims.Agent(
+      subject = subject,
+      issuer = None,
+      issuedAt = now,
+      expiresAt = now.plus(1, ChronoUnit.HOURS),
+      parentSubject = "alice@org",
+      purpose = "test",
+      allowedOps = Set("Get"),
+      jti = UUID.randomUUID().toString
+    ))
+
+  // ── Happy path + response shape ───────────────────────────────────────────
+
+  test("GET /v1/audit with no filters returns 200 and an empty records array") {
+    val reader = CapturingQuery()
+    val req    = Get("/v1/audit").withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithReader(reader) ~> check {
+      status shouldBe StatusCodes.OK
+      val json = parse(responseAs[String]).toOption.get.hcursor
+      json.downField("records").as[List[io.circe.Json]].toOption.get shouldBe empty
+      json.downField("limit").as[Int].toOption shouldBe Some(100)
+      json.downField("offset").as[Int].toOption shouldBe Some(0)
+      json.downField("hasMore").as[Boolean].toOption shouldBe Some(false)
+    }
+  }
+
+  test("records returned by the query layer round-trip through the wire DTO") {
+    val reader = CapturingQuery()
+    val sample = AuditRecord(
+      at = Instant.parse("2026-05-20T10:00:00Z"),
+      principal = Principal.Human("alice@org", Set("admins")),
+      operation = Operation.Sign,
+      resource = "key:abc",
+      outcome = "Success alg=RsaPssSha256",
+      correlationId = "corr-1",
+      context = Map("risk.score" -> "0.42", "outcome.decision" -> "Allow")
+    )
+    reader.nextPage = AuditQuery.Page(List(sample), 100, 0, false)
+
+    val req = Get("/v1/audit").withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithReader(reader) ~> check {
+      status shouldBe StatusCodes.OK
+      val rec = parse(responseAs[String]).toOption.get.hcursor.downField("records").downArray
+      rec.downField("actor").as[String].toOption shouldBe Some("alice@org")
+      rec.downField("actorKind").as[String].toOption shouldBe Some("Human")
+      rec.downField("operation").as[String].toOption shouldBe Some("Sign")
+      rec.downField("resource").as[String].toOption shouldBe Some("key:abc")
+      rec.downField("correlationId").as[String].toOption shouldBe Some("corr-1")
+      rec.downField("context").downField("risk.score").as[String].toOption shouldBe Some("0.42")
+    }
+  }
+
+  // ── Filter parsing ────────────────────────────────────────────────────────
+
+  test("query parameters land in AuditQuery.Filter with correct types") {
+    val reader = CapturingQuery()
+    val req = Get(
+      "/v1/audit?since=2026-05-20T00:00:00Z&until=2026-05-21T00:00:00Z&actor=alice@org&key=key:abc&op=Sign&limit=50&offset=100"
+    ).withHeaders(RawHeader("X-Aegis-User", "alice"))
+
+    req ~> routeWithReader(reader) ~> check {
+      status shouldBe StatusCodes.OK
+      val f = reader.lastFilter.get
+      f.since shouldBe Some(Instant.parse("2026-05-20T00:00:00Z"))
+      f.until shouldBe Some(Instant.parse("2026-05-21T00:00:00Z"))
+      f.actor shouldBe Some("alice@org")
+      f.resource shouldBe Some("key:abc")
+      f.operation shouldBe Some(Operation.Sign)
+      f.limit shouldBe 50
+      f.offset shouldBe 100
+    }
+  }
+
+  test("unknown operation name rejects with 400 InvalidField (not silent empty result)") {
+    val reader = CapturingQuery()
+    val req    = Get("/v1/audit?op=NotAnOp").withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithReader(reader) ~> check {
+      status shouldBe StatusCodes.BadRequest
+      val body = responseAs[String]
+      body should include(""""code":"InvalidField"""")
+      body should include("NotAnOp")
+      reader.lastFilter shouldBe None // query never invoked when op parse fails
+    }
+  }
+
+  // ── Authz ─────────────────────────────────────────────────────────────────
+
+  test("Human Bearer token successfully reads the audit log") {
+    val reader = CapturingQuery()
+    val token  = humanToken("alice@org")
+    val req    = Get("/v1/audit").withHeaders(RawHeader("Authorization", s"Bearer $token"))
+    req ~> jwtRouteWithReader(reader) ~> check {
+      status shouldBe StatusCodes.OK
+      reader.lastFilter shouldBe defined
+    }
+  }
+
+  test("Agent principals are refused with 403 (audit-read is human-only in v0.2.0)") {
+    val reader = CapturingQuery()
+    val token  = agentToken("agent-7a3")
+    val req    = Get("/v1/audit").withHeaders(RawHeader("Authorization", s"Bearer $token"))
+    req ~> jwtRouteWithReader(reader) ~> check {
+      status shouldBe StatusCodes.Forbidden
+      responseAs[String] should include("audit read is restricted to human principals")
+      reader.lastFilter shouldBe None
+    }
+  }
+
+  test("no audit reader wired → 501 NotImplemented with FeatureNotSupported") {
+    val req = Get("/v1/audit").withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithoutReader() ~> check {
+      status shouldBe StatusCodes.NotImplemented
+      responseAs[String] should include(""""code":"FeatureNotSupported"""")
+    }
+  }
+
+  // ── Pagination ────────────────────────────────────────────────────────────
+
+  test("hasMore=true from the query layer propagates to the wire response") {
+    val reader = CapturingQuery()
+    reader.nextPage = AuditQuery.Page(Nil, 50, 100, true)
+    val req = Get("/v1/audit?limit=50&offset=100").withHeaders(RawHeader("X-Aegis-User", "alice"))
+    req ~> routeWithReader(reader) ~> check {
+      status shouldBe StatusCodes.OK
+      val json = parse(responseAs[String]).toOption.get.hcursor
+      json.downField("hasMore").as[Boolean].toOption shouldBe Some(true)
+      json.downField("limit").as[Int].toOption shouldBe Some(50)
+      json.downField("offset").as[Int].toOption shouldBe Some(100)
+    }
+  }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -12,7 +12,7 @@ import dev.aegiskms.agent.{
   TappedAuditSink,
   ThresholdDecisionEngine
 }
-import dev.aegiskms.audit.{AuditSink, AuditingKeyService, PostgresAuditSink, StdoutAuditSink}
+import dev.aegiskms.audit.{AuditQuery, AuditSink, AuditingKeyService, PostgresAuditSink, StdoutAuditSink}
 import dev.aegiskms.http.HttpRoutes
 import dev.aegiskms.iam.{AgentTokenIssuer, AuthorizingKeyService, JwtIssuer, JwtVerifier, PrincipalResolver}
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
@@ -169,7 +169,19 @@ object Server extends IOApp.Simple:
           // agent credential minted (the keys surface is already covered by `AuditingKeyService`
           // wrapping `traced`, but agent issuance is not on the `KeyService` algebra and would
           // otherwise be invisible to operators).
-          HttpRoutes(auditing, resolver, Some(agentIssuer), Some(stdoutSink)).routes,
+          // Audit-read endpoint (#20): only wired when the sink is a `PostgresAuditSink` (the
+          // only impl that satisfies the `AuditQuery` SPI). With `aegis.audit.kind=stdout`,
+          // `GET /v1/audit` returns 501 NotImplemented — same shape as `/v1/agents/issue` when
+          // no issuer is configured.
+          HttpRoutes(
+            auditing,
+            resolver,
+            Some(agentIssuer),
+            Some(stdoutSink),
+            stdoutSink match
+              case q: AuditQuery[IO @unchecked] => Some(q)
+              case _                            => None
+          ).routes,
           MetricsRoutes.route(metricsRegistry)
         )
       _ <- httpBindingResource(host, port, appRoute)

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,8 +16,8 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 13 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
-    // wrap, unwrap, compromise, rotate) + agents/issue (#18). Bump this when a new top-level
-    // REST surface lands.
-    routes.serverEndpoints.size shouldBe 13
+    // 14 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap, compromise, rotate) + agents/issue (#18) + audit/query (#20). Bump this
+    // when a new top-level REST surface lands.
+    routes.serverEndpoints.size shouldBe 14
   }


### PR DESCRIPTION
## Summary
The read side of the audit pipeline. Operators (and the upcoming \`aegis audit tail\` CLI) can now query \`aegis_audit_events\` over REST instead of needing direct SQL access.

- New \`AuditQuery[F[_]]\` SPI in \`aegis-audit\`. \`PostgresAuditSink\` implements both \`AuditSink\` AND \`AuditQuery\` — one impl, two responsibilities.
- New Tapir endpoint \`GET /v1/audit?since&until&actor&key&op&limit&offset\`. Returns \`{records, limit, offset, hasMore}\`.
- Authz: humans only. Service + Agent → 403. Unknown \`op\` → 400. No query-capable sink wired → 501.
- Wired in \`Server.boot\` via pattern match — \`PostgresAuditSink\` becomes the reader; \`StdoutAuditSink\` doesn't.

Backs the \`aegis audit tail\` CLI stub. Unblocks operator-facing audit-investigation workflows.

## Test plan
- [x] \`sbt test\` — 345 pass, 0 failures
- [x] \`sbt audit/test\` — 22 + 17 Docker-gated (8 new query tests will run in CI)
- [x] \`sbt http/test\` — 58 (8 new HTTP-level cases for the endpoint)
- [x] \`sbt scalafmtCheckAll scalafmtSbtCheck \"scalafixAll --check\"\` — all green
- [ ] CI: the 17 Postgres-audit tests (including the 8 new query tests) run against a real Postgres 16
- [ ] Manual against \`:main\` image post-merge: set \`AEGIS_AUDIT_KIND=postgres\`, hit a few key ops, then \`curl http://localhost:8080/v1/audit?actor=alice\` → see the rows