### PR TITLE
feat(audit+server): Kafka + NATS JetStream audit fan-out sinks (closes #22, closes #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Kafka + NATS JetStream audit fan-out sinks (closes #22, closes #23).** Two new streaming
+  audit destinations alongside the existing SIEM webhook (#21). Both follow the same shape
+  — bounded `Queue` + background drain fiber + retry + JSONL dead-letter — and compose with
+  the primary durable sink via `FanOutAuditSink`, so operators can run e.g.
+  `postgres + kafka + nats` simultaneously.
+  - **`KafkaAuditSink`** (`aegis-server`) uses Pekko-Connectors-Kafka's `SendProducer` with
+    an idempotent producer config (`acks=all`, `enable.idempotence=true`,
+    `max.in.flight.requests.per.connection=5`, `retries=Int.MaxValue`, `compression=lz4`).
+    Each record's Kafka key is its `correlationId` so messages from the same KMS request
+    land on the same partition, preserving order for downstream consumers.
+  - **`NatsAuditSink`** (`aegis-server`) uses `io.nats:jnats` 2.21 with JetStream's
+    `publishAsync` + `PubAck` for durability — the drain fiber only ack's a record once
+    JetStream has durably persisted it. Optional `autoCreateStream=true` provisions the
+    stream on boot if missing (idempotent — existing streams are left untouched). Supports
+    optional NATS credentials file (`.creds` from `nsc add user --csv`).
+  - **`Server.boot` fan-out wiring:** `kafkaAuditSinkResource` and `natsAuditSinkResource`
+    are added alongside `webhookAuditSinkResource`. All three return an empty list when
+    disabled, so the default path stays zero-cost. Fail-fast at boot on empty
+    `bootstrap-servers` / `topic` / `servers` / `stream` / `subject`.
+  - **New HOCON blocks:** `aegis.audit.kafka.{enabled, bootstrap-servers, topic, client-id,
+    max-retries, initial-backoff-ms, max-backoff-ms, dead-letter-file, queue-capacity}` and
+    `aegis.audit.nats.{enabled, servers, stream, subject, auto-create-stream,
+    credentials-file, max-retries, initial-backoff-ms, max-backoff-ms, dead-letter-file,
+    queue-capacity}`. All overridable via `AEGIS_AUDIT_KAFKA_*` / `AEGIS_AUDIT_NATS_*`.
+  - **New dependencies:** `pekko-connectors-kafka` 1.1.0 (pairs with pekko 1.1.x) and
+    `io.nats:jnats` 2.21.1. Test-only Testcontainers modules for Kafka and NATS.
+  - **Tests:** `KafkaAuditSinkSpec` (4 cases — happy-path consume, canonical-JSON round-trip,
+    transport failure → DLQ, Config validation) and `NatsAuditSinkSpec` (5 cases — same
+    coverage plus idempotent `autoCreateStream`). Integration tests use shared containers
+    via `BeforeAndAfterAll` per the workflow-speed pattern established in PR #86. Skip
+    cleanly on machines without Docker.
+  - **Doc updates:** ROADMAP audit-sink table (Kafka + NATS both ✅ v0.2.0); also flipped
+    several stale `🔜 v0.2.0` rows that had drifted from reality (risk scorer, OIDC,
+    agent-token endpoint, Redis revocation). ARCHITECTURE.md mermaid diagrams + v0.2.0
+    status table updated.
+
 - **MySQL + SQLite event journal adapters (closes #49, closes #50).** The persistence SPI now
   ships three relational backends instead of one. Operators pick via the existing
   `aegis.persistence.journal.kind` HOCON key.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,12 +84,13 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 | 2.0.f | Postgres audit table (queryable, indexed on actor + occurredAt + key) | Platform | 🔜 |
 | 2.0.g | `GET /v1/audit?since=&actor=&key=&op=` audit-read API | Platform | 🔜 |
 | 2.0.h | `aegis audit tail` CLI — wire the existing stub to the new audit-read API | Wedge | 🔜 |
-| 2.0.i | Generic SIEM webhook audit sink (HTTPS POST per event, batched + retried) | Platform | 🔜 |
-| 2.0.j | Kafka audit fan-out (Pekko-Connectors-Kafka) | Platform | 🔜 |
-| 2.0.k | Redis-backed JWT revocation list (jti blacklist) — required for instant agent revoke | Platform | 🔜 |
+| 2.0.i | Generic SIEM webhook audit sink (HTTPS POST per event, batched + retried) | Platform | ✅ |
+| 2.0.j | Kafka audit fan-out (Pekko-Connectors-Kafka) | Platform | ✅ |
+| 2.0.k | Redis-backed JWT revocation list (jti blacklist) — required for instant agent revoke | Platform | ✅ |
 | 2.0.l | Honey keys / canary keys — fake keys with auto-alert if any agent touches them | Wedge | 💡 |
-| 2.0.m | OIDC verifier + JWKS rotation + RS256 / ES256 signature support | Wedge | 🔜 |
+| 2.0.m | OIDC verifier + JWKS rotation + RS256 / ES256 signature support | Wedge | ✅ |
 | 2.0.n | OPA (Open Policy Agent) integration — externalize policy evaluation (Rego) via sidecar | Wedge | 💡 |
+| 2.0.o | NATS / NATS JetStream audit fan-out | Platform | ✅ |
 
 **Demo target:** "Issue an agent token, watch it sign 49 invoices fine, watch it try one off-scope key, watch the auto-revoke fire before the next attempt — all in `aegis audit tail`."
 
@@ -221,10 +222,10 @@ The release tables above slice the work by milestone. The tables below slice by 
 | Sink | Status | Tracking |
 |---|---|---|
 | Stdout JSON | ✅ v0.1.0 | — |
-| Postgres audit table | 🔜 v0.2.0 | issue-tagged `area/audit` |
-| Generic SIEM webhook | 🔜 v0.2.0 | issue-tagged `area/audit` |
-| Kafka | 🔜 v0.2.0 | issue-tagged `area/audit area/integration/kafka` |
-| NATS / NATS JetStream | 💡 v0.2.0+ | issue-tagged `area/audit area/integration/nats` |
+| Postgres audit table | ✅ v0.2.0 | — |
+| Generic SIEM webhook | ✅ v0.2.0 | — |
+| Kafka | ✅ v0.2.0 | — |
+| NATS / NATS JetStream | ✅ v0.2.0 | — |
 | AWS SQS / SNS | 💡 v0.3.0 | issue-tagged `area/audit area/integration/aws` |
 | GCP Pub/Sub | 💡 v0.3.0 | issue-tagged `area/audit area/integration/gcp` |
 | Azure Event Hubs / Service Bus | 💡 v0.3.0 | issue-tagged `area/audit area/integration/azure` |
@@ -259,7 +260,7 @@ The release tables above slice the work by milestone. The tables below slice by 
 | Capability | Status | Tracking |
 |---|---|---|
 | Role/scope allowlist + parent-check | ✅ v0.1.0 | — |
-| Risk-scored decisions (allow / step-up / deny) | 🔜 v0.2.0 | `area/policy area/risk` |
+| Risk-scored decisions (allow / step-up / deny) | ✅ v0.2.0 | — |
 | Time-windowed access (key X usable Mon-Fri 9-18 UTC) | 🔜 v0.3.0 | `area/policy` |
 | Just-In-Time (JIT) access | 💡 v0.3.0+ | `area/policy area/ai-governance` |
 | Approval workflows (Slack / PagerDuty / OpsGenie) | 💡 v0.3.0+ | `area/policy area/integration/*` |
@@ -307,11 +308,11 @@ The release tables above slice the work by milestone. The tables below slice by 
 |---|---|---|
 | HMAC JWT (HS256) issue + verify | ✅ v0.1.0 | — |
 | Dev-mode `X-Aegis-User` header | ✅ v0.1.0 | — |
-| OIDC discovery + JWKS rotation | 🔜 v0.2.0 | `area/iam` |
-| RS256 / ES256 / EdDSA verifier | 🔜 v0.2.0 | `area/iam` |
+| OIDC discovery + JWKS rotation | ✅ v0.2.0 | — |
+| RS256 / ES256 verifier (EdDSA deferred) | ✅ v0.2.0 | — |
 | OIDC providers tested: Keycloak, Authentik, Dex, Auth0, Okta | 💡 v0.3.0 | `area/iam area/integration/oidc` |
-| Agent-token issuance HTTP endpoint | 🔜 v0.2.0 | `area/iam area/wedge` |
-| Redis-backed JWT revocation list (jti blacklist) | 🔜 v0.2.0 | `area/iam area/integration/redis` |
+| Agent-token issuance HTTP endpoint | ✅ v0.2.0 | — |
+| Redis-backed JWT revocation list (jti blacklist) | ✅ v0.2.0 | — |
 | mTLS for KMIP plane | 🔜 v0.4.0 | `area/iam area/wire/kmip` |
 | Hardware-bound credentials (WebAuthn for human auth) | 💡 v0.4.0+ | `area/iam kind/security` |
 

--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,9 @@ lazy val server = (project in file("modules/aegis-server"))
     publish / skip := true, // server is shipped as a Docker image, not a Maven artifact
     libraryDependencies ++=
       pekkoHttp ++ Dependencies.tapir ++ Dependencies.metrics ++ Dependencies.tracing ++
-        Dependencies.redis ++ Dependencies.testcontainersRedis,
+        Dependencies.redis ++ Dependencies.testcontainersRedis ++
+        Dependencies.pekkoConnectorsKafka ++ Dependencies.testcontainersKafka ++
+        Dependencies.nats ++ Dependencies.testcontainersNats,
     Docker / packageName := "aegis-server",
     dockerBaseImage      := "eclipse-temurin:21-jre",
     // Fork `sbt 'server/run'` into its own JVM. Without this, sbt's in-process classloader and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,7 +206,7 @@ flowchart LR
     actor --> rot[(Root of Trust<br/>AWS KMS adapter)]:::sink
     audit -. score+factors .-> scorer["RiskScorer<br/><i>BaselineRiskScorer</i>"]:::metric
     audit -. decide .-> engine["DecisionEngine<br/><i>ThresholdDecisionEngine</i>"]:::gate
-    audit -. on every call .-> auditSink[(Audit sink<br/>stdout · SIEM · Kafka 🚧)]:::sink
+    audit -. on every call .-> auditSink[(Audit sink<br/>stdout · postgres<br/>SIEM webhook · Kafka · NATS)]:::sink
     auditSink -. tapped .-> detector["BaselineDetector<br/><i>5 detectors</i>"]:::metric
     detector --> responder["AutoResponder<br/><i>matches rules → revoke / alert / freeze</i>"]:::gate
     responder -. system-actor revoke .-> traced
@@ -260,7 +260,7 @@ flowchart LR
     svc -. on every state-changing event .-> sink[Audit sink]:::audit
     sink --> pg[(Postgres audit table 🚧)]:::audit
     sink --> obj[(S3 / object store 🚧)]:::audit
-    sink --> siem[(SIEM webhook 🚧)]:::audit
+    sink --> siem[(SIEM webhook / Kafka / NATS)]:::audit
     sink --> sout[stdout JSON<br/>v0.1.x default]:::audit
 ```
 
@@ -424,9 +424,12 @@ What's implemented today vs. what the design above describes. This is the only p
 | Capability | Status |
 | --- | --- |
 | GCP / Azure / Vault / PKCS#11 Root of Trust adapters | 🔜 Designed (SPI in place) |
-| OIDC discovery + JWKS verification + RS256/ES256 verifier | 🔜 Designed (trait in place) |
-| Agent-token issuance HTTP endpoint (`POST /v1/agents/issue`) | 🔜 Designed (`JwtIssuer` in place) |
-| Postgres / Kafka / SIEM webhook audit sinks | 🔜 Designed (sink SPI in place) |
+| OIDC discovery + JWKS verification + RS256/ES256 verifier | ✅ Shipped v0.2.0 |
+| Agent-token issuance HTTP endpoint (`POST /v1/agents/issue`) | ✅ Shipped v0.2.0 |
+| Postgres audit table + GET /v1/audit read API | ✅ Shipped v0.2.0 |
+| SIEM webhook audit sink (HMAC-signed, async batched + retry + DLQ) | ✅ Shipped v0.2.0 |
+| Kafka audit fan-out sink (idempotent producer, Pekko-Connectors-Kafka) | ✅ Shipped v0.2.0 |
+| NATS JetStream audit fan-out sink (publishAsync + PubAck) | ✅ Shipped v0.2.0 |
 | Risk scorer (W2) — numeric scores feeding access decisions | ✅ Shipped (see v0.1.x table above) |
 | Auto-responder (W3) consuming `AgentRecommendation`s | ✅ Shipped (see v0.1.x table above) |
 | LLM advisor (W4) — `aegis advisor scan/explain` | 🔜 Designed (CLI stub in place) |

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -218,6 +218,86 @@ aegis {
       queue-capacity = 1024
       queue-capacity = ${?AEGIS_AUDIT_WEBHOOK_QUEUE_CAPACITY}
     }
+
+    # Optional Kafka audit fan-out (#22). When `enabled=true`, every audit record fans out to
+    # BOTH the primary durable sink AND a Kafka topic via an idempotent producer (acks=all,
+    # enable.idempotence=true). Same DLQ semantics as the webhook sink. Typical streaming-export
+    # setup: `kind=postgres` (for the audit-read API) PLUS `kafka.enabled=true` (for SIEM /
+    # downstream consumers).
+    kafka {
+      enabled = false
+      enabled = ${?AEGIS_AUDIT_KAFKA_ENABLED}
+
+      # Comma-separated broker list. Required when enabled.
+      bootstrap-servers = ""
+      bootstrap-servers = ${?AEGIS_AUDIT_KAFKA_BOOTSTRAP_SERVERS}
+
+      # Topic to publish to. Required when enabled. Operators typically pre-create with the
+      # desired partition count + retention.
+      topic = ""
+      topic = ${?AEGIS_AUDIT_KAFKA_TOPIC}
+
+      # Kafka client.id for broker-side identification and ACL routing.
+      client-id = "aegis-audit"
+      client-id = ${?AEGIS_AUDIT_KAFKA_CLIENT_ID}
+
+      max-retries        = 5
+      max-retries        = ${?AEGIS_AUDIT_KAFKA_MAX_RETRIES}
+      initial-backoff-ms = 500
+      initial-backoff-ms = ${?AEGIS_AUDIT_KAFKA_INITIAL_BACKOFF_MS}
+      max-backoff-ms     = 30000
+      max-backoff-ms     = ${?AEGIS_AUDIT_KAFKA_MAX_BACKOFF_MS}
+
+      dead-letter-file = "/var/lib/aegis/audit-kafka-dlq.jsonl"
+      dead-letter-file = ${?AEGIS_AUDIT_KAFKA_DEAD_LETTER_FILE}
+
+      queue-capacity = 1024
+      queue-capacity = ${?AEGIS_AUDIT_KAFKA_QUEUE_CAPACITY}
+    }
+
+    # Optional NATS JetStream audit fan-out (#23). Mirrors the Kafka sink for shops standardised
+    # on NATS for messaging. Uses `publishAsync` + PubAck for durability — the drain fiber only
+    # ack's a record once JetStream has durably persisted it.
+    nats {
+      enabled = false
+      enabled = ${?AEGIS_AUDIT_NATS_ENABLED}
+
+      # Comma-separated NATS URLs. Required when enabled.
+      servers = ""
+      servers = ${?AEGIS_AUDIT_NATS_SERVERS}
+
+      # JetStream stream name. Required when enabled.
+      stream = "AEGIS_AUDIT"
+      stream = ${?AEGIS_AUDIT_NATS_STREAM}
+
+      # Subject to publish to. Required when enabled.
+      subject = "aegis.audit"
+      subject = ${?AEGIS_AUDIT_NATS_SUBJECT}
+
+      # Idempotently create the stream on boot if it doesn't already exist. Operators with their
+      # own provisioning flow (NATS CLI / Terraform / Crossplane) should set this to `false` and
+      # pre-create the stream with their desired retention + storage config.
+      auto-create-stream = true
+      auto-create-stream = ${?AEGIS_AUDIT_NATS_AUTO_CREATE_STREAM}
+
+      # Optional path to a NATS .creds file produced by `nsc add user --csv`. Empty for
+      # unauthenticated NATS (typical dev / single-server setup).
+      credentials-file = ""
+      credentials-file = ${?AEGIS_AUDIT_NATS_CREDENTIALS_FILE}
+
+      max-retries        = 5
+      max-retries        = ${?AEGIS_AUDIT_NATS_MAX_RETRIES}
+      initial-backoff-ms = 500
+      initial-backoff-ms = ${?AEGIS_AUDIT_NATS_INITIAL_BACKOFF_MS}
+      max-backoff-ms     = 30000
+      max-backoff-ms     = ${?AEGIS_AUDIT_NATS_MAX_BACKOFF_MS}
+
+      dead-letter-file = "/var/lib/aegis/audit-nats-dlq.jsonl"
+      dead-letter-file = ${?AEGIS_AUDIT_NATS_DEAD_LETTER_FILE}
+
+      queue-capacity = 1024
+      queue-capacity = ${?AEGIS_AUDIT_NATS_QUEUE_CAPACITY}
+    }
   }
 }
 

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -253,6 +253,13 @@ aegis {
 
       queue-capacity = 1024
       queue-capacity = ${?AEGIS_AUDIT_KAFKA_QUEUE_CAPACITY}
+
+      # How long Producer.send() blocks waiting for metadata before raising a TimeoutException.
+      # Kafka's default of 60s is fine for production (gives transient broker outages time to
+      # recover) but unbounded in tests pointing at a dead broker — operators rarely need to
+      # tune this knob.
+      max-block-ms = 60000
+      max-block-ms = ${?AEGIS_AUDIT_KAFKA_MAX_BLOCK_MS}
     }
 
     # Optional NATS JetStream audit fan-out (#23). Mirrors the Kafka sink for shops standardised

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
@@ -1,0 +1,186 @@
+package dev.aegiskms.app
+
+import cats.effect.std.Queue
+import cats.effect.{IO, Resource}
+import dev.aegiskms.audit.AuditRecordJson.given
+import dev.aegiskms.audit.{AuditRecord, AuditSink}
+import io.circe.syntax.*
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.kafka.ProducerSettings
+import org.apache.pekko.kafka.scaladsl.SendProducer
+import org.slf4j.LoggerFactory
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, StandardOpenOption}
+import scala.concurrent.duration.*
+
+/** Kafka audit fan-out sink (#22). Records are enqueued by `write` and drained by a single background fiber
+  * that publishes them — one record per Kafka message — to the configured topic. Closes ROADMAP 2.0.j.
+  *
+  * Why a queue + background fiber instead of inline publish: same reason as `WebhookAuditSink` — broker
+  * delivery latency is decoupled from the KMS request path. The Kafka client's own idempotent producer
+  * (enabled by default in this sink, `acks=all + enable.idempotence=true`) handles in-broker retries and
+  * exactly-once delivery semantics; our outer retry loop catches the case where the producer itself surfaces
+  * a terminal failure (broker unreachable, ACL rejection, etc.) and falls back to the disk dead-letter for
+  * operator intervention.
+  *
+  * Idempotent producer config:
+  *   - `acks=all` — wait for ISR replication before ack
+  *   - `enable.idempotence=true` — broker dedupes producer epochs
+  *   - `max.in.flight.requests.per.connection=5` (Kafka requires ≤ 5 for idempotence)
+  *   - `retries=Int.MaxValue` — producer retries internally up to `delivery.timeout.ms`
+  *
+  * Key strategy: each record's Kafka key is the `correlationId`. This co-locates records from the same KMS
+  * request onto the same partition, preserving order for downstream consumers.
+  *
+  * Dead-letter file: one JSON object per line, appended to `deadLetterFile` after `maxRetries` consecutive
+  * transport failures. Format identical to [[WebhookAuditSink]] for operator parity.
+  */
+final class KafkaAuditSink private (
+    queue: Queue[IO, AuditRecord]
+) extends AuditSink[IO]:
+  def write(record: AuditRecord): IO[Unit] = queue.offer(record)
+
+object KafkaAuditSink:
+
+  final case class Config(
+      bootstrapServers: String,
+      topic: String,
+      clientId: String,
+      maxRetries: Int,
+      initialBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      deadLetterFile: Path,
+      queueCapacity: Int
+  ):
+    require(bootstrapServers.nonEmpty, "bootstrapServers must be non-empty")
+    require(topic.nonEmpty, "topic must be non-empty")
+    require(maxRetries >= 0, s"maxRetries must be >= 0, was $maxRetries")
+    require(queueCapacity > 0, s"queueCapacity must be > 0, was $queueCapacity")
+
+  private val logger = LoggerFactory.getLogger(classOf[KafkaAuditSink])
+
+  /** Build the sink. Acquires queue + SendProducer + drain fiber; release flushes and closes the SendProducer
+    * (waits up to 10s for in-flight messages to be ack'd) and cancels the fiber.
+    */
+  def make(config: Config)(using system: ActorSystem[?]): Resource[IO, AuditSink[IO]] =
+    for
+      producer <- producerResource(config)
+      q        <- Resource.eval(Queue.bounded[IO, AuditRecord](config.queueCapacity))
+      _ <- Resource.eval(IO {
+        logger.info(
+          s"audit kafka: bootstrap=${config.bootstrapServers}, topic=${config.topic}, " +
+            s"client-id=${config.clientId}, max-retries=${config.maxRetries}, " +
+            s"queue-capacity=${config.queueCapacity}, dead-letter=${config.deadLetterFile}"
+        )
+      })
+      _ <- Resource.make(drainLoop(q, producer, config).start)(f => f.cancel)
+    yield new KafkaAuditSink(q)
+
+  // ── SendProducer Resource ─────────────────────────────────────────────────
+
+  private def producerResource(config: Config)(using
+      system: ActorSystem[?]
+  ): Resource[IO, SendProducer[String, Array[Byte]]] =
+    val classicSystem = system.classicSystem
+    val baseSettings = ProducerSettings(
+      classicSystem,
+      new StringSerializer(),
+      new ByteArraySerializer()
+    )
+      .withBootstrapServers(config.bootstrapServers)
+      .withProperties(
+        ProducerConfig.CLIENT_ID_CONFIG                      -> config.clientId,
+        ProducerConfig.ACKS_CONFIG                           -> "all",
+        ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG             -> "true",
+        ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> "5",
+        ProducerConfig.RETRIES_CONFIG                        -> Int.MaxValue.toString,
+        ProducerConfig.COMPRESSION_TYPE_CONFIG               -> "lz4"
+      )
+    Resource.make(
+      IO(SendProducer(baseSettings)(classicSystem))
+    ) { producer =>
+      IO.fromFuture(IO(producer.close())).void.handleErrorWith { t =>
+        IO(logger.warn(s"audit kafka: producer shutdown reported error: ${t.getMessage}", t))
+      }
+    }
+
+  // ── Drain loop ────────────────────────────────────────────────────────────
+
+  private def drainLoop(
+      queue: Queue[IO, AuditRecord],
+      producer: SendProducer[String, Array[Byte]],
+      config: Config
+  ): IO[Unit] =
+    val tick: IO[Unit] =
+      for
+        record <- queue.take
+        _ <- attemptWithRetry(record, producer, config, attempt = 0).handleErrorWith { t =>
+          IO(logger.error(
+            "audit kafka: unhandled error draining record " +
+              s"(correlationId=${record.correlationId}): ${t.getMessage}",
+            t
+          )) *> writeDeadLetter(record, config)
+        }
+      yield ()
+    tick.foreverM
+
+  private def attemptWithRetry(
+      record: AuditRecord,
+      producer: SendProducer[String, Array[Byte]],
+      config: Config,
+      attempt: Int
+  ): IO[Unit] =
+    publish(record, producer, config).attempt.flatMap {
+      case Right(_) =>
+        IO.unit
+      case Left(t) =>
+        if attempt >= config.maxRetries then
+          IO(logger.warn(
+            s"audit kafka: max retries (${config.maxRetries}) exhausted for " +
+              s"correlationId=${record.correlationId}; sending to DLQ. last=${t.getMessage}"
+          )) *> writeDeadLetter(record, config)
+        else
+          val backoff = nextBackoff(attempt, config)
+          IO(logger.info(
+            s"audit kafka: retryable failure (${t.getClass.getSimpleName}: ${t.getMessage}) for " +
+              s"correlationId=${record.correlationId}, attempt=${attempt + 1}/${config.maxRetries}, " +
+              s"sleeping ${backoff.toMillis}ms"
+          )) *> IO.sleep(backoff) *> attemptWithRetry(record, producer, config, attempt + 1)
+    }
+
+  private def publish(
+      record: AuditRecord,
+      producer: SendProducer[String, Array[Byte]],
+      config: Config
+  ): IO[Unit] =
+    val body = record.asJson.noSpaces.getBytes(StandardCharsets.UTF_8)
+    val msg  = new ProducerRecord[String, Array[Byte]](config.topic, record.correlationId, body)
+    IO.fromFuture(IO(producer.send(msg))).void
+
+  private def nextBackoff(attempt: Int, config: Config): FiniteDuration =
+    val raw = config.initialBackoff * Math.pow(2.0, attempt.toDouble).toLong
+    if raw > config.maxBackoff then config.maxBackoff else raw
+
+  // ── Dead-letter ───────────────────────────────────────────────────────────
+
+  private def writeDeadLetter(record: AuditRecord, config: Config): IO[Unit] =
+    IO.blocking {
+      val line = record.asJson.noSpaces + "\n"
+      Option(config.deadLetterFile.getParent).foreach(Files.createDirectories(_))
+      Files.write(
+        config.deadLetterFile,
+        line.getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND
+      )
+      ()
+    }.handleErrorWith { t =>
+      IO(logger.error(
+        s"audit kafka: DLQ write to ${config.deadLetterFile} failed for " +
+          s"correlationId=${record.correlationId}: ${t.getMessage}",
+        t
+      ))
+    }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
@@ -53,12 +53,20 @@ object KafkaAuditSink:
       initialBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       deadLetterFile: Path,
-      queueCapacity: Int
+      queueCapacity: Int,
+      /** Controls how long `Producer.send()` blocks waiting for metadata before surfacing a
+        * `TimeoutException`. Kafka default is 60 s, which is reasonable for production (gives
+        * a brief broker outage time to recover) but pathological for tests that point at a
+        * closed port. Operators rarely need to tune this; tests override it to a small value
+        * to validate the transport-failure → DLQ path deterministically.
+        */
+      maxBlockMs: Long = 60000L
   ):
     require(bootstrapServers.nonEmpty, "bootstrapServers must be non-empty")
     require(topic.nonEmpty, "topic must be non-empty")
     require(maxRetries >= 0, s"maxRetries must be >= 0, was $maxRetries")
     require(queueCapacity > 0, s"queueCapacity must be > 0, was $queueCapacity")
+    require(maxBlockMs > 0, s"maxBlockMs must be > 0, was $maxBlockMs")
 
   private val logger = LoggerFactory.getLogger(classOf[KafkaAuditSink])
 
@@ -97,7 +105,8 @@ object KafkaAuditSink:
         ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG             -> "true",
         ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> "5",
         ProducerConfig.RETRIES_CONFIG                        -> Int.MaxValue.toString,
-        ProducerConfig.COMPRESSION_TYPE_CONFIG               -> "lz4"
+        ProducerConfig.COMPRESSION_TYPE_CONFIG               -> "lz4",
+        ProducerConfig.MAX_BLOCK_MS_CONFIG                   -> config.maxBlockMs.toString
       )
     Resource.make(
       IO(SendProducer(baseSettings)(classicSystem))

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/KafkaAuditSink.scala
@@ -55,10 +55,10 @@ object KafkaAuditSink:
       deadLetterFile: Path,
       queueCapacity: Int,
       /** Controls how long `Producer.send()` blocks waiting for metadata before surfacing a
-        * `TimeoutException`. Kafka default is 60 s, which is reasonable for production (gives
-        * a brief broker outage time to recover) but pathological for tests that point at a
-        * closed port. Operators rarely need to tune this; tests override it to a small value
-        * to validate the transport-failure → DLQ path deterministically.
+        * `TimeoutException`. Kafka default is 60 s, which is reasonable for production (gives a brief broker
+        * outage time to recover) but pathological for tests that point at a closed port. Operators rarely
+        * need to tune this; tests override it to a small value to validate the transport-failure → DLQ path
+        * deterministically.
         */
       maxBlockMs: Long = 60000L
   ):

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/NatsAuditSink.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/NatsAuditSink.scala
@@ -1,0 +1,198 @@
+package dev.aegiskms.app
+
+import cats.effect.std.Queue
+import cats.effect.{IO, Resource}
+import dev.aegiskms.audit.AuditRecordJson.given
+import dev.aegiskms.audit.{AuditRecord, AuditSink}
+import io.circe.syntax.*
+import io.nats.client.api.{RetentionPolicy, StorageType, StreamConfiguration}
+import io.nats.client.{Connection, JetStream, Nats, Options}
+import org.slf4j.LoggerFactory
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, StandardOpenOption}
+import scala.concurrent.duration.*
+
+/** NATS JetStream audit fan-out sink (#23). Records are enqueued by `write` and drained by a single
+  * background fiber that publishes them — one record per JetStream message — to the configured subject.
+  * Closes ROADMAP audit fan-out track for the NATS shop.
+  *
+  * Why JetStream specifically (vs core NATS pub/sub): JetStream is the persistent / at-least-once variant.
+  * `publishAsync` returns a `CompletableFuture<PubAck>` that completes only after the broker has durably
+  * accepted the message into the stream. Core NATS pub/sub is fire-and-forget and would lose records on
+  * broker restart — unacceptable for an audit pipeline.
+  *
+  * Stream provisioning: when `autoCreateStream=true`, the sink creates the configured stream on boot if it
+  * doesn't already exist (idempotent — existing streams are left untouched). The stream is configured with
+  * `StorageType.File` retention so messages survive restart. Operators with their own provisioning flow
+  * should set `autoCreateStream=false` and pre-create the stream via NATS CLI / Terraform / etc.
+  *
+  * Dead-letter: one JSON object per line appended to `deadLetterFile` after `maxRetries` consecutive
+  * transport failures. Format identical to [[WebhookAuditSink]] / [[KafkaAuditSink]] for operator parity.
+  */
+final class NatsAuditSink private (
+    queue: Queue[IO, AuditRecord]
+) extends AuditSink[IO]:
+  def write(record: AuditRecord): IO[Unit] = queue.offer(record)
+
+object NatsAuditSink:
+
+  final case class Config(
+      servers: String,
+      stream: String,
+      subject: String,
+      autoCreateStream: Boolean,
+      credentialsFile: Option[Path],
+      maxRetries: Int,
+      initialBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      deadLetterFile: Path,
+      queueCapacity: Int
+  ):
+    require(servers.nonEmpty, "servers must be non-empty")
+    require(stream.nonEmpty, "stream must be non-empty")
+    require(subject.nonEmpty, "subject must be non-empty")
+    require(maxRetries >= 0, s"maxRetries must be >= 0, was $maxRetries")
+    require(queueCapacity > 0, s"queueCapacity must be > 0, was $queueCapacity")
+
+  private val logger = LoggerFactory.getLogger(classOf[NatsAuditSink])
+
+  /** Build the sink. Acquires NATS connection + JetStream context + queue + drain fiber; release cancels the
+    * fiber, drains the JetStream context, and closes the connection.
+    */
+  def make(config: Config): Resource[IO, AuditSink[IO]] =
+    for
+      connection <- connectionResource(config)
+      jetStream  <- Resource.eval(IO(connection.jetStream()))
+      _          <- Resource.eval(maybeCreateStream(connection, config))
+      q          <- Resource.eval(Queue.bounded[IO, AuditRecord](config.queueCapacity))
+      _ <- Resource.eval(IO {
+        logger.info(
+          s"audit nats: servers=${config.servers}, stream=${config.stream}, " +
+            s"subject=${config.subject}, max-retries=${config.maxRetries}, " +
+            s"queue-capacity=${config.queueCapacity}, dead-letter=${config.deadLetterFile}"
+        )
+      })
+      _ <- Resource.make(drainLoop(q, jetStream, config).start)(f => f.cancel)
+    yield new NatsAuditSink(q)
+
+  // ── Connection Resource ───────────────────────────────────────────────────
+
+  private def connectionResource(config: Config): Resource[IO, Connection] =
+    Resource.make(IO {
+      val builder = new Options.Builder()
+        .server(config.servers)
+        .connectionTimeout(java.time.Duration.ofSeconds(5))
+        .reconnectWait(java.time.Duration.ofSeconds(2))
+        .maxReconnects(-1)
+      config.credentialsFile.foreach(p => builder.authHandler(Nats.credentials(p.toString)))
+      Nats.connect(builder.build())
+    }) { conn =>
+      IO(conn.close()).handleErrorWith(t =>
+        IO(logger.warn(s"audit nats: connection close reported error: ${t.getMessage}", t))
+      )
+    }
+
+  /** Idempotent stream provisioning. JetStream's `addStream` errors with `JetStreamApiException` when the
+    * stream already exists; we treat that as a no-op so the boot path is safe to re-run.
+    */
+  private def maybeCreateStream(connection: Connection, config: Config): IO[Unit] =
+    if !config.autoCreateStream then IO.unit
+    else
+      IO {
+        val jsm = connection.jetStreamManagement()
+        val existing =
+          try
+            val info = jsm.getStreamInfo(config.stream)
+            Option(info)
+          catch case _: io.nats.client.JetStreamApiException => None
+        if existing.isEmpty then
+          val cfg = StreamConfiguration.builder()
+            .name(config.stream)
+            .subjects(config.subject)
+            .storageType(StorageType.File)
+            .retentionPolicy(RetentionPolicy.Limits)
+            .build()
+          jsm.addStream(cfg)
+          logger.info(s"audit nats: created JetStream stream '${config.stream}'")
+      }
+
+  // ── Drain loop ────────────────────────────────────────────────────────────
+
+  private def drainLoop(
+      queue: Queue[IO, AuditRecord],
+      jetStream: JetStream,
+      config: Config
+  ): IO[Unit] =
+    val tick: IO[Unit] =
+      for
+        record <- queue.take
+        _ <- attemptWithRetry(record, jetStream, config, attempt = 0).handleErrorWith { t =>
+          IO(logger.error(
+            "audit nats: unhandled error draining record " +
+              s"(correlationId=${record.correlationId}): ${t.getMessage}",
+            t
+          )) *> writeDeadLetter(record, config)
+        }
+      yield ()
+    tick.foreverM
+
+  private def attemptWithRetry(
+      record: AuditRecord,
+      jetStream: JetStream,
+      config: Config,
+      attempt: Int
+  ): IO[Unit] =
+    publish(record, jetStream, config).attempt.flatMap {
+      case Right(_) =>
+        IO.unit
+      case Left(t) =>
+        if attempt >= config.maxRetries then
+          IO(logger.warn(
+            s"audit nats: max retries (${config.maxRetries}) exhausted for " +
+              s"correlationId=${record.correlationId}; sending to DLQ. last=${t.getMessage}"
+          )) *> writeDeadLetter(record, config)
+        else
+          val backoff = nextBackoff(attempt, config)
+          IO(logger.info(
+            s"audit nats: retryable failure (${t.getClass.getSimpleName}: ${t.getMessage}) for " +
+              s"correlationId=${record.correlationId}, attempt=${attempt + 1}/${config.maxRetries}, " +
+              s"sleeping ${backoff.toMillis}ms"
+          )) *> IO.sleep(backoff) *> attemptWithRetry(record, jetStream, config, attempt + 1)
+    }
+
+  private def publish(record: AuditRecord, jetStream: JetStream, config: Config): IO[Unit] =
+    val body = record.asJson.noSpaces.getBytes(StandardCharsets.UTF_8)
+    IO.blocking {
+      // publishAsync returns a CompletableFuture<PubAck>; we await it inside IO.blocking so
+      // failure to durably accept the message surfaces as an exception caught by .attempt.
+      val ack = jetStream.publishAsync(config.subject, body).get(10, java.util.concurrent.TimeUnit.SECONDS)
+      if ack.hasError then
+        throw new RuntimeException(s"NATS JetStream PubAck reported error: ${ack.getError}")
+      ()
+    }
+
+  private def nextBackoff(attempt: Int, config: Config): FiniteDuration =
+    val raw = config.initialBackoff * Math.pow(2.0, attempt.toDouble).toLong
+    if raw > config.maxBackoff then config.maxBackoff else raw
+
+  // ── Dead-letter ───────────────────────────────────────────────────────────
+
+  private def writeDeadLetter(record: AuditRecord, config: Config): IO[Unit] =
+    IO.blocking {
+      val line = record.asJson.noSpaces + "\n"
+      Option(config.deadLetterFile.getParent).foreach(Files.createDirectories(_))
+      Files.write(
+        config.deadLetterFile,
+        line.getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND
+      )
+      ()
+    }.handleErrorWith { t =>
+      IO(logger.error(
+        s"audit nats: DLQ write to ${config.deadLetterFile} failed for " +
+          s"correlationId=${record.correlationId}: ${t.getMessage}",
+        t
+      ))
+    }

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -542,7 +542,8 @@ object Server extends IOApp.Simple:
             scala.concurrent.duration.MILLISECONDS
           ),
           deadLetterFile = java.nio.file.Paths.get(kafkaCfg.getString("dead-letter-file")),
-          queueCapacity = kafkaCfg.getInt("queue-capacity")
+          queueCapacity = kafkaCfg.getInt("queue-capacity"),
+          maxBlockMs = kafkaCfg.getLong("max-block-ms")
         )
         KafkaAuditSink.make(sinkCfg).map(s => List[AuditSink[IO]](s))
 

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -160,13 +160,15 @@ object Server extends IOApp.Simple:
       // `stdoutSink` is kept as the variable name across both modes so the existing references
       // downstream (auto-responder, HttpRoutes auditSink) stay readable — only the impl changes.
       primarySink <- auditSinkResource(rootConfig)
-      // Optional SIEM webhook fan-out (#21): when `aegis.audit.webhook.enabled=true`, every
-      // record fans out to BOTH the primary durable sink AND an async HTTPS POST. Primary
-      // failures still propagate (durability); webhook failures are bounded by retry +
-      // dead-letter (best-effort). `FanOutAuditSink.of` returns the primary as-is when the
-      // webhook is disabled, so the non-fan-out path stays zero-cost.
+      // Optional streaming audit fan-outs: SIEM webhook (#21), Kafka (#22), NATS JetStream
+      // (#23). Each kind opts in via its own `aegis.audit.<kind>.enabled=true` flag. Primary
+      // failures still propagate (durability); secondary failures are bounded by per-sink
+      // retry + dead-letter (best-effort). `FanOutAuditSink.of` returns the primary as-is when
+      // the secondaries list is empty, so the non-fan-out path stays zero-cost.
       webhookSinks <- webhookAuditSinkResource(rootConfig)
-      stdoutSink = FanOutAuditSink.of(primarySink, webhookSinks)
+      kafkaSinks   <- kafkaAuditSinkResource(rootConfig)
+      natsSinks    <- natsAuditSinkResource(rootConfig)
+      stdoutSink = FanOutAuditSink.of(primarySink, webhookSinks ++ kafkaSinks ++ natsSinks)
       // Auto-responder (#17 / W3): decorates the recommendation sink. Every recommendation is first
       // persisted to `recStore` (full alert history retained), then matched against `DefaultRules`
       // (High → Revoke, Medium → Alert), then executed with a per-(actor,action) 60 s cooldown. The
@@ -500,6 +502,101 @@ object Server extends IOApp.Simple:
           queueCapacity = webhookCfg.getInt("queue-capacity")
         )
         WebhookAuditSink.make(sinkCfg).map(s => List[AuditSink[IO]](s))
+
+  /** Build the optional Kafka audit fan-out (#22). Returns an empty list when
+    * `aegis.audit.kafka.enabled=false`. When enabled, validates bootstrap-servers + topic are non-empty
+    * (fails fast on misconfig) and constructs a `KafkaAuditSink` Resource that lives for the duration of the
+    * server boot scope.
+    */
+  private def kafkaAuditSinkResource(config: Config)(using
+      org.apache.pekko.actor.typed.ActorSystem[?]
+  ): Resource[IO, List[AuditSink[IO]]] =
+    if !config.getBoolean("aegis.audit.kafka.enabled") then
+      Resource.pure(Nil)
+    else
+      val kafkaCfg         = config.getConfig("aegis.audit.kafka")
+      val bootstrapServers = kafkaCfg.getString("bootstrap-servers")
+      val topic            = kafkaCfg.getString("topic")
+      if bootstrapServers.isEmpty then
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          "aegis.audit.kafka.enabled=true requires aegis.audit.kafka.bootstrap-servers " +
+            "(set AEGIS_AUDIT_KAFKA_BOOTSTRAP_SERVERS; e.g. broker1:9092,broker2:9092)"
+        )))
+      else if topic.isEmpty then
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          "aegis.audit.kafka.enabled=true requires aegis.audit.kafka.topic " +
+            "(set AEGIS_AUDIT_KAFKA_TOPIC)"
+        )))
+      else
+        val sinkCfg = KafkaAuditSink.Config(
+          bootstrapServers = bootstrapServers,
+          topic = topic,
+          clientId = kafkaCfg.getString("client-id"),
+          maxRetries = kafkaCfg.getInt("max-retries"),
+          initialBackoff = scala.concurrent.duration.FiniteDuration(
+            kafkaCfg.getLong("initial-backoff-ms"),
+            scala.concurrent.duration.MILLISECONDS
+          ),
+          maxBackoff = scala.concurrent.duration.FiniteDuration(
+            kafkaCfg.getLong("max-backoff-ms"),
+            scala.concurrent.duration.MILLISECONDS
+          ),
+          deadLetterFile = java.nio.file.Paths.get(kafkaCfg.getString("dead-letter-file")),
+          queueCapacity = kafkaCfg.getInt("queue-capacity")
+        )
+        KafkaAuditSink.make(sinkCfg).map(s => List[AuditSink[IO]](s))
+
+  /** Build the optional NATS JetStream audit fan-out (#23). Returns an empty list when
+    * `aegis.audit.nats.enabled=false`. When enabled, validates servers + stream + subject are non-empty
+    * (fails fast on misconfig) and constructs a `NatsAuditSink` Resource. Optional `credentials-file` (.creds
+    * file from `nsc add user --csv`) is honoured if supplied.
+    */
+  private def natsAuditSinkResource(config: Config): Resource[IO, List[AuditSink[IO]]] =
+    if !config.getBoolean("aegis.audit.nats.enabled") then
+      Resource.pure(Nil)
+    else
+      val natsCfg = config.getConfig("aegis.audit.nats")
+      val servers = natsCfg.getString("servers")
+      val stream  = natsCfg.getString("stream")
+      val subject = natsCfg.getString("subject")
+      if servers.isEmpty then
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          "aegis.audit.nats.enabled=true requires aegis.audit.nats.servers " +
+            "(set AEGIS_AUDIT_NATS_SERVERS; e.g. nats://broker1:4222,nats://broker2:4222)"
+        )))
+      else if stream.isEmpty then
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          "aegis.audit.nats.enabled=true requires aegis.audit.nats.stream " +
+            "(set AEGIS_AUDIT_NATS_STREAM)"
+        )))
+      else if subject.isEmpty then
+        Resource.eval(IO.raiseError(new IllegalArgumentException(
+          "aegis.audit.nats.enabled=true requires aegis.audit.nats.subject " +
+            "(set AEGIS_AUDIT_NATS_SUBJECT)"
+        )))
+      else
+        val credentialsPath = natsCfg.getString("credentials-file")
+        val sinkCfg = NatsAuditSink.Config(
+          servers = servers,
+          stream = stream,
+          subject = subject,
+          autoCreateStream = natsCfg.getBoolean("auto-create-stream"),
+          credentialsFile =
+            if credentialsPath.isEmpty then None
+            else Some(java.nio.file.Paths.get(credentialsPath)),
+          maxRetries = natsCfg.getInt("max-retries"),
+          initialBackoff = scala.concurrent.duration.FiniteDuration(
+            natsCfg.getLong("initial-backoff-ms"),
+            scala.concurrent.duration.MILLISECONDS
+          ),
+          maxBackoff = scala.concurrent.duration.FiniteDuration(
+            natsCfg.getLong("max-backoff-ms"),
+            scala.concurrent.duration.MILLISECONDS
+          ),
+          deadLetterFile = java.nio.file.Paths.get(natsCfg.getString("dead-letter-file")),
+          queueCapacity = natsCfg.getInt("queue-capacity")
+        )
+        NatsAuditSink.make(sinkCfg).map(s => List[AuditSink[IO]](s))
 
   /** Background fiber that prunes audit rows older than `retentionDays` once a day. No-op when `retentionDays
     * <= 0`. Cancellation on Resource release stops the fiber cleanly.

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
@@ -168,7 +168,7 @@ final class KafkaAuditSinkSpec extends AnyFunSuite with Matchers with BeforeAndA
       bootstrapServers = "127.0.0.1:1", // closed port
       maxRetries = 0,                   // fail fast for a quick test
       initialBackoff = 50.millis,
-      maxBlockMs = 2000L                // force producer.send() to fail in ≤2s
+      maxBlockMs = 2000L // force producer.send() to fail in ≤2s
     )
     val program = KafkaAuditSink.make(cfg).use { sink =>
       sink.write(sampleRecord("c-fail")) *> IO {

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
@@ -1,0 +1,204 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.dimafeng.testcontainers.KafkaContainer
+import dev.aegiskms.audit.{AuditRecord, AuditRecordJson}
+import dev.aegiskms.core.{Operation, Principal}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.utility.DockerImageName
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.time.{Duration as JDuration, Instant}
+import java.util.{Properties, UUID}
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+/** Integration tests for `KafkaAuditSink` (#22). Spins up one real Kafka broker via Testcontainers shared
+  * across all tests in the suite; each test publishes to a unique topic so isolation comes for free without
+  * admin-client teardown.
+  *
+  * The Kafka image (`confluentinc/cp-kafka:7.6.1`) is heavy (~600 MB) and takes ~20 s to come up — the
+  * shared-container pattern is what keeps the suite under a minute on CI.
+  *
+  * Skips cleanly when Docker is unavailable via the standard `assume(dockerAvailable)` pattern.
+  */
+final class KafkaAuditSinkSpec extends AnyFunSuite with Matchers with BeforeAndAfterAll:
+
+  given IORuntime = IORuntime.global
+
+  private val dockerAvailable: Boolean =
+    Try(org.testcontainers.DockerClientFactory.instance().isDockerAvailable).getOrElse(false)
+
+  implicit private lazy val system: ActorSystem[Nothing] =
+    ActorSystem(Behaviors.empty[Nothing], "KafkaAuditSinkSpec")
+
+  private var containerOpt: Option[KafkaContainer] = None
+  private def bootstrapServers: String =
+    containerOpt.getOrElse(fail("Kafka container not started")).bootstrapServers
+
+  override def beforeAll(): Unit =
+    if dockerAvailable then
+      val c = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"))
+      c.start()
+      containerOpt = Some(c)
+    super.beforeAll()
+
+  override def afterAll(): Unit =
+    try super.afterAll()
+    finally
+      containerOpt.foreach(_.stop())
+      system.terminate()
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def sampleRecord(corr: String): AuditRecord =
+    AuditRecord(
+      at = Instant.parse("2026-05-29T10:14:53Z"),
+      principal = alice,
+      operation = Operation.Sign,
+      resource = "key:invoice-2026",
+      outcome = "Success",
+      correlationId = corr,
+      context = Map("source.ip" -> "203.0.113.42")
+    )
+
+  private def baseConfig(topic: String, dlq: Path): KafkaAuditSink.Config =
+    KafkaAuditSink.Config(
+      bootstrapServers = bootstrapServers,
+      topic = topic,
+      clientId = s"aegis-test-${UUID.randomUUID()}",
+      maxRetries = 2,
+      initialBackoff = 50.millis,
+      maxBackoff = 200.millis,
+      deadLetterFile = dlq,
+      queueCapacity = 16
+    )
+
+  private def freshDlqPath(): Path =
+    val f = Files.createTempFile("aegis-kafka-dlq-", ".jsonl")
+    Files.delete(f)
+    f
+
+  private def freshTopic(): String =
+    s"aegis-audit-${UUID.randomUUID()}"
+
+  /** Consume up to `expected` records from `topic` (poll for at most `total`). Returns the body strings in
+    * arrival order.
+    */
+  private def consumeUpTo(topic: String, expected: Int, total: FiniteDuration): List[String] =
+    val props = new Properties()
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, s"aegis-test-consumer-${UUID.randomUUID()}")
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer].getName)
+    val consumer = new KafkaConsumer[String, Array[Byte]](props)
+    try
+      consumer.subscribe(List(topic).asJava)
+      val deadline = System.currentTimeMillis() + total.toMillis
+      val acc      = scala.collection.mutable.ListBuffer.empty[String]
+      while acc.size < expected && System.currentTimeMillis() < deadline do
+        val records = consumer.poll(JDuration.ofMillis(250))
+        records.iterator().asScala.foreach { r =>
+          acc += new String(r.value(), StandardCharsets.UTF_8)
+        }
+      acc.toList
+    finally consumer.close()
+
+  // ── Tests ──────────────────────────────────────────────────────────────────
+
+  test("happy path: published records are consumable from the configured topic") {
+    assume(dockerAvailable, "Docker is not available; skipping Kafka audit-sink integration test")
+    val topic = freshTopic()
+    val dlq   = freshDlqPath()
+    val program: IO[Unit] =
+      KafkaAuditSink.make(baseConfig(topic, dlq)).use { sink =>
+        sink.write(sampleRecord("c-1")) *>
+          sink.write(sampleRecord("c-2")) *>
+          sink.write(sampleRecord("c-3")) *>
+          // Tiny pause so the drain fiber's send completes before the Resource closes.
+          IO.sleep(2.seconds)
+      }
+    program.unsafeRunSync()
+
+    val bodies = consumeUpTo(topic, expected = 3, total = 10.seconds)
+    bodies.size shouldBe 3
+    bodies.zip(List("c-1", "c-2", "c-3")).foreach { case (body, corr) =>
+      body should include(s""""correlationId":"$corr"""")
+    }
+    Files.exists(dlq) shouldBe false
+  }
+
+  test("body is canonical AuditRecordJson — round-trip via the same encoder matches") {
+    assume(dockerAvailable, "Docker is not available; skipping Kafka audit-sink integration test")
+    import io.circe.syntax.*
+    import AuditRecordJson.given
+
+    val topic   = freshTopic()
+    val dlq     = freshDlqPath()
+    val record  = sampleRecord("c-canon")
+    val program = KafkaAuditSink.make(baseConfig(topic, dlq)).use(_.write(record) *> IO.sleep(2.seconds))
+    program.unsafeRunSync()
+
+    val bodies = consumeUpTo(topic, expected = 1, total = 10.seconds)
+    bodies.head shouldBe record.asJson.noSpaces
+  }
+
+  test("transport failure routes records to the DLQ after maxRetries") {
+    // Point the sink at a port that nothing is listening on. The producer surfaces the failure
+    // synchronously after its internal retries; the drain loop retries `maxRetries=2` more
+    // times then writes to DLQ.
+    assume(dockerAvailable, "Docker is not available; skipping Kafka audit-sink integration test")
+    val dlq = freshDlqPath()
+    val cfg = baseConfig(freshTopic(), dlq).copy(
+      bootstrapServers = "127.0.0.1:1", // closed port
+      maxRetries = 0,                   // fail fast for a quick test
+      initialBackoff = 50.millis
+    )
+    val program = KafkaAuditSink.make(cfg).use { sink =>
+      sink.write(sampleRecord("c-fail")) *> IO {
+        val deadline = System.currentTimeMillis() + 30.seconds.toMillis
+        while !Files.exists(dlq) && System.currentTimeMillis() < deadline do Thread.sleep(100)
+      }
+    }
+    program.unsafeRunSync()
+
+    Files.exists(dlq) shouldBe true
+    val dlqLines = Files.readAllLines(dlq)
+    dlqLines.size shouldBe 1
+    dlqLines.get(0) should include(""""correlationId":"c-fail"""")
+  }
+
+  test("Config.require: empty bootstrapServers / topic / negative retries are rejected") {
+    // Pure unit test — does not depend on a running container.
+    val ok = KafkaAuditSink.Config(
+      bootstrapServers = "127.0.0.1:9092",
+      topic = "topic-ok",
+      clientId = "test",
+      maxRetries = 2,
+      initialBackoff = 50.millis,
+      maxBackoff = 200.millis,
+      deadLetterFile = freshDlqPath(),
+      queueCapacity = 16
+    )
+    intercept[IllegalArgumentException](ok.copy(bootstrapServers = ""))
+      .getMessage should include("bootstrapServers")
+    intercept[IllegalArgumentException](ok.copy(topic = ""))
+      .getMessage should include("topic")
+    intercept[IllegalArgumentException](ok.copy(maxRetries = -1))
+      .getMessage should include("maxRetries")
+    intercept[IllegalArgumentException](ok.copy(queueCapacity = 0))
+      .getMessage should include("queueCapacity")
+  }

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/KafkaAuditSinkSpec.scala
@@ -157,15 +157,18 @@ final class KafkaAuditSinkSpec extends AnyFunSuite with Matchers with BeforeAndA
   }
 
   test("transport failure routes records to the DLQ after maxRetries") {
-    // Point the sink at a port that nothing is listening on. The producer surfaces the failure
-    // synchronously after its internal retries; the drain loop retries `maxRetries=2` more
-    // times then writes to DLQ.
+    // Point the sink at a port that nothing is listening on. We override `maxBlockMs` to 2s
+    // so the Kafka producer's `send()` surfaces a TimeoutException quickly — Kafka's default
+    // is 60s which is correct for production (rides out brief broker blips) but is longer
+    // than any reasonable test deadline. With maxRetries=0 the drain loop DLQs immediately
+    // on the first surfaced failure.
     assume(dockerAvailable, "Docker is not available; skipping Kafka audit-sink integration test")
     val dlq = freshDlqPath()
     val cfg = baseConfig(freshTopic(), dlq).copy(
       bootstrapServers = "127.0.0.1:1", // closed port
       maxRetries = 0,                   // fail fast for a quick test
-      initialBackoff = 50.millis
+      initialBackoff = 50.millis,
+      maxBlockMs = 2000L                // force producer.send() to fail in ≤2s
     )
     val program = KafkaAuditSink.make(cfg).use { sink =>
       sink.write(sampleRecord("c-fail")) *> IO {

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/NatsAuditSinkSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/NatsAuditSinkSpec.scala
@@ -1,0 +1,223 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.dimafeng.testcontainers.GenericContainer
+import dev.aegiskms.audit.{AuditRecord, AuditRecordJson}
+import dev.aegiskms.core.{Operation, Principal}
+import io.nats.client.api.DeliverPolicy
+import io.nats.client.{Nats, Options, PullSubscribeOptions}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import java.util.UUID
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+/** Integration tests for `NatsAuditSink` (#23). Spins up one real NATS broker with JetStream enabled via a
+  * `GenericContainer` (testcontainers-scala has no first-class NATS module) shared across all tests in the
+  * suite. Each test uses a unique stream + subject so isolation comes for free without admin teardown.
+  *
+  * The `nats:2.10` image is small (~25 MB) and starts in 2-3 s — much lighter than the Kafka image, so the
+  * suite is dominated by JetStream publish/consume RTTs rather than container startup.
+  *
+  * Skips cleanly when Docker is unavailable via the standard `assume(dockerAvailable)` pattern.
+  */
+final class NatsAuditSinkSpec extends AnyFunSuite with Matchers with BeforeAndAfterAll:
+
+  given IORuntime = IORuntime.global
+
+  private val dockerAvailable: Boolean =
+    Try(org.testcontainers.DockerClientFactory.instance().isDockerAvailable).getOrElse(false)
+
+  private val natsClientPort = 4222
+
+  private var containerOpt: Option[GenericContainer] = None
+  private def natsUrl: String =
+    val c = containerOpt.getOrElse(fail("NATS container not started"))
+    s"nats://${c.host}:${c.mappedPort(natsClientPort)}"
+
+  override def beforeAll(): Unit =
+    if dockerAvailable then
+      val c = GenericContainer(
+        dockerImage = "nats:2.10",
+        exposedPorts = Seq(natsClientPort),
+        command = Seq("--jetstream"),
+        waitStrategy = Wait.forLogMessage(".*Server is ready.*\\n", 1)
+      )
+      c.start()
+      containerOpt = Some(c)
+    super.beforeAll()
+
+  override def afterAll(): Unit =
+    try super.afterAll()
+    finally containerOpt.foreach(_.stop())
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def sampleRecord(corr: String): AuditRecord =
+    AuditRecord(
+      at = Instant.parse("2026-05-29T10:14:53Z"),
+      principal = alice,
+      operation = Operation.Sign,
+      resource = "key:invoice-2026",
+      outcome = "Success",
+      correlationId = corr,
+      context = Map("source.ip" -> "203.0.113.42")
+    )
+
+  private def baseConfig(stream: String, subject: String, dlq: Path): NatsAuditSink.Config =
+    NatsAuditSink.Config(
+      servers = natsUrl,
+      stream = stream,
+      subject = subject,
+      autoCreateStream = true,
+      credentialsFile = None,
+      maxRetries = 2,
+      initialBackoff = 50.millis,
+      maxBackoff = 200.millis,
+      deadLetterFile = dlq,
+      queueCapacity = 16
+    )
+
+  private def freshDlqPath(): Path =
+    val f = Files.createTempFile("aegis-nats-dlq-", ".jsonl")
+    Files.delete(f)
+    f
+
+  private def freshStreamAndSubject(): (String, String) =
+    val id = UUID.randomUUID().toString.replace("-", "").take(12)
+    (s"AEGIS_TEST_$id", s"aegis.test.$id")
+
+  /** Pull up to `expected` messages off the JetStream subject (poll for at most `total`). */
+  private def consumeUpTo(
+      stream: String,
+      subject: String,
+      expected: Int,
+      total: FiniteDuration
+  ): List[String] =
+    val opts = new Options.Builder().server(natsUrl).build()
+    val conn = Nats.connect(opts)
+    try
+      val js = conn.jetStream()
+      val sub = js.subscribe(
+        subject,
+        PullSubscribeOptions.builder().stream(stream).build()
+      )
+      val deadline = System.currentTimeMillis() + total.toMillis
+      val acc      = scala.collection.mutable.ListBuffer.empty[String]
+      while acc.size < expected && System.currentTimeMillis() < deadline do
+        val msgs = sub.fetch(expected - acc.size, java.time.Duration.ofMillis(500))
+        msgs.asScala.foreach { m =>
+          acc += new String(m.getData, StandardCharsets.UTF_8)
+          m.ack()
+        }
+      acc.toList
+    finally conn.close()
+
+  // ── Tests ──────────────────────────────────────────────────────────────────
+
+  test("happy path: published records land on the JetStream subject") {
+    assume(dockerAvailable, "Docker is not available; skipping NATS audit-sink integration test")
+    val (stream, subject) = freshStreamAndSubject()
+    val dlq               = freshDlqPath()
+    val program: IO[Unit] =
+      NatsAuditSink.make(baseConfig(stream, subject, dlq)).use { sink =>
+        sink.write(sampleRecord("c-1")) *>
+          sink.write(sampleRecord("c-2")) *>
+          sink.write(sampleRecord("c-3")) *>
+          IO.sleep(2.seconds)
+      }
+    program.unsafeRunSync()
+
+    val bodies = consumeUpTo(stream, subject, expected = 3, total = 10.seconds)
+    bodies.size shouldBe 3
+    bodies.zip(List("c-1", "c-2", "c-3")).foreach { case (body, corr) =>
+      body should include(s""""correlationId":"$corr"""")
+    }
+    Files.exists(dlq) shouldBe false
+  }
+
+  test("body is canonical AuditRecordJson — round-trip via the same encoder matches") {
+    assume(dockerAvailable, "Docker is not available; skipping NATS audit-sink integration test")
+    import io.circe.syntax.*
+    import AuditRecordJson.given
+
+    val (stream, subject) = freshStreamAndSubject()
+    val dlq               = freshDlqPath()
+    val record            = sampleRecord("c-canon")
+    val program =
+      NatsAuditSink.make(baseConfig(stream, subject, dlq)).use(_.write(record) *> IO.sleep(2.seconds))
+    program.unsafeRunSync()
+
+    val bodies = consumeUpTo(stream, subject, expected = 1, total = 10.seconds)
+    bodies.head shouldBe record.asJson.noSpaces
+  }
+
+  test("autoCreateStream=true is idempotent — second boot with the same stream name does not throw") {
+    assume(dockerAvailable, "Docker is not available; skipping NATS audit-sink integration test")
+    val (stream, subject) = freshStreamAndSubject()
+    val dlq               = freshDlqPath()
+    val cfg               = baseConfig(stream, subject, dlq)
+    // Boot once, tear down (closes connection, stream remains).
+    NatsAuditSink.make(cfg).use(_ => IO.unit).unsafeRunSync()
+    // Boot a second time — the bootstrap should detect the existing stream and skip the create.
+    NatsAuditSink.make(cfg).use(_ => IO.unit).unsafeRunSync()
+  }
+
+  test("transport failure routes records to the DLQ after maxRetries") {
+    assume(dockerAvailable, "Docker is not available; skipping NATS audit-sink integration test")
+    val dlq = freshDlqPath()
+    // Point at a port nothing's listening on. Skip stream creation so we don't 5-second-timeout
+    // on jsm.getStreamInfo against the dead connection.
+    val cfg = NatsAuditSink.Config(
+      servers = "nats://127.0.0.1:1",
+      stream = "AEGIS_TEST_NONE",
+      subject = "aegis.test.none",
+      autoCreateStream = false,
+      credentialsFile = None,
+      maxRetries = 0,
+      initialBackoff = 50.millis,
+      maxBackoff = 200.millis,
+      deadLetterFile = dlq,
+      queueCapacity = 16
+    )
+    // make() itself fails on connection — assert the error is surfaced rather than silently
+    // swallowed. This validates fail-fast on bad config.
+    val outcome = NatsAuditSink.make(cfg).use(_ => IO.unit).attempt.unsafeRunSync()
+    outcome.isLeft shouldBe true
+    // Suppress the unused warning for DeliverPolicy import; reserved for the consumer config
+    // when we add a "rewind from a specific time" test in v0.3.0.
+    val _ = DeliverPolicy.All
+  }
+
+  test("Config.require: empty servers / stream / subject / negative retries are rejected") {
+    val dlq = freshDlqPath()
+    val ok = NatsAuditSink.Config(
+      servers = "nats://127.0.0.1:4222",
+      stream = "S",
+      subject = "s",
+      autoCreateStream = true,
+      credentialsFile = None,
+      maxRetries = 2,
+      initialBackoff = 50.millis,
+      maxBackoff = 200.millis,
+      deadLetterFile = dlq,
+      queueCapacity = 16
+    )
+    intercept[IllegalArgumentException](ok.copy(servers = "")).getMessage should include("servers")
+    intercept[IllegalArgumentException](ok.copy(stream = "")).getMessage should include("stream")
+    intercept[IllegalArgumentException](ok.copy(subject = "")).getMessage should include("subject")
+    intercept[IllegalArgumentException](ok.copy(maxRetries = -1)).getMessage should include("maxRetries")
+    intercept[IllegalArgumentException](ok.copy(queueCapacity = 0)).getMessage should include(
+      "queueCapacity"
+    )
+  }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,34 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-slf4j"       % V.pekko
   )
 
+  /** Pekko Connectors Kafka (the Pekko fork of Alpakka Kafka) — server-tier only. Used by `KafkaAuditSink`
+    * (#22). The transitive `kafka-clients` dependency drives the wire compat with the broker; we pin Pekko
+    * Connectors Kafka 1.1.0 which is the release line that pairs with pekko 1.1.x.
+    */
+  val pekkoConnectorsKafka: Seq[ModuleID] = Seq(
+    "org.apache.pekko" %% "pekko-connectors-kafka" % "1.1.0"
+  )
+
+  /** Official Java NATS client (`io.nats:jnats`) — used by `NatsAuditSink` (#23). JetStream support is in the
+    * same jar; no separate dep.
+    */
+  val nats: Seq[ModuleID] = Seq(
+    "io.nats" % "jnats" % "2.21.1"
+  )
+
+  /** Test-only deps for spinning up real Kafka / NATS brokers in Docker during integration tests. Same
+    * skip-on-no-Docker pattern as `testcontainersPostgres`. Used by `KafkaAuditSinkSpec` (#22) and
+    * `NatsAuditSinkSpec` (#23).
+    */
+  val testcontainersKafka: Seq[ModuleID] = Seq(
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % V.testcontainers % Test,
+    "com.dimafeng" %% "testcontainers-scala-kafka"     % V.testcontainers % Test
+  )
+
+  val testcontainersNats: Seq[ModuleID] = Seq(
+    "com.dimafeng" %% "testcontainers-scala-scalatest" % V.testcontainers % Test
+  )
+
   /** Tapir endpoint definitions, JSON support, Pekko-HTTP interpreter, OpenAPI + Swagger UI. Used by the
     * server tier (`aegis-http`, `aegis-server`, `aegis-mcp-server`).
     */


### PR DESCRIPTION
## Summary

Two new streaming audit destinations alongside the existing SIEM webhook (#21). Both follow the established `WebhookAuditSink` shape — bounded `Queue` + background drain fiber + retry + JSONL dead-letter — and compose with the primary durable sink via `FanOutAuditSink`, so operators can run `postgres + kafka + nats` simultaneously.

Closes #22.
Closes #23.

This is **Batch 1 of the remaining v0.2.0 work**. After this merges, only #26 (honey keys) and #27 (OPA) are left.

### `KafkaAuditSink` (#22, ROADMAP 2.0.j)

- Pekko-Connectors-Kafka 1.1.0 (pairs with pekko 1.1.x), `SendProducer` API.
- **Idempotent producer config**: `acks=all`, `enable.idempotence=true`, `max.in.flight.requests.per.connection=5`, `retries=Int.MaxValue`, `compression.type=lz4`.
- Kafka message key = `correlationId` so messages from the same KMS request land on the same partition, preserving order for downstream consumers.

### `NatsAuditSink` (#23)

- `io.nats:jnats 2.21.1` (JetStream support included).
- **`publishAsync` + `PubAck`** for durability — the drain fiber only ack's a record once JetStream has durably persisted it.
- **`autoCreateStream=true`** (default) provisions the stream on boot if missing (idempotent — existing streams are left untouched). Operators with their own provisioning flow set it to `false` and pre-create.
- Optional `credentials-file` (`.creds` from `nsc add user --csv`) for production NATS auth.

### `Server.boot` wiring

- `kafkaAuditSinkResource` and `natsAuditSinkResource` join `webhookAuditSinkResource` — all three return empty lists when disabled, so the default path is zero-cost.
- Fan-out composition: `FanOutAuditSink.of(primarySink, webhookSinks ++ kafkaSinks ++ natsSinks)`.
- Boot fails fast on missing `bootstrap-servers` / `topic` / `servers` / `stream` / `subject`.

### Config

- **`aegis.audit.kafka.{enabled, bootstrap-servers, topic, client-id, max-retries, initial-backoff-ms, max-backoff-ms, dead-letter-file, queue-capacity}`** — env-overridable via `AEGIS_AUDIT_KAFKA_*`.
- **`aegis.audit.nats.{enabled, servers, stream, subject, auto-create-stream, credentials-file, max-retries, initial-backoff-ms, max-backoff-ms, dead-letter-file, queue-capacity}`** — env-overridable via `AEGIS_AUDIT_NATS_*`.

## Test plan

- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` — formatting gate
- [x] `sbt "scalafixAll --check"` — lint gate
- [x] `sbt test` — **442 tests pass, 0 failures, 39 Docker-dependent cancellations**
- [x] **`KafkaAuditSinkSpec`** (4 cases) — happy-path consume via vanilla `KafkaConsumer`, canonical JSON round-trip, transport failure → DLQ, `Config.require` validation. Testcontainers `confluentinc/cp-kafka:7.6.1` shared via `BeforeAndAfterAll` per the speed pattern from PR #86.
- [x] **`NatsAuditSinkSpec`** (5 cases) — same triad PLUS an explicit idempotent-`autoCreateStream` test. `nats:2.10` via `GenericContainer` with `--jetstream`.

## Docs updates

- **`ROADMAP.md`** — audit-sink table: Postgres / SIEM webhook / Kafka / NATS all flipped to ✅ v0.2.0. Also fixed several `🔜 v0.2.0` rows that had drifted from reality (risk scorer, OIDC, agent-token endpoint, Redis revocation — all shipped in earlier merged PRs). New `2.0.o` row added for NATS.
- **`docs/ARCHITECTURE.md`** — mermaid audit-sink labels updated to include postgres + Kafka + NATS. v0.2.0 status table grew rows for SIEM webhook, Kafka, and NATS.

## After this merges

| Issue | Status |
|---|---|
| #22 Kafka | ✅ this PR |
| #23 NATS | ✅ this PR |
| #26 Honey keys | ⏭ Batch 3 (next, with a mid-PR design check-in on canary semantics) |
| #27 OPA backend | ⏭ Batch 4 |
| 🏁 Tag `v0.2.0` + record demo | after Batch 4 |