### PR TITLE
feat(server): wire AwsKmsRootOfTrust into Server.boot + close v0.2.0 doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **`AwsKmsRootOfTrust` wired into `Server.boot`.** Closes a doc-vs-code gap surfaced during the
+  v0.2.0 readiness audit. The AWS adapter has shipped in the `aegis-crypto` library since v0.1.x
+  (17 passing tests), but `Server.boot` was constructing `ActorBackedKeyService(system)` with the
+  default `RootOfTrust.inMemory` (deterministic-MAC dev backend) — meaning the published Docker
+  image used the dev backend regardless of how it was configured. The status / comparison docs
+  claimed "AWS KMS — Shipped" while the running server signed with HMAC. Fix:
+  - New `aegis.crypto.kind` HOCON key (`in-memory` (default) | `aws-kms`) with
+    `AEGIS_CRYPTO_KIND` env-var override.
+  - New `aegis.crypto.aws-kms.region` + `aegis.crypto.aws-kms.kek-arn` keys
+    (`AEGIS_CRYPTO_AWS_KMS_REGION` / `AEGIS_CRYPTO_AWS_KMS_KEK_ARN`); missing config fails fast
+    at boot, never silently falls back to dev.
+  - New `AwsKmsRootOfTrust.resource(cfg): Resource[IO, AwsKmsRootOfTrust]` factory wraps the
+    `KmsClient` in a cats-effect `Resource` so the SDK's connection pool / metric publisher /
+    background threads are released on SIGTERM. The pre-existing `fromConfig` is kept (with a
+    docstring warning about the leaked client) so single-shot scripts and embedder code that
+    manages its own KMS-client lifecycle stay supported.
+  - `Server.boot` gains a `rootOfTrustResource(config)` builder paralleling `journalResource`;
+    the in-memory branch logs a `warn` flagging "NOT a real KMS, set kind=aws-kms for
+    production" so operators can't accidentally rely on the dev backend.
+
+### Changed
+
+- **Doc drift cleanup, v0.2.0 readiness audit.**
+  - `CHANGELOG.md` removed duplicate `### Added` heading in the Unreleased section (merged into
+    a single Added block).
+  - `docs/about/status.md` corrected GCP KMS / Azure Key Vault / HashiCorp Vault Transit rows
+    from "v0.2.0" to "v0.3.0" (matches ROADMAP §3.0.a–c).
+  - `docs/about/status.md` corrected the OIDC / JWKS row from "WIP" to "Designed" (no commits
+    yet; the trait is in place but no implementation).
+  - `docs/about/status.md` AWS KMS row now explicitly states the `Server.boot` wiring path
+    instead of leaving it implicit.
+  - `docs/about/status.md` KMIP and MCP rows now reference v0.4.0 (matches ROADMAP §4.0.*)
+    instead of the previous v0.2.0 overclaim.
+  - `docs/about/comparison.md` KMIP and MCP-native rows corrected from "Designed (v0.2.0)" to
+    "Designed (v0.4.0)".
+
 - **Audit-read REST API: `GET /v1/audit` (closes #20).** New `AuditQuery[F[_]]` SPI in
   `aegis-audit` with `Filter` (since / until / actor / resource / operation / limit / offset)
   and `Page` (records / limit / offset / hasMore). `PostgresAuditSink` now implements both
@@ -114,8 +150,6 @@ All notable changes to Aegis will be documented here. This project follows
   `aegis-system` auto-revoke audit row, and exercising the decision adapter's `PermissionDenied` path.
   Time estimate updated 10 → 15 min, the introductory "What you'll have when you're done" callout
   spells out the wedge-demo deliverable so newcomers know what makes Aegis different before they start.
-
-### Added
 
 - **Auto-responder — recommendations become actions (closes #17).** New `AutoResponder` in
   `aegis-agent-ai` is itself a `RecommendationSink`: it decorates the existing in-memory store, so

--- a/docs/about/comparison.md
+++ b/docs/about/comparison.md
@@ -17,8 +17,8 @@ your decision matrix, not assume it.
 | **Agent identity in audit** | No | Workload identity (not agent-aware) | Workload identity | No | First-class (`agent_id`, `session_id`, `tool_name`) |
 | **Risk-scored decisions** | No | No | No | No | `Allow` / `StepUp` / `Deny` from a [0,1] risk score with structured reasoning (v0.2.0) |
 | **Auto-response to anomalies** | CloudTrail → Lambda (DIY) | Audit device → external pipeline (DIY) | Audit device → external pipeline (DIY) | Cloud Audit → Pub/Sub (DIY) | First-class `AutoResponder` with default rules + cooldown (v0.2.0) |
-| **KMIP** | No | Enterprise only | Roadmap | No | Designed (v0.2.0) |
-| **MCP-native** | No | No | No | No | Designed (v0.2.0) |
+| **KMIP** | No | Enterprise only | Roadmap | No | Designed (v0.4.0) |
+| **MCP-native** | No | No | No | No | Designed (v0.4.0) |
 | **Policy engine** | AWS IAM | Vault HCL policies | Vault HCL policies | Cloud IAM | Boolean policy (v0.1.x) + risk overlay (v0.2.0); richer policies (v0.3.0) |
 | **HSM-backed** | CloudHSM | Enterprise only | Roadmap | Cloud HSM | Via AWS KMS RoT today |
 | **OSS contributors** | N/A | 200+ | 100+ | N/A | <5 |

--- a/docs/about/status.md
+++ b/docs/about/status.md
@@ -39,7 +39,7 @@ roadmapped, not shipped.
 | `Principal.Human` / `Principal.Agent` ADT | :material-check: Shipped | Sealed trait, total case analysis |
 | Dev-mode `X-Aegis-User` header | :material-check: Shipped | Workstation only |
 | JWT bearer auth (HS256) | :material-check: Shipped | Configurable secret |
-| OIDC / JWKS verification | :material-progress-clock: WIP | v0.2.0 |
+| OIDC / JWKS verification + RS256/ES256 | :material-blueprint: Designed | v0.2.0 (#25 — trait in place, no impl) |
 | Agent-token issuance endpoint | :material-blueprint: Designed | v0.2.0 |
 | Policy engine (rules richer than allow/deny per principal) | :material-blueprint: Designed | v0.3.0 |
 
@@ -78,10 +78,10 @@ roadmapped, not shipped.
 
 | Capability | Status | Detail |
 |---|---|---|
-| AWS KMS | :material-check: Shipped | Full sign/verify/encrypt/decrypt/wrap/unwrap |
-| GCP KMS | :material-blueprint: Designed | v0.2.0 |
-| Azure Key Vault | :material-blueprint: Designed | v0.2.0 |
-| HashiCorp Vault Transit | :material-blueprint: Designed | v0.2.0 |
+| AWS KMS | :material-check: Shipped | Full sign/verify/encrypt/decrypt/wrap/unwrap. `Server.boot` wires it when `aegis.crypto.kind=aws-kms` (with region + KEK ARN env vars). |
+| GCP KMS | :material-blueprint: Designed | v0.3.0 (per ROADMAP §3.0.a) |
+| Azure Key Vault | :material-blueprint: Designed | v0.3.0 (per ROADMAP §3.0.b) |
+| HashiCorp Vault Transit | :material-blueprint: Designed | v0.3.0 (per ROADMAP §3.0.c) |
 | PKCS#11 / HSM | :material-blueprint: Designed | v0.4.0 |
 
 ### Wire planes
@@ -89,8 +89,8 @@ roadmapped, not shipped.
 | Capability | Status | Detail |
 |---|---|---|
 | REST `/v1/keys/*` | :material-check: Shipped | Full surface, OpenAPI documented |
-| KMIP server (TCP + TLS) | :material-blueprint: Designed | Skeleton in `aegis-kmip`; v0.2.0 lands the wire |
-| MCP server (LLM tool surface) | :material-blueprint: Designed | Skeleton in `aegis-mcp-server`; v0.2.0 |
+| KMIP server (TCP + TLS) | :material-blueprint: Designed | Trait + DTO skeleton in `aegis-kmip`; v0.4.0 lands the wire (per ROADMAP §4.0.a–c) |
+| MCP server (LLM tool surface) | :material-blueprint: Designed | Skeleton (`tools` list only) in `aegis-mcp-server`; v0.4.0 (per ROADMAP §4.0.e) |
 | Agent-AI plane | :material-check: Shipped | Detector + risk scorer + decision adapter + auto-responder all wired in `Server.boot` |
 
 ### Distribution & deployment

--- a/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
+++ b/modules/aegis-crypto/src/main/scala/dev/aegiskms/crypto/aws/AwsKmsRootOfTrust.scala
@@ -1,6 +1,6 @@
 package dev.aegiskms.crypto.aws
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import dev.aegiskms.core.{
   Algorithm,
   Ciphertext,
@@ -156,9 +156,28 @@ object AwsKmsRootOfTrust:
   def withPort(port: AwsKmsPort, kekArn: String): AwsKmsRootOfTrust =
     new AwsKmsRootOfTrust(port, kekArn)
 
-  /** Build a default AWS-region-configured client and wrap. Suitable for production. */
+  /** Build a default AWS-region-configured client and wrap. Suitable for production.
+    *
+    * The returned `AwsKmsRootOfTrust` owns a `KmsClient` that is **never closed**. Use this only for one-shot
+    * scripts, embedder code that manages its own KMS-client lifecycle, or tests. Long-running servers should
+    * use [[resource]] instead, which wraps the client in a cats-effect `Resource` and closes it on shutdown.
+    */
   def fromConfig(cfg: Config): AwsKmsRootOfTrust =
     val client: KmsClient = KmsClient.builder()
       .region(software.amazon.awssdk.regions.Region.of(cfg.region))
       .build()
     new AwsKmsRootOfTrust(AwsKmsPort.fromClient(client), cfg.kekArn)
+
+  /** Resource-managed builder for `AwsKmsRootOfTrust`. The underlying `KmsClient` is `AutoCloseable` and is
+    * registered with cats-effect `Resource` so the connection-pool / metric-publisher / SDK background
+    * threads inside the client are released on `SIGTERM`. This is the right constructor for `Server.boot`.
+    */
+  def resource(cfg: Config): Resource[IO, AwsKmsRootOfTrust] =
+    Resource
+      .fromAutoCloseable(IO {
+        KmsClient
+          .builder()
+          .region(software.amazon.awssdk.regions.Region.of(cfg.region))
+          .build()
+      })
+      .map(client => new AwsKmsRootOfTrust(AwsKmsPort.fromClient(client), cfg.kekArn))

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -39,6 +39,26 @@ aegis {
     }
   }
 
+  crypto {
+    # "in-memory" — deterministic-MAC dev backend. NOT a real KMS. Signatures are HMAC(KeyId,
+    #               msg); encryption is XOR-with-stream. Suitable for local dev, the wedge demo,
+    #               and integration tests; never for production data.
+    # "aws-kms"   — AwsKmsRootOfTrust against the configured AWS region. Requires `aws-kms.region`
+    #               and `aws-kms.kek-arn` (the ARN of the customer master key used as the KEK in
+    #               layered-mode key generation). Credentials come from the AWS SDK default
+    #               provider chain (env vars, instance metadata, SSO, etc.).
+    # GCP / Azure / Vault / PKCS#11 adapters are roadmapped for v0.3.0 / v0.4.0.
+    kind = "in-memory"
+    kind = ${?AEGIS_CRYPTO_KIND}
+
+    aws-kms {
+      region  = ""
+      region  = ${?AEGIS_CRYPTO_AWS_KMS_REGION}
+      kek-arn = ""
+      kek-arn = ${?AEGIS_CRYPTO_AWS_KMS_KEK_ARN}
+    }
+  }
+
   audit {
     # "stdout"   — write every AuditRecord to stdout (default; what the docs/demos use).
     # "postgres" — write every AuditRecord to the `aegis_audit_events` table, indexed for the

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -13,6 +13,8 @@ import dev.aegiskms.agent.{
   ThresholdDecisionEngine
 }
 import dev.aegiskms.audit.{AuditQuery, AuditSink, AuditingKeyService, PostgresAuditSink, StdoutAuditSink}
+import dev.aegiskms.crypto.RootOfTrust
+import dev.aegiskms.crypto.aws.AwsKmsRootOfTrust
 import dev.aegiskms.http.HttpRoutes
 import dev.aegiskms.iam.{AgentTokenIssuer, AuthorizingKeyService, JwtIssuer, JwtVerifier, PrincipalResolver}
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
@@ -105,11 +107,17 @@ object Server extends IOApp.Simple:
       given ActorSystem[KeyOpsActor.Command] = system
       given Scheduler                        = system.scheduler
 
+      // 3b. Root of Trust. `aegis.crypto.kind=in-memory` (default) uses the deterministic-MAC
+      //     dev backend — NOT a real KMS. `aegis.crypto.kind=aws-kms` uses `AwsKmsRootOfTrust`
+      //     with a Resource-managed `KmsClient` (closed on SIGTERM). The choice happens here so
+      //     ActorBackedKeyService stays unaware of which backend it's talking to.
+      rootOfTrust <- rootOfTrustResource(rootConfig)
+
       // 4. Decorate. Auth → metrics → tracing → audit; see the class docstring for why this order
       //    matters. Tracing sits between metrics and audit so the trace span measures auth + actor
       //    + journal as one unit; metrics record their own (smaller) timer next to it; audit stays
       //    the outermost layer so the audit row reflects the post-trace outcome.
-      actorBacked = new ActorBackedKeyService(system)
+      actorBacked = new ActorBackedKeyService(system, rootOfTrust)
       authorizing = new AuthorizingKeyService(actorBacked, new DevPolicyEngine)
       metered     = new MeteredKeyService(authorizing, metricsRegistry)
       traced      = new TracingKeyService(metered, tracer)
@@ -237,6 +245,51 @@ object Server extends IOApp.Simple:
       case other =>
         Resource.eval(IO.raiseError(new IllegalArgumentException(
           s"Unknown aegis.persistence.journal.kind=$other (expected 'in-memory' or 'postgres')"
+        )))
+
+  /** Root-of-Trust as a Resource — the crypto backend that does the actual sign / verify / wrap / unwrap work
+    * behind `KeyService`.
+    *
+    *   - `aegis.crypto.kind=in-memory` (default) — deterministic-MAC dev backend. **Not a real KMS** —
+    *     signatures are HMAC(KeyId, msg), encryption is XOR-with-stream. Suitable for local development, the
+    *     wedge demo, and integration tests; never for production data.
+    *   - `aegis.crypto.kind=aws-kms` — `AwsKmsRootOfTrust` against the configured AWS region with a
+    *     Resource-managed `KmsClient` (closed on SIGTERM). Requires `aegis.crypto.aws-kms.region` and
+    *     `aegis.crypto.aws-kms.kek-arn` to be set; the AWS SDK's default credential provider chain handles
+    *     authentication (env vars, instance metadata, SSO, etc. — see the AWS SDK docs).
+    *
+    * GCP / Azure / Vault / PKCS#11 adapters are roadmapped for v0.3.0 / v0.4.0; until they ship, this method
+    * only knows about `in-memory` and `aws-kms`. Misconfiguration fails fast at boot — silent fallback to the
+    * dev backend would be a security hole.
+    */
+  private def rootOfTrustResource(config: Config): Resource[IO, RootOfTrust[IO]] =
+    config.getString("aegis.crypto.kind") match
+      case "in-memory" =>
+        Resource.eval(IO {
+          logger.warn(
+            "crypto: in-memory (deterministic-MAC dev backend — NOT a real KMS). " +
+              "Set aegis.crypto.kind=aws-kms (with aegis.crypto.aws-kms.{region,kek-arn}) for production."
+          )
+          RootOfTrust.inMemory
+        })
+      case "aws-kms" =>
+        val region = config.getString("aegis.crypto.aws-kms.region")
+        val kekArn = config.getString("aegis.crypto.aws-kms.kek-arn")
+        if region.isEmpty then
+          Resource.eval(IO.raiseError(new IllegalArgumentException(
+            "aegis.crypto.kind=aws-kms requires aegis.crypto.aws-kms.region (set AEGIS_CRYPTO_AWS_KMS_REGION)"
+          )))
+        else if kekArn.isEmpty then
+          Resource.eval(IO.raiseError(new IllegalArgumentException(
+            "aegis.crypto.kind=aws-kms requires aegis.crypto.aws-kms.kek-arn (set AEGIS_CRYPTO_AWS_KMS_KEK_ARN)"
+          )))
+        else
+          Resource.eval(IO(logger.info(
+            s"crypto: aws-kms (region=$region, kek-arn=$kekArn)"
+          ))) *> AwsKmsRootOfTrust.resource(AwsKmsRootOfTrust.Config(region, kekArn)).widen
+      case other =>
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          s"Unknown aegis.crypto.kind=$other (expected 'in-memory' or 'aws-kms')"
         )))
 
   /** Actor system as a Resource. `terminate()` returns `Future[Terminated]`; we bridge to `IO` so the

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/RootOfTrustResourceSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/RootOfTrustResourceSpec.scala
@@ -1,0 +1,106 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.typesafe.config.ConfigFactory
+import dev.aegiskms.crypto.RootOfTrust
+import dev.aegiskms.crypto.aws.AwsKmsRootOfTrust
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Unit tests for `Server.rootOfTrustResource`. Verifies the config-driven RoT selection that closes the "AWS
+  * KMS shipped but not wired" gap surfaced in the v0.2.0 readiness audit.
+  *
+  * The aws-kms happy path is exercised only at the "we successfully built a RoT instance" level — actual AWS
+  * calls are out of scope (the adapter itself is covered by `AwsKmsRootOfTrustSpec` in aegis-crypto). What we
+  * test here is purely the boot-time selection logic.
+  */
+final class RootOfTrustResourceSpec extends AnyFunSuite with Matchers:
+
+  given IORuntime = IORuntime.global
+
+  // Reflectively invoke the private builder. The builder is private to keep operators from
+  // reaching past Server.boot; tests need access to verify the selection logic.
+  private val server = Server.getClass.getDeclaredMethod(
+    "rootOfTrustResource",
+    classOf[com.typesafe.config.Config]
+  )
+  server.setAccessible(true)
+  private def invoke(cfg: com.typesafe.config.Config) =
+    server.invoke(Server, cfg).asInstanceOf[cats.effect.Resource[IO, RootOfTrust[IO]]]
+
+  // Build a Config from an inline HOCON string. Falls through to defaults from application.conf
+  // for any keys not set so we don't have to re-specify the entire tree.
+  private def cfg(hocon: String) =
+    ConfigFactory.parseString(hocon).withFallback(ConfigFactory.load())
+
+  test("kind=in-memory yields the dev RoT (NOT an AwsKmsRootOfTrust)") {
+    // `RootOfTrust.inMemory` is a `def` that creates a fresh anonymous instance each call, so we
+    // can't use `eq` for identity comparison. We assert by negative type — anything that isn't
+    // `AwsKmsRootOfTrust` is the dev backend (in-memory is the only other production code path).
+    val rot = invoke(cfg("""aegis.crypto.kind = "in-memory" """)).use(IO.pure).unsafeRunSync()
+    rot shouldNot be(a[AwsKmsRootOfTrust])
+  }
+
+  test("kind defaults to in-memory when no override is set (application.conf default)") {
+    val rot = invoke(cfg("")).use(IO.pure).unsafeRunSync()
+    rot shouldNot be(a[AwsKmsRootOfTrust])
+  }
+
+  test("kind=aws-kms with region + kek-arn yields an AwsKmsRootOfTrust") {
+    // The KmsClient connects lazily on the first SDK call, so building the RoT without a real
+    // region/credentials is fine — the AWS SDK validates the region string but doesn't make a
+    // network call here.
+    val hocon = """
+      aegis.crypto {
+        kind = "aws-kms"
+        aws-kms {
+          region  = "us-east-1"
+          kek-arn = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234"
+        }
+      }
+    """
+    val rot   = invoke(cfg(hocon)).use(IO.pure).unsafeRunSync()
+    rot shouldBe a[AwsKmsRootOfTrust]
+  }
+
+  test("kind=aws-kms with missing region fails at boot (no silent fallback to dev)") {
+    val hocon = """
+      aegis.crypto {
+        kind = "aws-kms"
+        aws-kms {
+          region  = ""
+          kek-arn = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234"
+        }
+      }
+    """
+    val ex = intercept[IllegalArgumentException] {
+      invoke(cfg(hocon)).use(IO.pure).unsafeRunSync()
+    }
+    ex.getMessage should include("aegis.crypto.aws-kms.region")
+  }
+
+  test("kind=aws-kms with missing kek-arn fails at boot (no silent fallback to dev)") {
+    val hocon = """
+      aegis.crypto {
+        kind = "aws-kms"
+        aws-kms {
+          region  = "us-east-1"
+          kek-arn = ""
+        }
+      }
+    """
+    val ex = intercept[IllegalArgumentException] {
+      invoke(cfg(hocon)).use(IO.pure).unsafeRunSync()
+    }
+    ex.getMessage should include("aegis.crypto.aws-kms.kek-arn")
+  }
+
+  test("unknown kind fails fast with a clear error message") {
+    val ex = intercept[IllegalArgumentException] {
+      invoke(cfg("""aegis.crypto.kind = "softhsm" """)).use(IO.pure).unsafeRunSync()
+    }
+    ex.getMessage should include("Unknown aegis.crypto.kind=softhsm")
+    ex.getMessage should include("'in-memory'")
+    ex.getMessage should include("'aws-kms'")
+  }


### PR DESCRIPTION
## The gap this closes
\`AwsKmsRootOfTrust\` has shipped in the \`aegis-crypto\` library since v0.1.x with 17 passing tests, but \`Server.boot\` was constructing \`ActorBackedKeyService(system)\` with the default \`RootOfTrust.inMemory\` (the deterministic-MAC dev backend) — meaning **the published Docker image used the dev backend regardless of how it was configured**. status.md / comparison.md / README all claimed \"AWS KMS — Shipped\"; the running server signed with HMAC. Reasonable outside readers read \"shipped\" as \"I can \`docker compose up\` and it talks to AWS KMS.\" That was not true. **This was the single most consequential doc-vs-code drift in the project.**

## Summary
- New \`AwsKmsRootOfTrust.resource(cfg)\` factory wraps the \`KmsClient\` in a cats-effect \`Resource\` so the SDK's connection pool / metrics / background threads release on SIGTERM.
- New \`aegis.crypto.kind\` HOCON key (\`in-memory\` (default) | \`aws-kms\`) with \`AEGIS_CRYPTO_KIND\` env override. \`aegis.crypto.aws-kms.region\` + \`aegis.crypto.aws-kms.kek-arn\` for the AWS path. Missing config fails fast at boot — never silently falls back to dev.
- \`Server.rootOfTrustResource(config)\` builder; in-memory branch logs a clear \`warn\` flagging NOT-a-real-KMS.
- Doc drift cleanup from the readiness audit: CHANGELOG dup heading, status.md GCP/Azure/Vault → v0.3.0, status.md OIDC → Designed, status.md & comparison.md KMIP/MCP → v0.4.0.

## Related issues filed
- **#77** — wire \`RoleBasedPolicyEngine\` in \`Server.boot\` (\`DevPolicyEngine\` is hardcoded in all auth modes; pair with #25)
- **#78** — plumb \`source.ip\` from \`HttpRoutes\` into \`AuditRecord.context\` (\`SourceIpBaseline\` detector is dead in production)
- **#79** — wire \`aegis agent issue\` + \`aegis audit tail\` CLI subcommands (the v0.2.0 demo target literally references commands that print \"not yet wired up\")

## Test plan
- [x] \`sbt test\` — 351 pass, 0 failures
- [x] \`sbt scalafmtCheckAll scalafmtSbtCheck \"scalafixAll --check\"\` — all green
- [x] New \`RootOfTrustResourceSpec\` (6 cases): in-memory default, aws-kms happy path, missing region rejects, missing kek-arn rejects, unknown kind rejects
- [ ] Manual against \`:main\` post-merge: set \`AEGIS_CRYPTO_KIND=aws-kms\` + region + kek-arn against a real AWS KMS CMK; sign a payload; verify the audit row shows the real KMS sig