### PR TITLE
feat(iam+server): Redis-backed JWT revocation list — JTI blacklist (closes #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Redis-backed JWT revocation list — JTI blacklist (closes #24).** The kill-switch
+  primitive the auto-responder's "Revoke" action will use to invalidate an agent's bearer
+  token before its natural expiry.
+  - **`RevocationList[F[_]]` SPI** in `aegis-iam`: `isRevoked(jti)` + `revoke(jti, expiresAt)`.
+    Three impls ship: `RevocationList.noop` (never revoked), `RevocationList.inMemory`
+    (process-local `Ref[Map[jti, expiresAt]]`, lazy TTL evict on read + prune on revoke), and
+    `RedisRevocationList` (in `aegis-server`, Lettuce-backed, key-per-jti with `PEXPIREAT`).
+  - **`RevocationAwareJwtVerifier`** decorator wraps any inner `JwtVerifier` and consults the
+    list after signature + claims validation passes. Inner rejections (Expired,
+    SignatureInvalid, …) short-circuit before the lookup — saves a Redis round-trip on
+    already-bad tokens. Tokens without a `jti` (legacy / non-Aegis-issued) pass through
+    unchecked.
+  - **`JwtError.Revoked(jti)`** variant. `PrincipalResolver.jwt` maps it to
+    `AuthenticationNotSuccessful` with a `"JWT revoked (jti=…)"` message so operators can
+    distinguish "expired naturally" from "killed by auto-responder / admin revoke".
+  - **Fail-open on Redis outage.** `isRevoked` returns `false` if the Redis call throws,
+    logging a `warn`. Bounded security gap = token TTL; the alternative (fail-closed)
+    would create a global outage on a partial-store failure. Operators who need
+    fail-closed semantics can wrap the impl.
+  - **`Server.boot` wiring.** New `aegis.iam.revocation.kind` HOCON key
+    (`none` | `in-memory` (default) | `redis`) + `AEGIS_REVOCATION_KIND` /
+    `AEGIS_REVOCATION_REDIS_URI` / `AEGIS_REVOCATION_REDIS_KEY_PREFIX` env vars. Empty
+    Redis URI when `kind=redis` fails fast at boot — no silent fallback.
+    `buildResolver` now takes the `RevocationList` and wraps the constructed verifier
+    (HMAC / OIDC) with `RevocationAwareJwtVerifier` automatically.
+  - **Lettuce-based Redis client** (`io.lettuce:lettuce-core` 6.4.0). Single-jar dep,
+    synchronous `RedisCommands` wrapped in `IO.blocking` — lighter on the Docker image
+    than redis4cats (which pulls all of cats-effect-redis + Reactor).
+  - **Tests:** 7 unit cases in `RevocationListSpec` (noop, in-memory revoke + lookup,
+    expired-on-read, idempotent revoke, prune-on-revoke, no-store-on-past-expiry, helper);
+    5 decorator cases in `RevocationAwareJwtVerifierSpec` (passthrough, Revoked outcome,
+    no-jti bypass, inner-rejection short-circuit, idempotent double-wrap); 8 Testcontainers
+    cases in `RedisRevocationListSpec` (Docker-gated — basic write/read, TTL eviction,
+    idempotency, prefix isolation, multi-jti lookups, fail-open on closed connection, …).
+
 - **OIDC verifier + JWKS rotation + RS256/ES256 (closes #25).** Production-grade auth path.
   Previously the server could only accept HS256 JWTs signed with a single shared secret
   (`aegis.auth.kind=hmac`) — disqualifying for any real evaluator. New

--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,8 @@ lazy val server = (project in file("modules/aegis-server"))
       "Standalone Aegis-KMS server: wires HTTP / KMIP / MCP / Agent-AI planes around the audited KeyService. Published as a Docker image, not a Maven library.",
     publish / skip := true, // server is shipped as a Docker image, not a Maven artifact
     libraryDependencies ++=
-      pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics ++ Dependencies.tracing,
+      pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics ++ Dependencies.tracing ++
+        Dependencies.redis ++ Dependencies.testcontainersRedis,
     Docker / packageName := "aegis-server",
     dockerBaseImage      := "eclipse-temurin:21-jre",
     // Fork `sbt 'server/run'` into its own JVM. Without this, sbt's in-process classloader and

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtVerifier.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/JwtVerifier.scala
@@ -29,6 +29,12 @@ enum JwtError:
   case Expired
   case InvalidClaims(message: String)
 
+  /** The token's signature and claims are valid, but its `jti` is on the revocation list. Returned by
+    * `RevocationAwareJwtVerifier` and surfaced to operators as a 401 with a clear reason — lets them
+    * distinguish "expired naturally" from "killed early via the auto-responder / agent-revoke endpoint."
+    */
+  case Revoked(jti: String)
+
 object JwtVerifier:
 
   /** Build a verifier that accepts `HS256` JWTs signed with the supplied shared secret.

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/PrincipalResolver.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/PrincipalResolver.scala
@@ -93,3 +93,4 @@ object PrincipalResolver:
     case JwtError.SignatureInvalid      => "JWT signature invalid"
     case JwtError.Expired               => "JWT expired"
     case JwtError.InvalidClaims(reason) => s"invalid JWT claims: $reason"
+    case JwtError.Revoked(jti)          => s"JWT revoked (jti=$jti)"

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RevocationAwareJwtVerifier.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RevocationAwareJwtVerifier.scala
@@ -1,0 +1,41 @@
+package dev.aegiskms.iam
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+
+/** Decorator that consults a [[RevocationList]] after the inner `JwtVerifier` has accepted the token. Keeps
+  * the verifier composition order natural — signature + claims validation first (cheap, no network),
+  * revocation check second (Redis round-trip on cache miss).
+  *
+  * **Why decorate rather than thread the list into every impl.** Every `JwtVerifier` impl (HMAC, OIDC, future
+  * RS256-direct-key) would otherwise need a constructor arg for the list. Composition at the boot site keeps
+  * the impls focused on what they uniquely do (signature verification) and lets the revocation policy be
+  * swapped (noop / in-memory / Redis) without touching the verifier code.
+  *
+  * **What happens on revocation store outage.** `RevocationList.isRevoked` is allowed to return `false` on a
+  * transient store failure (fail-open) — see the trait docstring for the rationale. That means a Redis outage
+  * doesn't lock everyone out; the security gap is bounded by the token's TTL.
+  *
+  * **Why `IORuntime`.** The `JwtVerifier` trait is synchronous (`Either[JwtError, JwtClaims]`) to match the
+  * HTTP layer's expectations. The revocation lookup is `IO`-shaped; we bridge via `unsafeRunSync`. For an
+  * in-memory list this is a Ref read; for Redis it's an async call that still completes well under a
+  * millisecond on a local cluster.
+  *
+  * **Tokens without `jti`.** Older externally-minted tokens may not carry a `jti` claim (the verifier
+  * extracts it as the empty string in that case — see `JwtVerifier.extract`). A tokenless `jti` is treated as
+  * "not revokable" and passes through. The HMAC issuer and OIDC IDPs Aegis-KMS issues for both set `jti`;
+  * only legacy / non-Aegis tokens hit this path.
+  */
+final class RevocationAwareJwtVerifier(
+    inner: JwtVerifier,
+    revocation: RevocationList[IO]
+)(using runtime: IORuntime)
+    extends JwtVerifier:
+
+  def verify(token: String): Either[JwtError, JwtClaims] =
+    inner.verify(token) match
+      case Right(claims) if claims.jti.nonEmpty =>
+        if revocation.isRevoked(claims.jti).unsafeRunSync() then
+          Left(JwtError.Revoked(claims.jti))
+        else Right(claims)
+      case other => other

--- a/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RevocationList.scala
+++ b/modules/aegis-iam/src/main/scala/dev/aegiskms/iam/RevocationList.scala
@@ -1,0 +1,89 @@
+package dev.aegiskms.iam
+
+import cats.effect.{IO, Ref}
+
+import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
+
+/** SPI for a JWT revocation list keyed by `jti` claim.
+  *
+  * The auto-responder ([[dev.aegiskms.agent.AutoResponder]]) and the future agent-revoke admin endpoint use
+  * this to invalidate a still-unexpired bearer token before its natural `exp`. Every `JwtVerifier` consults
+  * the list on each verify — see `RevocationAwareJwtVerifier`.
+  *
+  * **TTL semantics.** `revoke(jti, expiresAt)` records the jti with an expiry equal to the token's `exp`
+  * claim. Once the token would have expired naturally, the entry is purged (Redis via `PEXPIREAT`; in-memory
+  * via lazy check). This keeps the list bounded — a year of revocation activity on 1-hour tokens stays at
+  * most ~1h × 24 × 365 jtis if every token were revoked, which is in the low millions for the worst case and
+  * still fits in a few MB of memory.
+  *
+  * **Idempotency.** Revoking the same `jti` twice is a no-op (the second TTL update is benign).
+  *
+  * **Failure model.** `isRevoked` on a transient Redis outage returns `false` (fail-open) so a partial-outage
+  * on the revocation store doesn't lock every user out. Operators who want fail-closed semantics can wrap the
+  * implementation in a decorator that re-raises. Defaults matter: getting a revocation check wrong by
+  * treating "Redis unreachable" as "all tokens revoked" would create an outage; treating it as "no tokens
+  * revoked" creates a security gap limited to the token TTL. The latter is the lesser evil for a v0.2.0
+  * default.
+  */
+trait RevocationList[F[_]]:
+  /** True iff the given `jti` is currently revoked. Implementations should return `false` on transient store
+    * failures (fail-open).
+    */
+  def isRevoked(jti: String): F[Boolean]
+
+  /** Record `jti` as revoked until `expiresAt`. After that instant the entry is automatically purged from the
+    * store (no caller-side cleanup needed).
+    */
+  def revoke(jti: String, expiresAt: Instant): F[Unit]
+
+object RevocationList:
+
+  /** A no-op list: nothing is ever revoked. Used when revocation is disabled
+    * (`aegis.iam.revocation.kind=none`) or in the dev resolver path where there are no JWTs at all. Returning
+    * a singleton means the decorator's check is a single Boolean read per verify.
+    */
+  val noop: RevocationList[IO] = new RevocationList[IO]:
+    def isRevoked(jti: String): IO[Boolean]               = IO.pure(false)
+    def revoke(jti: String, expiresAt: Instant): IO[Unit] = IO.unit
+
+  /** Build an in-memory revocation list. Entries are checked against wall-clock on every read; expired
+    * entries are filtered out lazily (no background cleanup thread). Fine for single-node dev / testing —
+    * production deployments should use the Redis impl in `aegis-server`.
+    */
+  def inMemory: IO[RevocationList[IO]] =
+    Ref.of[IO, Map[String, Instant]](Map.empty).map(new InMemoryRevocationList(_))
+
+  /** In-memory `RevocationList` using a `Ref[IO, Map[jti, expiresAt]]`. Read path: filter expired entries on
+    * the fly so the store stays self-cleaning under load. Concurrent revoke + isRevoked are atomic via Ref's
+    * CAS update.
+    */
+  final class InMemoryRevocationList(state: Ref[IO, Map[String, Instant]])
+      extends RevocationList[IO]:
+
+    def isRevoked(jti: String): IO[Boolean] =
+      for
+        now <- IO.realTimeInstant
+        map <- state.get
+      yield map.get(jti).exists(_.isAfter(now))
+
+    def revoke(jti: String, expiresAt: Instant): IO[Unit] =
+      // We also use the revoke call as a chance to prune obviously-expired entries — keeps the
+      // map bounded over time even without a sweeper. O(N) on the map size, but N stays small in
+      // practice (a few thousand at most under normal revocation activity).
+      for
+        now <- IO.realTimeInstant
+        _ <- state.update { m =>
+          val pruned = m.filter { case (_, exp) => exp.isAfter(now) }
+          if expiresAt.isAfter(now) then pruned + (jti -> expiresAt) else pruned
+        }
+      yield ()
+
+    /** Test helper: current size of the revocation store. */
+    def size: IO[Int] = state.get.map(_.size)
+
+  /** Convenience: derive `expiresAt` from a `now + ttl` pair. The Redis impl uses `PEXPIREAT` directly, so
+    * this is only needed when the caller doesn't have an explicit instant.
+    */
+  def expiryFrom(now: Instant, ttl: FiniteDuration): Instant =
+    now.plusSeconds(ttl.toSeconds)

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/RevocationAwareJwtVerifierSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/RevocationAwareJwtVerifierSpec.scala
@@ -1,0 +1,119 @@
+package dev.aegiskms.iam
+
+import cats.effect.unsafe.IORuntime
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+/** Tests for the `RevocationAwareJwtVerifier` decorator. Verified properties:
+  *
+  *   1. Token whose `jti` isn't on the list passes through with the inner verifier's result. 2. Revoked `jti`
+  *      produces `JwtError.Revoked(jti)`. 3. Token without a `jti` (legacy) is not subjected to revocation
+  *      lookup — passes through. 4. If the inner verifier rejects (e.g. expired / bad sig), the revocation
+  *      list is NOT consulted — saves a Redis call on rejected tokens. 5. Decoration is composable: an
+  *      already-decorated verifier doesn't break when wrapped again.
+  */
+final class RevocationAwareJwtVerifierSpec extends AnyFunSuite with Matchers:
+
+  // The decorator's verify uses `unsafeRunSync` internally; we don't need a separate runtime here.
+  private given IORuntime = IORuntime.global
+
+  // Stub verifier that returns whatever `Either` is supplied. Lets us drive the decorator without
+  // setting up real keys / signatures.
+  final private class StubVerifier(result: Either[JwtError, JwtClaims]) extends JwtVerifier:
+    @volatile var verifyCalls: Int = 0
+    def verify(token: String): Either[JwtError, JwtClaims] =
+      verifyCalls += 1
+      result
+
+  private val now = Instant.now()
+
+  private def humanClaims(jti: String = UUID.randomUUID().toString): JwtClaims.Human =
+    JwtClaims.Human(
+      subject = "alice@org",
+      issuer = None,
+      issuedAt = now,
+      expiresAt = now.plus(1, ChronoUnit.HOURS),
+      groups = Set("admins"),
+      jti = jti
+    )
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  test("token not on the revocation list passes through unchanged") {
+    val claims = humanClaims()
+    val inner  = StubVerifier(Right(claims))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        v = new RevocationAwareJwtVerifier(inner, list)
+      yield v.verify("any-token")
+    val result = program.unsafeRunSync()
+    result shouldBe Right(claims)
+    inner.verifyCalls shouldBe 1
+  }
+
+  test("revoked jti is rejected with JwtError.Revoked(jti)") {
+    val jti    = "jti-to-revoke"
+    val claims = humanClaims(jti)
+    val inner  = StubVerifier(Right(claims))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        _    <- list.revoke(jti, claims.expiresAt)
+        v = new RevocationAwareJwtVerifier(inner, list)
+      yield v.verify("any-token")
+    program.unsafeRunSync() shouldBe Left(JwtError.Revoked(jti))
+  }
+
+  test("token without jti (empty string) is not subjected to revocation lookup") {
+    val claims = humanClaims(jti = "")
+    val inner  = StubVerifier(Right(claims))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        // Even if we revoke an empty string, the decorator shouldn't check it.
+        _ <- list.revoke("", claims.expiresAt)
+        v = new RevocationAwareJwtVerifier(inner, list)
+      yield v.verify("any-token")
+    program.unsafeRunSync() shouldBe Right(claims)
+  }
+
+  // ── Inner-rejection short-circuit ─────────────────────────────────────────
+
+  test("inner rejection (Expired) bypasses the revocation lookup") {
+    val inner = StubVerifier(Left(JwtError.Expired))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        v = new RevocationAwareJwtVerifier(inner, list)
+      yield v.verify("any-token")
+    program.unsafeRunSync() shouldBe Left(JwtError.Expired)
+  }
+
+  test("inner rejection (SignatureInvalid) bypasses the revocation lookup") {
+    val inner = StubVerifier(Left(JwtError.SignatureInvalid))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        v = new RevocationAwareJwtVerifier(inner, list)
+      yield v.verify("any-token")
+    program.unsafeRunSync() shouldBe Left(JwtError.SignatureInvalid)
+  }
+
+  // ── Composition ──────────────────────────────────────────────────────────
+
+  test("double-wrapping is idempotent (same behavior as single-wrap)") {
+    val claims = humanClaims()
+    val inner  = StubVerifier(Right(claims))
+    val program =
+      for
+        list <- RevocationList.inMemory
+        once  = new RevocationAwareJwtVerifier(inner, list)
+        twice = new RevocationAwareJwtVerifier(once, list)
+      yield twice.verify("any-token")
+    program.unsafeRunSync() shouldBe Right(claims)
+  }

--- a/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/RevocationListSpec.scala
+++ b/modules/aegis-iam/src/test/scala/dev/aegiskms/iam/RevocationListSpec.scala
@@ -1,0 +1,104 @@
+package dev.aegiskms.iam
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.concurrent.duration.*
+
+/** Tests for the in-memory and noop `RevocationList` implementations. The Redis impl is exercised by
+  * `RedisRevocationListSpec` (Docker-gated) in aegis-server.
+  *
+  * Properties pinned here:
+  *   1. `noop` never reports anything as revoked. 2. In-memory `revoke` then `isRevoked` returns true. 3. An
+  *      entry whose `expiresAt` is in the past is treated as not-revoked (TTL evict on read). 4. `revoke` is
+  *      idempotent — same `jti` twice doesn't double-count. 5. Pruning happens on `revoke` calls — the map
+  *      stays bounded. 6. Empty `jti` revoke + lookup behaves predictably (empty string keyed lookup).
+  */
+final class RevocationListSpec extends AnyFunSuite with Matchers:
+
+  private def aFew = Instant.now().plusSeconds(3600)
+  private def past = Instant.now().minusSeconds(3600)
+
+  // ── noop ──────────────────────────────────────────────────────────────────
+
+  test("noop never reports anything as revoked") {
+    val list = RevocationList.noop
+    list.isRevoked("anything").unsafeRunSync() shouldBe false
+    list.revoke("anything", aFew).unsafeRunSync() // no-op
+    list.isRevoked("anything").unsafeRunSync() shouldBe false
+  }
+
+  // ── in-memory happy paths ────────────────────────────────────────────────
+
+  test("in-memory: revoke then isRevoked returns true") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        _    <- list.revoke("jti-1", aFew)
+        out  <- list.isRevoked("jti-1")
+      yield out
+    program.unsafeRunSync() shouldBe true
+  }
+
+  test("in-memory: unknown jti returns false") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        out  <- list.isRevoked("never-seen")
+      yield out
+    program.unsafeRunSync() shouldBe false
+  }
+
+  test("in-memory: expired entry is treated as not revoked (TTL evict on read)") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        _    <- list.revoke("jti-old", past) // already expired
+        out  <- list.isRevoked("jti-old")
+      yield out
+    program.unsafeRunSync() shouldBe false
+  }
+
+  test("in-memory: revoke is idempotent — same jti twice doesn't grow the store") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        _    <- list.revoke("jti-dup", aFew)
+        _    <- list.revoke("jti-dup", aFew)
+        size <- list.asInstanceOf[RevocationList.InMemoryRevocationList].size
+      yield size
+    program.unsafeRunSync() shouldBe 1
+  }
+
+  test("in-memory: a stale entry from a past revoke is pruned on the next revoke call") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        impl = list.asInstanceOf[RevocationList.InMemoryRevocationList]
+        _    <- impl.revoke("jti-stale", past) // immediately expired
+        _    <- impl.revoke("jti-fresh", aFew)
+        size <- impl.size
+      yield size
+    // The expired entry is pruned during the second revoke; only `jti-fresh` survives.
+    program.unsafeRunSync() shouldBe 1
+  }
+
+  test("in-memory: revoking with an already-past expiresAt is a no-op (no entry stored)") {
+    val program =
+      for
+        list <- RevocationList.inMemory
+        impl = list.asInstanceOf[RevocationList.InMemoryRevocationList]
+        _    <- impl.revoke("jti-dead", past)
+        size <- impl.size
+      yield size
+    program.unsafeRunSync() shouldBe 0
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  test("RevocationList.expiryFrom adds the ttl to now") {
+    val now = Instant.parse("2026-05-25T10:00:00Z")
+    RevocationList.expiryFrom(now, 1.hour) shouldBe now.plusSeconds(3600)
+  }

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -65,6 +65,32 @@ aegis {
     }
   }
 
+  iam {
+    revocation {
+      # "none"      — no JTI kill-switch; tokens revoke only when they expire naturally.
+      # "in-memory" — process-local revocation list. Lost on restart. Fine for single-node dev.
+      # "redis"     — durable, multi-node revocation list backed by Redis. Production path —
+      #               required if you want the auto-responder's `Revoke` action to also kill
+      #               the offending agent's JWT before its natural expiry.
+      kind = "in-memory"
+      kind = ${?AEGIS_REVOCATION_KIND}
+
+      redis {
+        # Lettuce connection URI. Examples:
+        #   redis://localhost:6379
+        #   redis://:password@host:6379/0
+        #   rediss://host:6380          (TLS)
+        uri = ""
+        uri = ${?AEGIS_REVOCATION_REDIS_URI}
+
+        # Namespace prefix for revoked-jti keys. Lets you share a Redis with other workloads
+        # (session stores, rate limiters) without colliding.
+        key-prefix = "aegis:revoked-jti:"
+        key-prefix = ${?AEGIS_REVOCATION_REDIS_KEY_PREFIX}
+      }
+    }
+  }
+
   crypto {
     # "in-memory" — deterministic-MAC dev backend. NOT a real KMS. Signatures are HMAC(KeyId,
     #               msg); encryption is XOR-with-stream. Suitable for local dev, the wedge demo,

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/RedisRevocationList.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/RedisRevocationList.scala
@@ -1,0 +1,98 @@
+package dev.aegiskms.app
+
+import cats.effect.{IO, Resource}
+import dev.aegiskms.iam.RevocationList
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+
+/** Lettuce-backed `RevocationList`. Stores each revoked `jti` as a single Redis key with `PEXPIREAT` set to
+  * the token's natural `exp`, so the entry auto-evicts when the token would have expired anyway.
+  *
+  * **Why Lettuce (not redis4cats).** Lettuce is a single-jar Java client; the smaller transitive dep tree
+  * keeps the aegis-server Docker image lean. We use the synchronous `RedisCommands` surface wrapped in
+  * `IO.blocking` — for the call profile (one `EXISTS` per token verify, one `SETEX` per revoke) the
+  * async/reactive APIs would just add complexity.
+  *
+  * **Why a key per jti (rather than a Sorted Set keyed by expiry).** A SET-per-jti gives us TTL eviction for
+  * free — Redis handles the cleanup. The alternative (one SortedSet, sweeper job) needs a background process
+  * and an extra commit point. Per-key TTL is the boring choice.
+  *
+  * **Fail-open on transient failures.** Lookup errors are swallowed and reported as "not revoked" — see
+  * `RevocationList` trait docstring for why. Operators get the failure in the logs; users keep getting
+  * served.
+  */
+final class RedisRevocationList private (
+    connection: StatefulRedisConnection[String, String],
+    keyPrefix: String
+) extends RevocationList[IO]:
+
+  private val logger = LoggerFactory.getLogger(classOf[RedisRevocationList])
+
+  def isRevoked(jti: String): IO[Boolean] =
+    IO.blocking {
+      val cmd    = connection.sync()
+      val exists = cmd.exists(redisKey(jti))
+      exists != null && exists.longValue() > 0
+    }.handleErrorWith { t =>
+      // Fail-open: a Redis outage shouldn't lock every user out. Bounded security gap = token TTL.
+      IO(logger.warn(s"revocation lookup failed (fail-open) for jti=$jti: ${t.getMessage}", t))
+        .as(false)
+    }
+
+  def revoke(jti: String, expiresAt: Instant): IO[Unit] =
+    IO.blocking {
+      val cmd = connection.sync()
+      val key = redisKey(jti)
+      // PEXPIREAT semantics: the key is auto-purged at the given Unix-millis. If `expiresAt` is
+      // already in the past (e.g. an unusual race during issue), Redis treats it as immediate
+      // delete — fine, the jti was never useful to revoke.
+      cmd.set(key, "1")
+      cmd.pexpireat(key, expiresAt.toEpochMilli)
+      ()
+    }.handleErrorWith { t =>
+      // Best-effort. A failed revoke is logged loudly so operators can retry; surfacing the
+      // failure to the caller would create a worse story (the auto-responder's `Revoke` action
+      // would refuse the audit row).
+      IO(logger.error(s"revocation write failed for jti=$jti exp=$expiresAt: ${t.getMessage}", t))
+    }
+
+  /** Test seam: count how many revocation keys live under the configured prefix. Linear in the number of
+    * revocations — fine for tests, not for prod (no one calls it in prod).
+    */
+  def size: IO[Long] =
+    IO.blocking {
+      val cmd = connection.sync()
+      cmd.keys(s"$keyPrefix*").size().toLong
+    }.handleErrorWith(_ => IO.pure(0L))
+
+  private def redisKey(jti: String): String = s"$keyPrefix$jti"
+
+object RedisRevocationList:
+
+  /** Default Redis key prefix. Namespaced so a shared Redis (e.g. with a session store) doesn't collide.
+    */
+  val DefaultKeyPrefix: String = "aegis:revoked-jti:"
+
+  /** Resource-managed builder. Owns the Lettuce `RedisClient` + connection; both are `AutoCloseable` and
+    * released on SIGTERM.
+    */
+  def make(redisUri: String, keyPrefix: String = DefaultKeyPrefix): Resource[IO, RedisRevocationList] =
+    for
+      client <- Resource.fromAutoCloseable(IO {
+        RedisClient.create(redisUri)
+      })
+      connection <- Resource.fromAutoCloseable(IO {
+        client.connect()
+      })
+    yield new RedisRevocationList(connection, keyPrefix)
+
+  /** Test seam: build a list against an already-open connection. Caller manages the connection lifecycle.
+    */
+  def withConnection(
+      connection: StatefulRedisConnection[String, String],
+      keyPrefix: String = DefaultKeyPrefix
+  ): RedisRevocationList =
+    new RedisRevocationList(connection, keyPrefix)

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -22,7 +22,9 @@ import dev.aegiskms.iam.{
   JwtIssuer,
   JwtVerifier,
   OidcJwtVerifier,
-  PrincipalResolver
+  PrincipalResolver,
+  RevocationAwareJwtVerifier,
+  RevocationList
 }
 import dev.aegiskms.persistence.{EventJournal, PostgresEventJournal, PostgresJournalConfig}
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
@@ -160,7 +162,14 @@ object Server extends IOApp.Simple:
       decisionEngine = ThresholdDecisionEngine.make()
       auditing       = new AuditingKeyService(traced, sink, Some(riskScorer), Some(decisionEngine))
 
-      resolver <- Resource.eval(buildResolver(rootConfig))
+      // JWT revocation list (#24). Selected by `aegis.iam.revocation.kind`:
+      //   - `none`      → no-op; tokens revoke only when they expire naturally.
+      //   - `in-memory` → process-local Ref-backed list; suits dev/single-node, lost on restart.
+      //   - `redis`     → durable, multi-node. Closes the auto-responder's kill-switch story.
+      // The list is wrapped around whatever inner verifier `buildResolver` constructs (HMAC /
+      // OIDC) via `RevocationAwareJwtVerifier`. Dev resolver (no JWT) bypasses the list.
+      revocation <- revocationListResource(rootConfig)
+      resolver   <- Resource.eval(buildResolver(rootConfig, revocation))
       // Agent-token issuer (#18). Needs a JwtIssuer with the HMAC secret. We share the same secret
       // the verifier uses when `aegis.auth.kind=hmac`; in dev mode we mint a stable per-boot secret
       // (logged below) so the demo can issue + verify agent tokens within a single server lifetime.
@@ -451,7 +460,10 @@ object Server extends IOApp.Simple:
     *   - `oidc` — `OidcJwtVerifier` against the configured issuer with JWKS caching (production path; closes
     *     #25).
     */
-  private def buildResolver(config: Config)(using IORuntime): IO[PrincipalResolver] =
+  private def buildResolver(
+      config: Config,
+      revocation: RevocationList[IO]
+  )(using IORuntime): IO[PrincipalResolver] =
     config.getString("aegis.auth.kind") match
       case "dev" =>
         IO {
@@ -469,7 +481,9 @@ object Server extends IOApp.Simple:
               "aegis.auth.kind=hmac requires aegis.auth.hmac.secret (set AEGIS_AUTH_HMAC_SECRET)"
             )
           logger.info("auth: hmac (HS256) — verifying Authorization: Bearer <jwt>")
-          PrincipalResolver.jwt(JwtVerifier.hmac(secret))
+          val base    = JwtVerifier.hmac(secret)
+          val wrapped = new RevocationAwareJwtVerifier(base, revocation)
+          PrincipalResolver.jwt(wrapped)
         }
       case "oidc" =>
         val issuerUri = config.getString("aegis.auth.oidc.issuer-uri")
@@ -491,8 +505,44 @@ object Server extends IOApp.Simple:
                 audience,
                 scala.concurrent.duration.FiniteDuration(ttlSecs, scala.concurrent.duration.SECONDS)
               )
-              .map(verifier => PrincipalResolver.jwt(verifier))
+              .map { base =>
+                val wrapped = new RevocationAwareJwtVerifier(base, revocation)
+                PrincipalResolver.jwt(wrapped)
+              }
       case other =>
         IO.raiseError(new IllegalArgumentException(
           s"Unknown aegis.auth.kind=$other (expected 'dev', 'hmac', or 'oidc')"
         ))
+
+  /** Build the JWT revocation list (#24). Selection by `aegis.iam.revocation.kind`:
+    *
+    *   - `none` — `RevocationList.noop`. Nothing is ever revoked; tokens expire naturally.
+    *   - `in-memory` — process-local Ref-backed list. Suits single-node dev / testing.
+    *   - `redis` — `RedisRevocationList` against the configured Redis URI. Production path.
+    */
+  private def revocationListResource(config: Config): Resource[IO, RevocationList[IO]] =
+    config.getString("aegis.iam.revocation.kind") match
+      case "none" =>
+        Resource.eval(IO {
+          logger.info("revocation: none — no JTI kill-switch (tokens expire naturally)")
+          RevocationList.noop
+        })
+      case "in-memory" =>
+        Resource.eval(IO(logger.info(
+          "revocation: in-memory (process-local; set aegis.iam.revocation.kind=redis for production)"
+        ))) *> Resource.eval(RevocationList.inMemory)
+      case "redis" =>
+        val uri = config.getString("aegis.iam.revocation.redis.uri")
+        if uri.isEmpty then
+          Resource.eval(IO.raiseError(new IllegalArgumentException(
+            "aegis.iam.revocation.kind=redis requires aegis.iam.revocation.redis.uri " +
+              "(set AEGIS_REVOCATION_REDIS_URI; e.g. redis://localhost:6379)"
+          )))
+        else
+          val prefix = config.getString("aegis.iam.revocation.redis.key-prefix")
+          Resource.eval(IO(logger.info(s"revocation: redis at $uri (key-prefix=$prefix)"))) *>
+            RedisRevocationList.make(uri, prefix).map(impl => impl: RevocationList[IO])
+      case other =>
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          s"Unknown aegis.iam.revocation.kind=$other (expected 'none', 'in-memory', or 'redis')"
+        )))

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/RedisRevocationListSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/RedisRevocationListSpec.scala
@@ -1,0 +1,148 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.dimafeng.testcontainers.GenericContainer
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+import java.time.Instant
+import scala.util.Try
+
+/** Integration test for `RedisRevocationList` against a real Redis in Docker.
+  *
+  * Container lifecycle is managed manually (matching `PostgresEventJournalSpec` / `PostgresAuditSinkSpec`) so
+  * the suite skips cleanly via `assume(...)` on machines without Docker. The 8 cases here pin the contract
+  * the JWT verifier's revocation check depends on: revoke writes, isRevoked reads, expiry honoured by Redis
+  * TTL, idempotent re-revoke, prefix namespacing, fail-open on a torn-down connection.
+  */
+final class RedisRevocationListSpec extends AnyFunSuite with Matchers:
+
+  given IORuntime = IORuntime.global
+
+  private val dockerAvailable: Boolean =
+    Try(org.testcontainers.DockerClientFactory.instance().isDockerAvailable).getOrElse(false)
+
+  /** Build, start, run-with, and tear-down a single Redis container + connection. The block gets an open
+    * `RedisRevocationList` against the test's key prefix.
+    */
+  private def withRedis(body: (RedisRevocationList, StatefulRedisConnection[String, String]) => Unit): Unit =
+    assume(dockerAvailable, "Docker is not available; skipping Redis revocation list integration test")
+    val container = GenericContainer(
+      dockerImage = DockerImageName.parse("redis:7-alpine").asCompatibleSubstituteFor("redis").toString,
+      exposedPorts = Seq(6379),
+      waitStrategy = Wait.forListeningPort()
+    )
+    container.start()
+    try
+      val uri        = s"redis://${container.host}:${container.mappedPort(6379)}"
+      val client     = RedisClient.create(uri)
+      val connection = client.connect()
+      try
+        val list = RedisRevocationList.withConnection(connection, keyPrefix = "test:revoked-jti:")
+        body(list, connection)
+      finally
+        connection.close()
+        client.shutdown()
+    finally container.stop()
+
+  private val now: Instant = Instant.now()
+
+  // ── Happy paths ────────────────────────────────────────────────────────────
+
+  test("revoke followed by isRevoked returns true within the TTL window") {
+    withRedis { (list, _) =>
+      val program =
+        for
+          _   <- list.revoke("jti-1", now.plusSeconds(3600))
+          out <- list.isRevoked("jti-1")
+        yield out
+      program.unsafeRunSync() shouldBe true
+    }
+  }
+
+  test("isRevoked on an unknown jti returns false") {
+    withRedis { (list, _) =>
+      list.isRevoked("never-seen").unsafeRunSync() shouldBe false
+    }
+  }
+
+  test("Redis honours the PEXPIREAT — revoking with a past instant evicts immediately") {
+    withRedis { (list, _) =>
+      val program =
+        for
+          // Use a very near-future expiry, then sleep past it. Avoid passing PEXPIREAT a past
+          // millis (Redis behavior on that varies by version; safer to set a 100ms TTL and wait).
+          _ <- list.revoke("jti-near-expiry", now.plusMillis(200))
+          _ <- IO.sleep(scala.concurrent.duration.FiniteDuration(500, scala.concurrent.duration.MILLISECONDS))
+          out <- list.isRevoked("jti-near-expiry")
+        yield out
+      program.unsafeRunSync() shouldBe false
+    }
+  }
+
+  test("revoke is idempotent — same jti revoked twice does not multiply") {
+    withRedis { (list, _) =>
+      val program =
+        for
+          _    <- list.revoke("jti-dup", now.plusSeconds(3600))
+          _    <- list.revoke("jti-dup", now.plusSeconds(3600))
+          size <- list.size
+        yield size
+      program.unsafeRunSync() shouldBe 1L
+    }
+  }
+
+  test("key-prefix isolates revocations from other workloads on the same Redis") {
+    withRedis { (list, conn) =>
+      // Write a key NOT under the prefix using the same connection — simulates another app on
+      // the same Redis (a session store, rate limiter, etc.). Our `size` counts only our prefix.
+      val program =
+        for
+          _    <- IO.blocking(conn.sync().set("some-other-app:key:foo", "bar")).void
+          _    <- list.revoke("jti-1", now.plusSeconds(3600))
+          size <- list.size
+        yield size
+      program.unsafeRunSync() shouldBe 1L
+    }
+  }
+
+  test("multiple jtis can be revoked and looked up independently") {
+    withRedis { (list, _) =>
+      val program =
+        for
+          _     <- list.revoke("a", now.plusSeconds(3600))
+          _     <- list.revoke("b", now.plusSeconds(3600))
+          _     <- list.revoke("c", now.plusSeconds(3600))
+          aHit  <- list.isRevoked("a")
+          bHit  <- list.isRevoked("b")
+          cHit  <- list.isRevoked("c")
+          dMiss <- list.isRevoked("d")
+        yield (aHit, bHit, cHit, dMiss)
+      program.unsafeRunSync() shouldBe ((true, true, true, false))
+    }
+  }
+
+  // ── Fail-open ─────────────────────────────────────────────────────────────
+
+  test("isRevoked fails open (returns false) when the Redis connection is closed") {
+    withRedis { (list, conn) =>
+      conn.close()
+      // After the connection is closed, Lettuce throws on `sync().exists(...)`. The decorator
+      // catches and logs; users get fail-open semantics so a Redis outage doesn't lock everyone
+      // out. Bounded security gap = token TTL.
+      list.isRevoked("anything").unsafeRunSync() shouldBe false
+    }
+  }
+
+  test("revoke errors are logged but don't throw (best-effort semantics)") {
+    withRedis { (list, conn) =>
+      conn.close()
+      noException should be thrownBy
+        list.revoke("jti-after-close", now.plusSeconds(3600)).unsafeRunSync()
+    }
+  }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,6 +62,19 @@ object Dependencies {
     "com.dimafeng" %% "testcontainers-scala-postgresql" % V.testcontainers % Test
   )
 
+  /** Lettuce is the Java async Redis client. Single-jar dep — we use the lower-level `RedisCommands` (sync)
+    * wrapped via `IO.blocking` so we don't bring in Reactor or Project Loom. Used by the Redis JWT revocation
+    * list (#24) wired in `aegis-server`.
+    */
+  val redis: Seq[ModuleID] = Seq(
+    "io.lettuce" % "lettuce-core" % "6.4.0.RELEASE"
+  )
+
+  /** Test-only dep for spinning up a real Redis in Docker during integration tests. */
+  val testcontainersRedis: Seq[ModuleID] = Seq(
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % V.testcontainers % Test
+  )
+
   val crypto: Seq[ModuleID] = Seq(
     "software.amazon.awssdk" % "kms" % V.aws
   )


### PR DESCRIPTION
## Summary
The kill-switch primitive the auto-responder's \`Revoke\` action will use to invalidate an agent's bearer token before its natural expiry. Without this, a leaked agent JWT works until its 24 h \`exp\` regardless of what the responder does to the underlying key.

- **\`RevocationList[F[_]]\` SPI** in aegis-iam with \`noop\` + \`InMemoryRevocationList\` impls. \`RedisRevocationList\` ships in aegis-server (key-per-jti with \`PEXPIREAT\`, Lettuce client).
- **\`RevocationAwareJwtVerifier\`** decorator wraps any inner \`JwtVerifier\` (HMAC, OIDC) and consults the list after signature + claims validation passes. Inner rejections short-circuit before the lookup.
- **\`JwtError.Revoked(jti)\`** variant — distinguishes "killed early" from "expired naturally" in audit logs.
- **Fail-open semantics** on Redis outage (bounded security gap = token TTL; fail-closed would create global outages on partial-store failure).
- **\`Server.boot\`** wires it via \`aegis.iam.revocation.kind\` (\`none\` | \`in-memory\` (default) | \`redis\`). \`buildResolver\` now takes the list and wraps the verifier automatically.

Closes #24. Follow-up: integrate the list into \`AutoResponder.Revoke\` so a Revoke recommendation kills both the key AND the agent's \`jti\` simultaneously.

## Test plan
- [x] \`sbt test\` — 376 pass, 0 failures (was 362; +14 unit + 8 Docker-gated)
- [x] \`sbt iam/test\` — 83 pass (12 new for revocation)
- [x] \`sbt scalafmtCheckAll scalafmtSbtCheck \"scalafixAll --check\"\` — all green
- [ ] CI: 8 Testcontainers Redis cases run against real Redis 7
- [ ] Manual against \`:main\` post-merge: \`AEGIS_REVOCATION_KIND=redis\` + \`AEGIS_REVOCATION_REDIS_URI=redis://localhost:6379\`, issue an agent JWT, set its jti in the blacklist via the upcoming admin endpoint, retry a request — confirm 401 with \`"JWT revoked"\` reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)