### PR TITLE
feat(audit+http): plumb source.ip into AuditRecord.context (closes #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Source-IP plumbed into audit records — activates `SourceIpBaseline` (closes #78).** The
+  detector has been inert since v0.1.0 because `source.ip` never landed in
+  `AuditRecord.context`. This change wires the HTTP transport's remote address through to
+  every audit row produced by `AuditingKeyService`.
+  - **`RequestContext` SPI** in `aegis-audit`: a tiny `IOLocal`-backed side-channel with
+    `current: IO[Map[String, String]]` and `set(Map): IO[Unit]`. Two impls ship:
+    `RequestContext.empty` (no-op, the default so existing callers compile unchanged) and
+    `RequestContext.fromIOLocal(local)` (the real wire-up). Lives in `aegis-audit` so the
+    library tier stays Pekko-free — only cats-effect is on the classpath.
+  - **`AuditingKeyService`** gains an optional `requestContext` ctor param. The decorator
+    calls `requestContext.current` inside `instrument` / `locate` and `preflightContext`
+    merges the per-request bag last so a transport-supplied key (e.g. `source.ip`)
+    wins over a same-key value from the scorer/engine.
+  - **`Endpoints.scala`** introduces a server-only `extractFromRequest`-based
+    `sourceIpInput`. It does NOT appear in the OpenAPI document (the wire shape is
+    unchanged for clients), but every keys / agents / audit endpoint gains an internal
+    `Option[String]` slot for the remote IP. The extractor reads from `req.underlying`
+    cast to pekko's `RequestContext` because Tapir's pekko adapter hardcodes
+    `ServerRequest.connectionInfo` to `(None, None, None)` — naive use of
+    `connectionInfo.remote` would always yield `None`.
+  - **`application.conf`** sets `pekko.http.server.remote-address-attribute = on` so
+    pekko populates `AttributeKeys.remoteAddress` on every incoming request (the default
+    is `off` for backwards compatibility).
+  - **`HttpRoutes.runIO(clientIp)(io)`** sets the IOLocal as the first IO step of every
+    request, before any user-facing work runs. Setting it inside the IO chain (rather than
+    on the calling thread) is what makes the value visible to deeper IO consumers — every
+    subsequent `flatMap` in the fiber inherits it, including the read inside
+    `AuditingKeyService.preflightContext`.
+  - **`Server.boot`** constructs one `IOLocal[Map[String,String]]` and hands the same
+    `RequestContext.fromIOLocal(local)` to both `AuditingKeyService` and `HttpRoutes` —
+    separate locals would leave the read empty. No new HOCON keys; the wiring is automatic
+    when the server runs.
+  - **Tests**: 4 new `AuditingKeyServiceSpec` cases covering the back-compat empty path,
+    the source.ip stamp on a state-changing op, the source.ip stamp on the read-only
+    `locate` path, and the three-way coexistence with `risk.score` + `outcome.decision`
+    on the same record. Plus a new `HttpRoutesSourceIpSpec` integration suite (3 cases)
+    that drives requests through the full `Route` and asserts the audit log carries
+    `source.ip` end-to-end — covering criterion #4 of the issue.
+  - **`BaselineDetector` doc cleanup.** Removed the three "inert until the HTTP plumbing
+    PR populates this key" comments now that this PR is that plumbing.
+
 - **CLI `agent issue` + `audit tail` subcommands (closes #79).** The two demo-critical CLI
   surfaces moved from stubs (`(planned — PR A1)` / `(planned — PR F2.b)`) to real
   implementations against the v0.2.0 backends.

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
@@ -24,7 +24,7 @@ import java.util.UUID
   *   - `OpHistogramBaseline`: the actor performed an `Operation` it has never performed before.
   *   - `TimeOfDayBaseline`: the actor was active in a UTC hour-of-day they have never been active in.
   *   - `SourceIpBaseline`: the actor's request came from an IP not in their seen set. Reads
-  *     `record.context("source.ip")`; inert until the HTTP plumbing PR populates that key.
+  *     `record.context("source.ip")`, which the HTTP layer populates via `RequestContext` (#78).
   *
   * Cold-start: every detector requires the actor to have at least one prior observation in the relevant
   * dimension before it can fire. The first time `claude-session-7a3` shows up we record but don't alert; the
@@ -55,9 +55,9 @@ final class BaselineDetector private (
 
 object BaselineDetector:
 
-  /** Well-known key the SourceIp detector reads from `AuditRecord.context`. The HTTP layer is responsible for
-    * populating this once per-request context plumbing lands; until then the SourceIp detector stays inert in
-    * production but can be exercised by tests that build records with the context populated.
+  /** Well-known key the SourceIp detector reads from `AuditRecord.context`. The HTTP layer populates it via
+    * `RequestContext.fromIOLocal` wired through `AuditingKeyService` (#78). Tests can also synthesize records
+    * with this key directly.
     */
   val SourceIpContextKey: String = "source.ip"
 
@@ -75,8 +75,8 @@ object BaselineDetector:
     )
 
   /** Per-actor baseline. `hoursSeen` are UTC hours-of-day (`0`–`23`); we deliberately don't try to be
-    * timezone-aware in v0.1.1 — this is the *demo* detector. `sourceIpsSeen` is empty until the HTTP plumbing
-    * PR populates `AuditRecord.context("source.ip")`.
+    * timezone-aware in v0.1.1 — this is the *demo* detector. `sourceIpsSeen` is populated from
+    * `AuditRecord.context("source.ip")`, which the HTTP layer fills in (#78).
     */
   final case class ActorBaseline(
       keysSeen: Set[String],
@@ -208,9 +208,9 @@ object BaselineDetector:
       )
 
     // 5. SourceIpBaseline — request from an IP not in the actor's seen set. Reads
-    //    `record.context("source.ip")`. Inert in production until the HTTP plumbing PR populates the
-    //    key; tests can build records with the context map set directly. We only fire when the actor
-    //    has at least one prior IP — so the cold-start case (no IP history at all) doesn't alert.
+    //    `record.context("source.ip")`, populated by the HTTP layer's `RequestContext` (#78). We only
+    //    fire when the actor has at least one prior IP — so the cold-start case (no IP history at
+    //    all) doesn't alert.
     rec.context.get(SourceIpContextKey).foreach { ip =>
       if existing.sourceIpsSeen.nonEmpty && !existing.sourceIpsSeen.contains(ip) then
         recs += AgentRecommendation(

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/AuditingKeyService.scala
@@ -40,7 +40,13 @@ final class AuditingKeyService(
     inner: KeyService[IO],
     sink: AuditSink[IO],
     scorer: Option[RiskScorer[IO]] = None,
-    engine: Option[DecisionEngine[IO]] = None
+    engine: Option[DecisionEngine[IO]] = None,
+    /** Per-request context bag (typically the HTTP layer's `source.ip`, MCP session id, etc.). Defaults to
+      * [[RequestContext.empty]] so existing callers compile unchanged. When wired with
+      * `RequestContext.fromIOLocal`, every audit record's `context` map merges in whatever the transport
+      * layer stamped onto the IOLocal for this request.
+      */
+    requestContext: RequestContext = RequestContext.empty
 ) extends KeyService[IO]:
 
   def create(spec: KeySpec, by: Principal): IO[Either[KmsError, ManagedKey]] =
@@ -70,10 +76,11 @@ final class AuditingKeyService(
     // discovery separately.
     val resource = s"pattern:$namePattern"
     for
-      corr  <- IO(freshCorrelationId())
-      now   <- IO.realTimeInstant
-      score <- scoreOpt(by, Operation.Locate, None, now)
-      ctx = preflightContext(score, None)
+      corr   <- IO(freshCorrelationId())
+      now    <- IO.realTimeInstant
+      reqCtx <- requestContext.current
+      score  <- scoreOpt(by, Operation.Locate, None, now)
+      ctx = preflightContext(score, None, reqCtx)
       list <- inner.locate(namePattern, by)
       _ <- sink.write(
         AuditRecord(now, by, Operation.Locate, resource, s"Hits=${list.size}", corr, ctx)
@@ -232,9 +239,10 @@ final class AuditingKeyService(
     for
       corr     <- IO(freshCorrelationId())
       now0     <- IO.realTimeInstant
+      reqCtx   <- requestContext.current
       score    <- scoreOpt(by, op, keyId, now0)
       decision <- decideOpt(score, by, op)
-      ctx = preflightContext(score, decision)
+      ctx = preflightContext(score, decision, reqCtx)
       result <- shortCircuitOr(decision, action)
       now    <- IO.realTimeInstant
       _      <- sink.write(record(now, corr, ctx, result))
@@ -273,16 +281,21 @@ final class AuditingKeyService(
       case (Some(s), Some(e)) => e.decide(s, by, op).map(Some(_))
       case _                  => IO.pure(None)
 
-  /** Build the `AuditRecord.context` fragment from the score + decision. Stamps:
+  /** Build the `AuditRecord.context` fragment from the score, decision, and the per-request context bag
+    * stamped by the transport layer (typically `source.ip`). Stamps:
     *
     *   - `risk.score` — present iff scorer was configured
     *   - `risk.factors` — present iff scorer was configured
     *   - `outcome.decision` — present iff engine was configured ("Allow" / "StepUp" / "Deny")
     *   - `outcome.decision.reason` — present iff engine was configured AND decision != Allow
+    *   - any keys present on the request context (e.g. `source.ip`) — merged last so an explicit
+    *     transport-supplied value overrides a same-key value from score/decision (unlikely but defines an
+    *     unambiguous precedence).
     */
   private def preflightContext(
       score: Option[RiskScore],
-      decision: Option[Decision]
+      decision: Option[Decision],
+      requestCtx: Map[String, String]
   ): Map[String, String] =
     val builder = Map.newBuilder[String, String]
     score.foreach { rs =>
@@ -296,6 +309,7 @@ final class AuditingKeyService(
       val reason                                = d.reasonOrEmpty
       if reason.nonEmpty then builder += ("outcome.decision.reason" -> reason)
     }
+    builder ++= requestCtx
     builder.result()
 
   private def resourceForCreate(spec: KeySpec): String =

--- a/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/RequestContext.scala
+++ b/modules/aegis-audit/src/main/scala/dev/aegiskms/audit/RequestContext.scala
@@ -1,0 +1,46 @@
+package dev.aegiskms.audit
+
+import cats.effect.{IO, IOLocal}
+
+/** Per-request side-channel for context keys that originate at the transport layer (HTTP / KMIP / MCP) but
+  * need to land in `AuditRecord.context` deep inside `AuditingKeyService`. Today carries `source.ip`;
+  * tomorrow it can carry `user-agent`, `mcp.session-id`, `kmip.client-cn`, etc.
+  *
+  * Why this exists: `AuditingKeyService` cannot accept HTTP-shaped parameters without dragging Pekko / Tapir
+  * into `aegis-audit` (which would break the two-tier rule). And we cannot thread the IP through every
+  * `KeyService` method without changing the algebra for every embedder. The IOLocal-backed implementation
+  * lets the HTTP layer call `set` once per request, then the auditing decorator reads `current` deep in its
+  * instrument loop — both ends speak only `IO` and `Map[String, String]`.
+  *
+  * `IOLocal` is fiber-local: it propagates through `flatMap`/`map` within the same fiber. As long as the HTTP
+  * layer calls `set` as the first IO step (before `unsafeToFuture`), every downstream `current` sees the
+  * value. Tests that don't care can pass [[RequestContext.empty]].
+  */
+trait RequestContext:
+
+  /** The current per-request context map. Returns `Map.empty` when no request scope is active (boot code,
+    * background fibers, tests that didn't set anything).
+    */
+  def current: IO[Map[String, String]]
+
+  /** Set the context for the rest of the current fiber. The HTTP layer calls this exactly once per request,
+    * as the first IO step, before any user-facing work runs.
+    */
+  def set(ctx: Map[String, String]): IO[Unit]
+
+object RequestContext:
+
+  /** The no-op context — `current` always returns `Map.empty`, `set` is a no-op. Use this in
+    * `AuditingKeyService` tests that don't exercise the source-ip path, and as the constructor default so
+    * older callers compile unchanged.
+    */
+  val empty: RequestContext = new RequestContext:
+    def current: IO[Map[String, String]]        = IO.pure(Map.empty)
+    def set(ctx: Map[String, String]): IO[Unit] = IO.unit
+
+  /** Wire-up against a cats-effect `IOLocal`. The IOLocal must be constructed at boot time via
+    * `IOLocal(Map.empty[String, String])` and shared across `HttpRoutes` and `AuditingKeyService`.
+    */
+  def fromIOLocal(local: IOLocal[Map[String, String]]): RequestContext = new RequestContext:
+    def current: IO[Map[String, String]]        = local.get
+    def set(ctx: Map[String, String]): IO[Unit] = local.set(ctx)

--- a/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
+++ b/modules/aegis-audit/src/test/scala/dev/aegiskms/audit/AuditingKeyServiceSpec.scala
@@ -1,7 +1,7 @@
 package dev.aegiskms.audit
 
-import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, IOLocal}
 import dev.aegiskms.core.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -387,4 +387,84 @@ final class AuditingKeyServiceSpec extends AnyFunSuite with Matchers:
     // Locate audit row carries the score but NOT a decision (engine isn't consulted for locate).
     record.context.contains("risk.score") shouldBe true
     record.context.contains("outcome.decision") shouldBe false
+  }
+
+  // ── RequestContext / source.ip integration (#78) ──────────────────────────
+  //
+  // The HTTP layer stamps `source.ip` onto a shared IOLocal as the first IO step of each request;
+  // `AuditingKeyService` reads it back via `requestContext.current` and merges it into
+  // `AuditRecord.context`. These tests assert the contract end-to-end: a `set` upstream becomes a
+  // visible key in every downstream audit record produced inside the same fiber.
+
+  test("RequestContext.empty (default) → no source.ip key on the audit record") {
+    val (svc, sink) = fixture() // default ctor → RequestContext.empty
+    svc.create(KeySpec.aes256("no-ip"), alice).unsafeRunSync()
+    sink.all.unsafeRunSync().head.context.contains("source.ip") shouldBe false
+  }
+
+  test("fromIOLocal: set('source.ip' -> ip) upstream lands in AuditRecord.context downstream") {
+    val program: IO[AuditRecord] =
+      for
+        local <- IOLocal(Map.empty[String, String])
+        sink  <- InMemoryAuditSink.make
+        inner <- KeyService.inMemory
+        svc = AuditingKeyService(
+          inner,
+          sink,
+          requestContext = RequestContext.fromIOLocal(local)
+        )
+        // Mimic HttpRoutes.runIO: set the IOLocal as the first IO step, then run the work.
+        _       <- local.set(Map("source.ip" -> "203.0.113.42"))
+        _       <- svc.create(KeySpec.aes256("ip-stamped"), alice)
+        records <- sink.all
+      yield records.head
+
+    val rec = program.unsafeRunSync()
+    rec.context("source.ip") shouldBe "203.0.113.42"
+  }
+
+  test("source.ip also lands on the locate audit row (read-only path)") {
+    val program: IO[AuditRecord] =
+      for
+        local <- IOLocal(Map.empty[String, String])
+        sink  <- InMemoryAuditSink.make
+        inner <- KeyService.inMemory
+        svc = AuditingKeyService(
+          inner,
+          sink,
+          requestContext = RequestContext.fromIOLocal(local)
+        )
+        _       <- local.set(Map("source.ip" -> "198.51.100.7"))
+        _       <- svc.locate("anything", alice)
+        records <- sink.all
+      yield records.head
+
+    val rec = program.unsafeRunSync()
+    rec.operation shouldBe Operation.Locate
+    rec.context("source.ip") shouldBe "198.51.100.7"
+  }
+
+  test("source.ip coexists with risk.score / outcome.decision on the same record") {
+    // Combines all three context contributors: scorer, engine, and request bag.
+    val program: IO[AuditRecord] =
+      for
+        local <- IOLocal(Map.empty[String, String])
+        sink  <- InMemoryAuditSink.make
+        inner <- KeyService.inMemory
+        svc = AuditingKeyService(
+          inner,
+          sink,
+          scorer = Some(new FixedScorer(RiskScore(0.42, List(RiskFactor("AgentPrincipal", 0.2, "x"))))),
+          engine = Some(new FixedEngine(Decision.Allow)),
+          requestContext = RequestContext.fromIOLocal(local)
+        )
+        _       <- local.set(Map("source.ip" -> "192.0.2.5"))
+        _       <- svc.create(KeySpec.aes256("combo"), alice)
+        records <- sink.all
+      yield records.head
+
+    val rec = program.unsafeRunSync()
+    rec.context("source.ip") shouldBe "192.0.2.5"
+    rec.context("risk.score") shouldBe "0.42"
+    rec.context("outcome.decision") shouldBe "Allow"
   }

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -34,18 +34,50 @@ object Endpoints:
     header[Option[String]]("X-Aegis-User")
       .description("Dev-mode principal subject. Honoured ONLY under `aegis.auth.kind=dev`.")
 
-  /** Common path + headers + error contract shared by every keys endpoint. */
+  /** Server-side-only extraction of the remote IP address. `extractFromRequest` does NOT appear in the
+    * OpenAPI document — it's a pure server-internal input — so adding it here keeps the wire shape and SDK
+    * contracts identical while giving every serverLogic body access to the source IP. The HTTP layer stamps
+    * it onto the per-request `RequestContext`, which `AuditingKeyService` then merges into
+    * `AuditRecord.context("source.ip")`, activating the `SourceIpBaseline` detector that has been inert since
+    * v0.1.0 (closes #78).
+    *
+    * Implementation note: Tapir's pekko-http adapter hardcodes `ServerRequest.connectionInfo` to
+    * `ConnectionInfo(None, None, None)`, so we cannot use `req.connectionInfo.remote` directly. Instead we go
+    * through `req.underlying`, which the adapter exposes as the pekko `RequestContext`, and read pekko's
+    * `AttributeKeys.remoteAddress` attribute. That attribute is set automatically when
+    * `pekko.http.server.remote-address-attribute = on` (set in `aegis-server/application.conf`); tests
+    * synthesize it with `HttpRequest.addAttribute`.
+    *
+    * Returns `None` when the request has no detectable remote address (test stubs without the attribute,
+    * loopback bridges, in-process invocations).
+    */
+  private[http] val sourceIpInput: EndpointInput[Option[String]] =
+    extractFromRequest { req =>
+      req.underlying match
+        case ctx: org.apache.pekko.http.scaladsl.server.RequestContext =>
+          ctx.request
+            .attribute(org.apache.pekko.http.scaladsl.model.AttributeKeys.remoteAddress)
+            .flatMap(_.toOption)
+            .map(_.getHostAddress)
+        case _ => None
+    }
+
+  /** Common path + headers + error contract shared by every keys endpoint. The `sourceIpInput` is a
+    * server-only extractor (does not appear in OpenAPI), so OpenAPI clients are unaffected; every keys
+    * serverLogic signature gains an extra `Option[String]` slot for the remote IP.
+    */
   private val keysBase =
     endpoint
       .in("v1" / "keys")
       .in(authHeader)
       .in(devUserHeader)
+      .in(sourceIpInput)
       .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
       .tag("keys")
 
   /** `POST /v1/keys` — create a new managed key. Returns 201 with the new key in PreActive state. */
   val createKey: PublicEndpoint[
-    (Option[String], Option[String], CreateKeyRequest),
+    (Option[String], Option[String], Option[String], CreateKeyRequest),
     (StatusCode, KmsErrorDto),
     ManagedKeyDto,
     Any
@@ -59,7 +91,7 @@ object Endpoints:
 
   /** `GET /v1/keys/{id}` — fetch a key by id. */
   val getKey: PublicEndpoint[
-    (Option[String], Option[String], String),
+    (Option[String], Option[String], Option[String], String),
     (StatusCode, KmsErrorDto),
     ManagedKeyDto,
     Any
@@ -71,7 +103,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/activate` — transition PreActive → Active. */
   val activateKey: PublicEndpoint[
-    (Option[String], Option[String], String),
+    (Option[String], Option[String], Option[String], String),
     (StatusCode, KmsErrorDto),
     ManagedKeyDto,
     Any
@@ -83,7 +115,7 @@ object Endpoints:
 
   /** `DELETE /v1/keys/{id}` — destroy a key. Returns 204 on success. */
   val destroyKey: PublicEndpoint[
-    (Option[String], Option[String], String),
+    (Option[String], Option[String], Option[String], String),
     (StatusCode, KmsErrorDto),
     Unit,
     Any
@@ -95,7 +127,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/sign` — sign a base64-encoded message with the named key. Key must be `Active`. */
   val signKey: PublicEndpoint[
-    (Option[String], Option[String], String, SignRequest),
+    (Option[String], Option[String], Option[String], String, SignRequest),
     (StatusCode, KmsErrorDto),
     SignResponse,
     Any
@@ -109,7 +141,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/verify` — verify a signature over a message. */
   val verifyKey: PublicEndpoint[
-    (Option[String], Option[String], String, VerifyRequest),
+    (Option[String], Option[String], Option[String], String, VerifyRequest),
     (StatusCode, KmsErrorDto),
     VerifyResponse,
     Any
@@ -125,7 +157,7 @@ object Endpoints:
     * context is bound as AAD; the same context must be supplied at decrypt time.
     */
   val encryptKey: PublicEndpoint[
-    (Option[String], Option[String], String, EncryptRequest),
+    (Option[String], Option[String], Option[String], String, EncryptRequest),
     (StatusCode, KmsErrorDto),
     EncryptResponse,
     Any
@@ -141,7 +173,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/decrypt` — decrypt a ciphertext produced by /encrypt. Same context required. */
   val decryptKey: PublicEndpoint[
-    (Option[String], Option[String], String, DecryptRequest),
+    (Option[String], Option[String], Option[String], String, DecryptRequest),
     (StatusCode, KmsErrorDto),
     DecryptResponse,
     Any
@@ -155,7 +187,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/wrap` — wrap a data-encryption key under the named KEK. Key must be `Active`. */
   val wrapKey: PublicEndpoint[
-    (Option[String], Option[String], String, WrapRequest),
+    (Option[String], Option[String], Option[String], String, WrapRequest),
     (StatusCode, KmsErrorDto),
     WrapResponse,
     Any
@@ -171,7 +203,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/unwrap` — unwrap a previously wrapped DEK. Permitted on Active + Deactivated. */
   val unwrapKey: PublicEndpoint[
-    (Option[String], Option[String], String, UnwrapRequest),
+    (Option[String], Option[String], Option[String], String, UnwrapRequest),
     (StatusCode, KmsErrorDto),
     UnwrapResponse,
     Any
@@ -187,7 +219,7 @@ object Endpoints:
     * refuses every cryptographic operation thereafter.
     */
   val compromiseKey: PublicEndpoint[
-    (Option[String], Option[String], String, CompromiseRequest),
+    (Option[String], Option[String], Option[String], String, CompromiseRequest),
     (StatusCode, KmsErrorDto),
     ManagedKeyDto,
     Any
@@ -204,7 +236,7 @@ object Endpoints:
 
   /** `POST /v1/keys/{id}/rotate` — bump the key's `currentVersion`. Legal source state is `Active` only. */
   val rotateKey: PublicEndpoint[
-    (Option[String], Option[String], String, RotateRequest),
+    (Option[String], Option[String], Option[String], String, RotateRequest),
     (StatusCode, KmsErrorDto),
     ManagedKeyDto,
     Any
@@ -230,6 +262,7 @@ object Endpoints:
       .in("v1" / "agents")
       .in(authHeader)
       .in(devUserHeader)
+      .in(sourceIpInput)
       .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
       .tag("agents")
 
@@ -239,7 +272,7 @@ object Endpoints:
     * Request body: `{ label, scopes, ttlSeconds, parent? }` Response: `{ agentId, jwt, jti, expiresAt }`
     */
   val issueAgent: PublicEndpoint[
-    (Option[String], Option[String], IssueAgentRequestDto),
+    (Option[String], Option[String], Option[String], IssueAgentRequestDto),
     (StatusCode, KmsErrorDto),
     IssueAgentResponseDto,
     Any
@@ -267,6 +300,7 @@ object Endpoints:
       .in("v1" / "audit")
       .in(authHeader)
       .in(devUserHeader)
+      .in(sourceIpInput)
       .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
       .tag("audit")
 
@@ -285,6 +319,7 @@ object Endpoints:
     */
   val queryAudit: PublicEndpoint[
     (
+        Option[String],
         Option[String],
         Option[String],
         Option[Instant],

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -2,7 +2,7 @@ package dev.aegiskms.http
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import dev.aegiskms.audit.{AuditQuery, AuditRecord, AuditSink}
+import dev.aegiskms.audit.{AuditQuery, AuditRecord, AuditSink, RequestContext}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
 import dev.aegiskms.iam.{AgentTokenIssuer, IssueAgentRequest as IamIssueAgentRequest, PrincipalResolver}
@@ -44,7 +44,16 @@ final class HttpRoutes(
       * when `aegis.audit.kind=postgres` (the only sink that implements `AuditQuery`). When `None`, `GET
       * /v1/audit` returns `501 FeatureNotSupported`.
       */
-    auditReader: Option[AuditQuery[IO]] = None
+    auditReader: Option[AuditQuery[IO]] = None,
+    /** Per-request context bag shared with the same `AuditingKeyService` decorator wrapping `svc`. Every
+      * `runIO` call writes `source.ip` to it as the first IO step, before the user-facing work runs, so the
+      * downstream `AuditingKeyService.preflightContext` reads the IP back via `current` and stamps it into
+      * `AuditRecord.context("source.ip")` (activates `SourceIpBaseline` — closes #78).
+      *
+      * Defaults to [[RequestContext.empty]] so existing tests that construct `HttpRoutes` without the IOLocal
+      * compile unchanged — the production wiring in `Server.boot` swaps in the real one.
+      */
+    requestContext: RequestContext = RequestContext.empty
 )(using runtime: IORuntime):
 
   private given ExecutionContext = runtime.compute
@@ -78,12 +87,24 @@ final class HttpRoutes(
       StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg)
     }
 
-  private def runIO[A](io: IO[A]): Future[A] = io.unsafeToFuture()
+  /** Run an IO and bridge to Future for Tapir, stamping `source.ip` into the shared `RequestContext` as the
+    * first IO step. Setting the IOLocal inside the IO chain (rather than the calling thread) is what makes
+    * the value visible to deeper IO consumers — every subsequent `flatMap` in the fiber inherits it,
+    * including the read inside `AuditingKeyService.preflightContext`.
+    *
+    * When `clientIp` is `None` the context is left untouched so background fibers and tests that never set it
+    * observe an empty map (rather than a stale value from a prior request).
+    */
+  private def runIO[A](clientIp: Option[String])(io: IO[A]): Future[A] =
+    val withCtx = clientIp match
+      case Some(ip) => requestContext.set(Map("source.ip" -> ip)) *> io
+      case None     => requestContext.set(Map.empty) *> io
+    withCtx.unsafeToFuture()
 
   // ── Server endpoints ───────────────────────────────────────────────────────
 
   private val createSE: ServerEndpoint[Any, Future] =
-    Endpoints.createKey.serverLogic { case (auth, devHdr, req) =>
+    Endpoints.createKey.serverLogic { case (auth, devHdr, clientIp, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -93,56 +114,56 @@ final class HttpRoutes(
                 Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
               )
             case Right(spec) =>
-              runIO(svc.create(spec, principal)).map {
+              runIO(clientIp)(svc.create(spec, principal)).map {
                 case Left(err) => Left(errorOut(err))
                 case Right(k)  => Right(ManagedKeyDto.fromCore(k))
               }
     }
 
   private val getSE: ServerEndpoint[Any, Future] =
-    Endpoints.getKey.serverLogic { case (auth, devHdr, idStr) =>
+    Endpoints.getKey.serverLogic { case (auth, devHdr, clientIp, idStr) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
           parseId(idStr) match
             case Left(e) => Future.successful(Left(e))
             case Right(id) =>
-              runIO(svc.get(id, principal)).map {
+              runIO(clientIp)(svc.get(id, principal)).map {
                 case Left(err) => Left(errorOut(err))
                 case Right(k)  => Right(ManagedKeyDto.fromCore(k))
               }
     }
 
   private val activateSE: ServerEndpoint[Any, Future] =
-    Endpoints.activateKey.serverLogic { case (auth, devHdr, idStr) =>
+    Endpoints.activateKey.serverLogic { case (auth, devHdr, clientIp, idStr) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
           parseId(idStr) match
             case Left(e) => Future.successful(Left(e))
             case Right(id) =>
-              runIO(svc.activate(id, principal)).map {
+              runIO(clientIp)(svc.activate(id, principal)).map {
                 case Left(err) => Left(errorOut(err))
                 case Right(k)  => Right(ManagedKeyDto.fromCore(k))
               }
     }
 
   private val destroySE: ServerEndpoint[Any, Future] =
-    Endpoints.destroyKey.serverLogic { case (auth, devHdr, idStr) =>
+    Endpoints.destroyKey.serverLogic { case (auth, devHdr, clientIp, idStr) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
           parseId(idStr) match
             case Left(e) => Future.successful(Left(e))
             case Right(id) =>
-              runIO(svc.destroy(id, principal)).map {
+              runIO(clientIp)(svc.destroy(id, principal)).map {
                 case Left(err) => Left(errorOut(err))
                 case Right(_)  => Right(())
               }
     }
 
   private val signSE: ServerEndpoint[Any, Future] =
-    Endpoints.signKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.signKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -152,14 +173,14 @@ final class HttpRoutes(
               decodeSignRequest(req) match
                 case Left(e) => Future.successful(Left(e))
                 case Right((message, alg)) =>
-                  runIO(svc.sign(id, message, alg, principal)).map {
+                  runIO(clientIp)(svc.sign(id, message, alg, principal)).map {
                     case Left(err)  => Left(errorOut(err))
                     case Right(sig) => Right(SignResponse.fromCore(sig))
                   }
     }
 
   private val verifySE: ServerEndpoint[Any, Future] =
-    Endpoints.verifyKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.verifyKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -169,14 +190,14 @@ final class HttpRoutes(
               decodeVerifyRequest(req) match
                 case Left(e) => Future.successful(Left(e))
                 case Right((message, signature)) =>
-                  runIO(svc.verify(id, message, signature, principal)).map {
+                  runIO(clientIp)(svc.verify(id, message, signature, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(ok) => Right(VerifyResponse(ok, signature.algorithm.toString))
                   }
     }
 
   private val encryptSE: ServerEndpoint[Any, Future] =
-    Endpoints.encryptKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.encryptKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -186,14 +207,14 @@ final class HttpRoutes(
               decodeBase64(req.plaintextBase64, "plaintextBase64") match
                 case Left(e) => Future.successful(Left(e))
                 case Right(plaintext) =>
-                  runIO(svc.encrypt(id, plaintext, req.context, principal)).map {
+                  runIO(clientIp)(svc.encrypt(id, plaintext, req.context, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(ct) => Right(EncryptResponse.of(ct, req.context))
                   }
     }
 
   private val decryptSE: ServerEndpoint[Any, Future] =
-    Endpoints.decryptKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.decryptKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -206,7 +227,7 @@ final class HttpRoutes(
                     Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
                   )
                 case Right(ct) =>
-                  runIO(svc.decrypt(id, ct, req.context, principal)).map {
+                  runIO(clientIp)(svc.decrypt(id, ct, req.context, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(pt) =>
                       Right(DecryptResponse(java.util.Base64.getEncoder.encodeToString(pt), req.context))
@@ -214,7 +235,7 @@ final class HttpRoutes(
     }
 
   private val wrapSE: ServerEndpoint[Any, Future] =
-    Endpoints.wrapKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.wrapKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -224,14 +245,14 @@ final class HttpRoutes(
               decodeBase64(req.dekBase64, "dekBase64") match
                 case Left(e) => Future.successful(Left(e))
                 case Right(dek) =>
-                  runIO(svc.wrap(id, dek, principal)).map {
+                  runIO(clientIp)(svc.wrap(id, dek, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(w)  => Right(WrapResponse.of(w))
                   }
     }
 
   private val unwrapSE: ServerEndpoint[Any, Future] =
-    Endpoints.unwrapKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.unwrapKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -244,7 +265,7 @@ final class HttpRoutes(
                     Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
                   )
                 case Right(w) =>
-                  runIO(svc.unwrap(id, w, principal)).map {
+                  runIO(clientIp)(svc.unwrap(id, w, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(dek) =>
                       Right(UnwrapResponse(java.util.Base64.getEncoder.encodeToString(dek)))
@@ -252,7 +273,7 @@ final class HttpRoutes(
     }
 
   private val compromiseSE: ServerEndpoint[Any, Future] =
-    Endpoints.compromiseKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.compromiseKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -267,14 +288,14 @@ final class HttpRoutes(
                   ))
                 )
               else
-                runIO(svc.compromise(id, req.reason, principal)).map {
+                runIO(clientIp)(svc.compromise(id, req.reason, principal)).map {
                   case Left(err) => Left(errorOut(err))
                   case Right(k)  => Right(ManagedKeyDto.fromCore(k))
                 }
     }
 
   private val rotateSE: ServerEndpoint[Any, Future] =
-    Endpoints.rotateKey.serverLogic { case (auth, devHdr, idStr, req) =>
+    Endpoints.rotateKey.serverLogic { case (auth, devHdr, clientIp, idStr, req) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -287,14 +308,14 @@ final class HttpRoutes(
                     Left(StatusCode.BadRequest -> KmsErrorDto.of(ErrorCode.InvalidField, msg))
                   )
                 case Right(policy) =>
-                  runIO(svc.rotate(id, policy, principal)).map {
+                  runIO(clientIp)(svc.rotate(id, policy, principal)).map {
                     case Left(err) => Left(errorOut(err))
                     case Right(k)  => Right(ManagedKeyDto.fromCore(k))
                   }
     }
 
   private val issueAgentSE: ServerEndpoint[Any, Future] =
-    Endpoints.issueAgent.serverLogic { case (auth, devHdr, body) =>
+    Endpoints.issueAgent.serverLogic { case (auth, devHdr, clientIp, body) =>
       principalOf(auth, devHdr) match
         case Left(e) => Future.successful(Left(e))
         case Right(principal) =>
@@ -333,7 +354,7 @@ final class HttpRoutes(
                     expiresAt = token.expiresAt
                   )
                 )
-              runIO(issueAndAudit).map(_.left.map(errorOut))
+              runIO(clientIp)(issueAndAudit).map(_.left.map(errorOut))
     }
 
   /** `GET /v1/audit` — paginated read of `aegis_audit_events`. Caller must be a `Principal.Human` (Service +
@@ -341,64 +362,65 @@ final class HttpRoutes(
     * returns 501 NotImplemented.
     */
   private val queryAuditSE: ServerEndpoint[Any, Future] =
-    Endpoints.queryAudit.serverLogic { case (auth, devHdr, since, until, actor, key, op, limit, offset) =>
-      principalOf(auth, devHdr) match
-        case Left(e) => Future.successful(Left(e))
-        case Right(principal) =>
-          principal match
-            case _: Principal.Human =>
-              auditReader match
-                case None =>
-                  // Audit-read isn't wired (e.g. aegis.audit.kind=stdout). Surface the same way
-                  // we do for /agents/issue when its dependency is missing.
-                  Future.successful(Left(
-                    StatusCode.NotImplemented -> KmsErrorDto.of(
-                      ErrorCode.FeatureNotSupported,
-                      "audit query is not enabled on this server (set aegis.audit.kind=postgres)"
-                    )
-                  ))
-                case Some(reader) =>
-                  // Parse the optional `op` filter. Unknown op names are user error → 400, not
-                  // an empty result (silent empty would mask the typo).
-                  val parsedOp: Either[(StatusCode, KmsErrorDto), Option[Operation]] = op match
-                    case None => Right(None)
-                    case Some(name) =>
-                      Operation.values
-                        .find(_.toString == name)
-                        .toRight(StatusCode.BadRequest -> KmsErrorDto.of(
-                          ErrorCode.InvalidField,
-                          s"unknown op '$name'; expected one of: ${Operation.values.map(_.toString).mkString(", ")}"
-                        ))
-                        .map(Some(_))
-                  parsedOp match
-                    case Left(e) => Future.successful(Left(e))
-                    case Right(opVal) =>
-                      val filter = AuditQuery.Filter(
-                        since = since,
-                        until = until,
-                        actor = actor,
-                        resource = key,
-                        operation = opVal,
-                        limit = limit.getOrElse(AuditQuery.DefaultLimit),
-                        offset = offset.getOrElse(0)
+    Endpoints.queryAudit.serverLogic {
+      case (auth, devHdr, clientIp, since, until, actor, key, op, limit, offset) =>
+        principalOf(auth, devHdr) match
+          case Left(e) => Future.successful(Left(e))
+          case Right(principal) =>
+            principal match
+              case _: Principal.Human =>
+                auditReader match
+                  case None =>
+                    // Audit-read isn't wired (e.g. aegis.audit.kind=stdout). Surface the same way
+                    // we do for /agents/issue when its dependency is missing.
+                    Future.successful(Left(
+                      StatusCode.NotImplemented -> KmsErrorDto.of(
+                        ErrorCode.FeatureNotSupported,
+                        "audit query is not enabled on this server (set aegis.audit.kind=postgres)"
                       )
-                      runIO(reader.query(filter)).map { page =>
-                        Right(AuditQueryResponseDto(
-                          records = page.records.map(AuditRecordDto.fromCore),
-                          limit = page.limit,
-                          offset = page.offset,
-                          hasMore = page.hasMore
-                        ))
-                      }
-            case _ =>
-              // Service + Agent are refused. v0.2.0 simplification of the future
-              // "audit:read permission via policy engine" model.
-              Future.successful(Left(
-                StatusCode.Forbidden -> KmsErrorDto.of(
-                  ErrorCode.PermissionDenied,
-                  "audit read is restricted to human principals"
-                )
-              ))
+                    ))
+                  case Some(reader) =>
+                    // Parse the optional `op` filter. Unknown op names are user error → 400, not
+                    // an empty result (silent empty would mask the typo).
+                    val parsedOp: Either[(StatusCode, KmsErrorDto), Option[Operation]] = op match
+                      case None => Right(None)
+                      case Some(name) =>
+                        Operation.values
+                          .find(_.toString == name)
+                          .toRight(StatusCode.BadRequest -> KmsErrorDto.of(
+                            ErrorCode.InvalidField,
+                            s"unknown op '$name'; expected one of: ${Operation.values.map(_.toString).mkString(", ")}"
+                          ))
+                          .map(Some(_))
+                    parsedOp match
+                      case Left(e) => Future.successful(Left(e))
+                      case Right(opVal) =>
+                        val filter = AuditQuery.Filter(
+                          since = since,
+                          until = until,
+                          actor = actor,
+                          resource = key,
+                          operation = opVal,
+                          limit = limit.getOrElse(AuditQuery.DefaultLimit),
+                          offset = offset.getOrElse(0)
+                        )
+                        runIO(clientIp)(reader.query(filter)).map { page =>
+                          Right(AuditQueryResponseDto(
+                            records = page.records.map(AuditRecordDto.fromCore),
+                            limit = page.limit,
+                            offset = page.offset,
+                            hasMore = page.hasMore
+                          ))
+                        }
+              case _ =>
+                // Service + Agent are refused. v0.2.0 simplification of the future
+                // "audit:read permission via policy engine" model.
+                Future.successful(Left(
+                  StatusCode.Forbidden -> KmsErrorDto.of(
+                    ErrorCode.PermissionDenied,
+                    "audit read is restricted to human principals"
+                  )
+                ))
     }
 
   /** Write one `AuditRecord` per `/v1/agents/issue` call — success OR failure — so operators have a forensic

--- a/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSourceIpSpec.scala
+++ b/modules/aegis-http/src/test/scala/dev/aegiskms/http/HttpRoutesSourceIpSpec.scala
@@ -1,0 +1,105 @@
+package dev.aegiskms.http
+
+import cats.effect.unsafe.IORuntime
+import dev.aegiskms.audit.{AuditingKeyService, InMemoryAuditSink, RequestContext}
+import dev.aegiskms.core.KeyService
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.{AttributeKeys, *}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetAddress
+
+/** Integration test for issue #78: a real HTTP request — driven through the same `Route` the server boots in
+  * production — must produce an `AuditRecord` carrying `context("source.ip") = <remote IP>`. Closing the "1
+  * of 5 anomaly detectors is dead in production" gap.
+  *
+  * The wiring under test is the full chain: pekko-http test-kit request → Tapir `extractFromRequest` →
+  * `HttpRoutes.runIO(clientIp)` → IOLocal write → `AuditingKeyService.preflightContext` IOLocal read →
+  * `AuditRecord.context`. The IOLocal instance is shared between `HttpRoutes` and `AuditingKeyService`,
+  * exactly as `Server.boot` wires it.
+  */
+final class HttpRoutesSourceIpSpec extends AnyFunSuite with Matchers with ScalatestRouteTest:
+
+  private given IORuntime = IORuntime.global
+
+  /** Build a fully-wired stack: in-memory KeyService → AuditingKeyService(requestContext = rc) →
+    * HttpRoutes(requestContext = rc) → Route. Returns (route, sink) so the test can both drive requests and
+    * observe the audit log written by the decorator.
+    */
+  private def freshStack(): (Route, InMemoryAuditSink) =
+    val local = cats.effect.IOLocal(Map.empty[String, String]).unsafeRunSync()
+    val rc    = RequestContext.fromIOLocal(local)
+    val sink  = InMemoryAuditSink.make.unsafeRunSync()
+    val inner = KeyService.inMemory.unsafeRunSync()
+    val svc   = AuditingKeyService(inner, sink, requestContext = rc)
+    val route = HttpRoutes(svc, requestContext = rc).routes
+    (route, sink)
+
+  private val createBody =
+    """{"spec":{"name":"ip-stamped","algorithm":"AES","sizeBits":256,"objectType":"SymmetricKey"}}"""
+
+  private def jsonEntity(body: String): RequestEntity =
+    HttpEntity(ContentTypes.`application/json`, body)
+
+  /** Attach pekko-http's `remoteAddress` attribute to the request so Tapir's `req.connectionInfo.remote`
+    * picks it up — this is the same key pekko-http sets automatically when
+    * `pekko.http.server.remote-address-attribute = on` and a real socket is involved.
+    */
+  private def withRemoteIp(req: HttpRequest, ip: String): HttpRequest =
+    req.addAttribute(
+      AttributeKeys.remoteAddress,
+      RemoteAddress(InetAddress.getByName(ip))
+    )
+
+  test("POST /v1/keys with a remote IP lands source.ip in the audit record") {
+    val (route, sink) = freshStack()
+    val req = withRemoteIp(Post("/v1/keys", jsonEntity(createBody)), "203.0.113.42")
+      .withHeaders(RawHeader("X-Aegis-User", "alice"))
+
+    req ~> route ~> check {
+      status shouldBe StatusCodes.Created
+    }
+
+    val records = sink.all.unsafeRunSync()
+    records.size shouldBe 1
+    records.head.context.get("source.ip") shouldBe Some("203.0.113.42")
+  }
+
+  test("GET /v1/keys/{id} also carries source.ip on the read-side audit row") {
+    val (route, sink) = freshStack()
+
+    var id = ""
+    withRemoteIp(Post("/v1/keys", jsonEntity(createBody)), "198.51.100.7")
+      .withHeaders(RawHeader("X-Aegis-User", "alice")) ~> route ~> check {
+      status shouldBe StatusCodes.Created
+      id = io.circe.parser.parse(responseAs[String]).toOption
+        .flatMap(_.hcursor.downField("id").as[String].toOption)
+        .getOrElse(fail("missing id in create response"))
+    }
+
+    withRemoteIp(Get(s"/v1/keys/$id"), "198.51.100.7")
+      .withHeaders(RawHeader("X-Aegis-User", "alice")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+    val records = sink.all.unsafeRunSync()
+    records.size shouldBe 2
+    records.foreach(_.context.get("source.ip") shouldBe Some("198.51.100.7"))
+  }
+
+  test("request without a remote IP attribute → audit row has no source.ip key") {
+    val (route, sink) = freshStack()
+
+    // No `withRemoteIp(...)`: simulates a request the transport couldn't attribute (loopback bridges,
+    // test stubs without the attribute). The detector then has nothing to fire on for this row.
+    Post("/v1/keys", jsonEntity(createBody))
+      .withHeaders(RawHeader("X-Aegis-User", "alice")) ~> route ~> check {
+      status shouldBe StatusCodes.Created
+    }
+
+    val record = sink.all.unsafeRunSync().head
+    record.context.contains("source.ip") shouldBe false
+  }

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -134,4 +134,15 @@ pekko {
   loglevel        = "INFO"
   loggers         = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
   logging-filter  = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
+
+  http {
+    server {
+      # Populate `AttributeKeys.remoteAddress` on every incoming request so
+      # `Endpoints.sourceIpInput` can read the socket's remote address and HttpRoutes
+      # can stamp it into `AuditRecord.context("source.ip")` (closes #78). Default
+      # in pekko-http is `off` for backwards compatibility, but the SourceIpBaseline
+      # anomaly detector is inert without it.
+      remote-address-attribute = on
+    }
+  }
 }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -1,7 +1,7 @@
 package dev.aegiskms.app
 
 import cats.effect.unsafe.IORuntime
-import cats.effect.{IO, IOApp, Resource}
+import cats.effect.{IO, IOApp, IOLocal, Resource}
 import cats.syntax.all.*
 import com.typesafe.config.{Config, ConfigFactory}
 import dev.aegiskms.agent.{
@@ -12,7 +12,14 @@ import dev.aegiskms.agent.{
   TappedAuditSink,
   ThresholdDecisionEngine
 }
-import dev.aegiskms.audit.{AuditQuery, AuditSink, AuditingKeyService, PostgresAuditSink, StdoutAuditSink}
+import dev.aegiskms.audit.{
+  AuditQuery,
+  AuditSink,
+  AuditingKeyService,
+  PostgresAuditSink,
+  RequestContext,
+  StdoutAuditSink
+}
 import dev.aegiskms.crypto.RootOfTrust
 import dev.aegiskms.crypto.aws.AwsKmsRootOfTrust
 import dev.aegiskms.http.HttpRoutes
@@ -160,7 +167,19 @@ object Server extends IOApp.Simple:
       // step-up, a composite trips deny, and destructive ops (Rotate / Compromise / Destroy / Revoke)
       // are gated harder by 0.15. Operator-tuned thresholds via HOCON land later.
       decisionEngine = ThresholdDecisionEngine.make()
-      auditing       = new AuditingKeyService(traced, sink, Some(riskScorer), Some(decisionEngine))
+      // Per-request context bag (#78). The HTTP layer stamps `source.ip` onto this IOLocal as
+      // the first IO step of each request; `AuditingKeyService` reads it back via `current` and
+      // merges it into `AuditRecord.context`, activating the `SourceIpBaseline` detector. Both
+      // ends MUST share the same `IOLocal` — separate locals would leave the read empty.
+      sourceContextLocal <- Resource.eval(IOLocal(Map.empty[String, String]))
+      reqContext = RequestContext.fromIOLocal(sourceContextLocal)
+      auditing = new AuditingKeyService(
+        traced,
+        sink,
+        Some(riskScorer),
+        Some(decisionEngine),
+        reqContext
+      )
 
       // JWT revocation list (#24). Selected by `aegis.iam.revocation.kind`:
       //   - `none`      → no-op; tokens revoke only when they expire naturally.
@@ -204,7 +223,8 @@ object Server extends IOApp.Simple:
             Some(stdoutSink),
             stdoutSink match
               case q: AuditQuery[IO @unchecked] => Some(q)
-              case _                            => None
+              case _                            => None,
+            reqContext
           ).routes,
           MetricsRoutes.route(metricsRegistry)
         )


### PR DESCRIPTION
## Summary

The `SourceIpBaseline` detector in `BaselineDetector` has been inert since v0.1.0 because `record.context("source.ip")` was never populated — **1 of 5 anomaly detectors was dead in production**. This PR wires the HTTP transport's remote address through every audit row written by `AuditingKeyService`, using an `IOLocal`-backed side-channel so the audit decorator stays Pekko-unaware.

Closes #78.

### Library tier (`aegis-audit`, stays Pekko-free)
- **`RequestContext` SPI** — tiny `IOLocal`-backed side-channel with `current: IO[Map[String, String]]` and `set(Map): IO[Unit]`. Two impls ship: `RequestContext.empty` (default; back-compat for existing callers) and `RequestContext.fromIOLocal(local)` (production wire-up).
- **`AuditingKeyService`** gains an optional `requestContext` ctor param. `instrument` and `locate` read `requestContext.current` and pass it through `preflightContext`, which merges the per-request bag **last** so a transport-supplied key (e.g. `source.ip`) wins on collision with the scorer/engine outputs.

### Server tier (`aegis-http`, `aegis-server`)
- **`Endpoints.sourceIpInput`** — server-only `extractFromRequest` input (does NOT appear in OpenAPI) added to `keysBase`/`agentsBase`/`auditBase`. Tapir's pekko adapter hardcodes `ServerRequest.connectionInfo` to `(None, None, None)`, so the extractor reads from `req.underlying` cast to pekko's `RequestContext` and pulls `AttributeKeys.remoteAddress` off the request. Every endpoint tuple gains an internal `Option[String]` slot for the remote IP — **wire shape unchanged**.
- **`HttpRoutes.runIO(clientIp)(io)`** sets the IOLocal as the **first IO step** of every request, before any user-facing work runs. Setting it inside the IO chain (not on the calling thread) is what makes it visible to deeper IO consumers — every downstream `flatMap` in the fiber inherits it, including the read inside `AuditingKeyService`.
- **`Server.boot`** constructs ONE `IOLocal[Map[String,String]]` and hands the SAME `RequestContext.fromIOLocal(local)` to both `AuditingKeyService` and `HttpRoutes`. Separate locals would leave the read empty.
- **`application.conf`** sets `pekko.http.server.remote-address-attribute = on`. Pekko's default is `off` for back-compat, but the extractor needs the attribute populated on every request for the detector to fire.

### Doc cleanup (`aegis-agent-ai`)
- Removed the three "inert until the HTTP plumbing PR populates this key" comments in `BaselineDetector` now that this PR **is** that plumbing.

## Acceptance criteria (from #78)
- [x] `HttpRoutes` extracts the source IP from pekko-http and stores it in a per-request `IOLocal`.
- [x] `AuditingKeyService` reads the `IOLocal` and merges `"source.ip" -> <ip>` into the audit record context.
- [x] Existing `SourceIpBaseline` tests stay green.
- [x] Integration test: HTTP request produces an audit record with `context("source.ip")` set.

## Test plan
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` — formatting gate
- [x] `sbt "scalafixAll --check"` — lint gate
- [x] `sbt test` — full suite green across all modules
- [x] `AuditingKeyServiceSpec` — 4 new cases (back-compat empty path, source.ip on state-changing op, source.ip on read-only `locate`, three-way coexistence with `risk.score` + `outcome.decision`)
- [x] `HttpRoutesSourceIpSpec` (new file) — 3 cases driving requests through the full `Route` and asserting end-to-end `source.ip` propagation
- [x] Existing `BaselineDetectorSpec` `SourceIpBaseline` tests still green (they synthesize context directly, agnostic to where the IP came from)

## Notes for reviewers
The hardest part was a subtle bug I almost shipped: my first cut used `req.connectionInfo.remote` in `extractFromRequest`, which compiled and unit-tested fine — but Tapir's pekko-http adapter (1.11.10, `PekkoServerRequest.scala`) hardcodes `connectionInfo` to `(None, None, None)`. Writing the integration test caught it; the fix is the `req.underlying` cast in `Endpoints.scala` plus the pekko config flip. Without the integration test we'd have merged the PR with the detector still inert.