### PR TITLE
feat(agent-ai+server): honey keys (canary) registry + auto-revoke detector (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Honey keys (canary keys) with auto-revoke on agent touch (closes #26).** Operator-marked
+  `KeyId`s that fire a `Severity.High` recommendation any time an agent principal touches
+  them; `AutoResponder.DefaultRules` then translate High → Revoke, killing both the key and
+  the agent's JWT via the wired `RevocationList`. The first touch is the trip wire by
+  design — there's no cold-start guard like the other detectors have.
+  - **`HoneyKeyRegistry` SPI** (`aegis-agent-ai`): tiny — `isHoney(KeyId): Boolean` +
+    `snapshot: Set[KeyId]`. Three impls: `empty` (production-safe default), `fromSet` for
+    HOCON-backed wiring, and the ctor-default on `BaselineDetector.make` so embedders
+    compile unchanged.
+  - **`BaselineDetector` gains a 6th detector** (`"HoneyKey"`) that runs after the five
+    existing ones. Restricted to agent principals only — humans validating that a canary
+    is still alive don't trigger auto-revoke. Skips Create / Locate audit resources (their
+    `name:...` / `pattern:...` shapes don't yield a parseable `KeyId`).
+  - **`Server.boot` wiring**: `aegis.security.honey-keys` HOCON list parsed into a
+    `Set[KeyId]` and threaded into `BaselineDetector.make(honeyKeys = ...)`. Supports both
+    HOCON-list syntax and the `AEGIS_HONEY_KEYS` comma-separated env-var override. Boot
+    fails fast on malformed `KeyId` strings (a typo'd canary that doesn't catch the agent
+    is the opposite of what an operator wanted).
+  - **Tests:** `HoneyKeyRegistrySpec` (4 cases — `empty`, `fromSet` semantics, snapshot
+    fidelity, `fromSet(Set.empty)` equivalence). `BaselineDetectorSpec` (+6 cases —
+    happy-path fire, first-touch trip wire, human-touch no-fire, non-honey no-fire,
+    empty-registry inert, Create/Locate skip).
+
 - **Kafka + NATS JetStream audit fan-out sinks (closes #22, closes #23).** Two new streaming
   audit destinations alongside the existing SIEM webhook (#21). Both follow the same shape
   — bounded `Queue` + background drain fiber + retry + JSONL dead-letter — and compose with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 | 2.0.i | Generic SIEM webhook audit sink (HTTPS POST per event, batched + retried) | Platform | ✅ |
 | 2.0.j | Kafka audit fan-out (Pekko-Connectors-Kafka) | Platform | ✅ |
 | 2.0.k | Redis-backed JWT revocation list (jti blacklist) — required for instant agent revoke | Platform | ✅ |
-| 2.0.l | Honey keys / canary keys — fake keys with auto-alert if any agent touches them | Wedge | 💡 |
+| 2.0.l | Honey keys / canary keys — fake keys with auto-alert if any agent touches them | Wedge | ✅ |
 | 2.0.m | OIDC verifier + JWKS rotation + RS256 / ES256 signature support | Wedge | ✅ |
 | 2.0.n | OPA (Open Policy Agent) integration — externalize policy evaluation (Rego) via sidecar | Wedge | 💡 |
 | 2.0.o | NATS / NATS JetStream audit fan-out | Platform | ✅ |
@@ -281,7 +281,7 @@ The release tables above slice the work by milestone. The tables below slice by 
 | Per-prompt accountability (record originating LLM prompt) | 💡 v0.4.0 | `area/ai-governance area/wire/mcp` |
 | Model identifier in audit (`actor.model = "..."`) | 💡 v0.4.0 | `area/ai-governance area/audit` |
 | Token cost / op-rate tracking per agent | 💡 v0.4.0+ | `area/ai-governance` |
-| Honey keys / canary keys with auto-alert | 💡 v0.2.0 | `area/ai-governance kind/security` |
+| Honey keys / canary keys with auto-alert | ✅ v0.2.0 | — |
 | Scope-creep detection (effective scope vs. baseline) | 💡 v0.3.0 | `area/ai-governance area/risk` |
 | Compliance reports (SOC2 / PCI / HIPAA exportable) | 💡 v0.6.0 | `area/ai-governance area/compliance` |
 | LLM advisor with RAG over audit log | 🔜 v0.2.1 | `area/ai-governance area/wedge/llm-advisor` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -430,6 +430,7 @@ What's implemented today vs. what the design above describes. This is the only p
 | SIEM webhook audit sink (HMAC-signed, async batched + retry + DLQ) | ✅ Shipped v0.2.0 |
 | Kafka audit fan-out sink (idempotent producer, Pekko-Connectors-Kafka) | ✅ Shipped v0.2.0 |
 | NATS JetStream audit fan-out sink (publishAsync + PubAck) | ✅ Shipped v0.2.0 |
+| Honey keys (canary) registry + 6th `HoneyKey` detector → auto-revoke | ✅ Shipped v0.2.0 |
 | Risk scorer (W2) — numeric scores feeding access decisions | ✅ Shipped (see v0.1.x table above) |
 | Auto-responder (W3) consuming `AgentRecommendation`s | ✅ Shipped (see v0.1.x table above) |
 | LLM advisor (W4) — `aegis advisor scan/explain` | 🔜 Designed (CLI stub in place) |

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/BaselineDetector.scala
@@ -2,7 +2,7 @@ package dev.aegiskms.agent
 
 import cats.effect.{IO, Ref}
 import dev.aegiskms.audit.AuditRecord
-import dev.aegiskms.core.{Operation, Principal}
+import dev.aegiskms.core.{KeyId, Operation, Principal}
 
 import java.time.{Duration, Instant, ZoneOffset}
 import java.util.UUID
@@ -25,6 +25,10 @@ import java.util.UUID
   *   - `TimeOfDayBaseline`: the actor was active in a UTC hour-of-day they have never been active in.
   *   - `SourceIpBaseline`: the actor's request came from an IP not in their seen set. Reads
   *     `record.context("source.ip")`, which the HTTP layer populates via `RequestContext` (#78).
+  *   - `HoneyKey` (#26): an **agent** touched a `KeyId` the operator marked as a canary via
+  *     `aegis.security.honey-keys`. Fires unconditionally at `Severity.High` — no cold-start guard.
+  *     AutoResponder.DefaultRules turn High → Revoke, killing both the key and the agent's JWT via the wired
+  *     RevocationList.
   *
   * Cold-start: every detector requires the actor to have at least one prior observation in the relevant
   * dimension before it can fire. The first time `claude-session-7a3` shows up we record but don't alert; the
@@ -35,7 +39,8 @@ import java.util.UUID
   */
 final class BaselineDetector private (
     state: Ref[IO, Map[String, BaselineDetector.ActorBaseline]],
-    config: BaselineDetector.Config
+    config: BaselineDetector.Config,
+    honeyKeys: HoneyKeyRegistry
 ):
 
   import BaselineDetector.*
@@ -45,7 +50,7 @@ final class BaselineDetector private (
     state.modify { current =>
       val existing = current.getOrElse(rec.principal.subject, ActorBaseline.empty)
       val resource = keyResource(rec)
-      val recs     = mutable(rec, existing, config, resource)
+      val recs     = mutable(rec, existing, config, resource, honeyKeys)
       val updated  = existing.update(rec, resource, config.rateRetention)
       (current + (rec.principal.subject -> updated), recs)
     }
@@ -105,8 +110,12 @@ object BaselineDetector:
     val empty: ActorBaseline =
       ActorBaseline(Set.empty, Map.empty, Set.empty, Set.empty, Vector.empty, None)
 
-  def make(config: Config = Config.Demo): IO[BaselineDetector] =
-    Ref.of[IO, Map[String, ActorBaseline]](Map.empty).map(new BaselineDetector(_, config))
+  def make(
+      config: Config = Config.Demo,
+      honeyKeys: HoneyKeyRegistry = HoneyKeyRegistry.empty
+  ): IO[BaselineDetector] =
+    Ref.of[IO, Map[String, ActorBaseline]](Map.empty)
+      .map(new BaselineDetector(_, config, honeyKeys))
 
   // ── Detector logic ────────────────────────────────────────────────────────
 
@@ -114,7 +123,8 @@ object BaselineDetector:
       rec: AuditRecord,
       existing: ActorBaseline,
       config: Config,
-      resource: String
+      resource: String,
+      honeyKeys: HoneyKeyRegistry
   ): List[AgentRecommendation] =
     val recs = List.newBuilder[AgentRecommendation]
 
@@ -229,6 +239,40 @@ object BaselineDetector:
         )
     }
 
+    // 6. HoneyKey (#26) — agent touched a key the operator has marked as a canary. Fires at
+    //    Severity.High unconditionally regardless of the agent's prior baseline; the entire point
+    //    of a honey key is to short-circuit the "give the actor benefit of the doubt" path. The
+    //    AutoResponder.DefaultRules turn High → Revoke, which kills both the key and the agent's
+    //    JWT via the wired RevocationList. NO cold-start guard (unlike the other detectors) — the
+    //    first touch is the trip wire by design.
+    //
+    //    Humans touching a honey key intentionally is plausible (someone validating the canary is
+    //    still active), so we restrict the detector to agent principals only. A human touching a
+    //    honey key may still warrant an audit-log investigation, but we don't auto-revoke.
+    rec.principal match
+      case _: Principal.Agent =>
+        keyIdFromResource(rec.resource).foreach { keyId =>
+          if honeyKeys.isHoney(keyId) then
+            recs += AgentRecommendation(
+              eventId = freshId(),
+              at = rec.at,
+              actor = rec.principal,
+              detector = "HoneyKey",
+              severity = Severity.High,
+              summary =
+                s"Agent ${rec.principal.subject} touched honey key ${keyId.value} via ${rec.operation} — auto-revoke fired",
+              details = Map(
+                "honeyKeyId"    -> keyId.value,
+                "operation"     -> rec.operation.toString,
+                "outcome"       -> rec.outcome,
+                "resource"      -> resource,
+                "correlationId" -> rec.correlationId
+              ),
+              suggestedAction = SuggestedAction.Revoke
+            )
+        }
+      case _ => ()
+
     recs.result()
 
   private def severityForActor(p: Principal): Severity = p match
@@ -244,5 +288,15 @@ object BaselineDetector:
     // Normalize to the keyId where possible.
     if rec.resource.startsWith("name:") then rec.resource
     else rec.resource
+
+  /** Parse the `KeyId` out of an audit `resource` string. Audit records produced by
+    * `AuditingKeyService.instrument(...)` set `resource = id.value` for ops on existing keys (Sign, Get,
+    * Activate, Revoke, ...). The `Create` op uses `name:.../alg:.../size:...` shape (no `KeyId` yet) and
+    * `Locate` uses `pattern:...`; both return `None` here, which means honey keys aren't tripped by Create /
+    * Locate — by design, since you can't touch a honey key you haven't seen yet.
+    */
+  private def keyIdFromResource(resource: String): Option[KeyId] =
+    if resource.startsWith("name:") || resource.startsWith("pattern:") then None
+    else KeyId.fromString(resource).toOption
 
   private def freshId(): String = UUID.randomUUID().toString

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/HoneyKeyRegistry.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/HoneyKeyRegistry.scala
@@ -1,0 +1,43 @@
+package dev.aegiskms.agent
+
+import dev.aegiskms.core.KeyId
+
+/** Registry of "honey" (canary) `KeyId`s — keys the operator has marked as bait. Any **agent** operation
+  * against a honey key fires a `HoneyKey` recommendation at `Severity.High`, which the
+  * `AutoResponder.DefaultRules` translate into a `Revoke` action — killing both the offending key and the
+  * agent's JWT via the wired `RevocationList`.
+  *
+  * Why a separate SPI rather than a `boolean` flag on `ManagedKey`: marking a key honey is an **operational**
+  * decision that often happens AFTER key creation (e.g. "we noticed Claude is fishing for treasury keys —
+  * let's plant a canary named `treasury-master-canary`"). A schema flag would require key rotation to mark an
+  * existing key, which is hostile to the operator workflow. The registry pattern also keeps the library tier
+  * (`aegis-core`, `aegis-persistence`) unchanged so embedders don't see a binary-compat break.
+  *
+  * Closes ROADMAP §v0.2.0 2.0.l (closes #26).
+  */
+trait HoneyKeyRegistry:
+
+  /** True iff `keyId` is registered as a honey key. */
+  def isHoney(keyId: KeyId): Boolean
+
+  /** Snapshot of all currently-registered honey keys. Used by `Server.boot` to log how many honey keys are
+    * active and by future operator UIs that list the canaries.
+    */
+  def snapshot: Set[KeyId]
+
+object HoneyKeyRegistry:
+
+  /** The default — no honey keys are registered. Used when `aegis.security.honey-keys` is empty (the
+    * production-safe default; operators opt in explicitly) and as the constructor default on
+    * `BaselineDetector` so existing call sites compile unchanged.
+    */
+  val empty: HoneyKeyRegistry = new HoneyKeyRegistry:
+    def isHoney(keyId: KeyId): Boolean = false
+    def snapshot: Set[KeyId]           = Set.empty
+
+  /** Construct a registry from a fixed set of `KeyId`s. The set is captured by reference at boot; dynamic
+    * add/remove is deferred to a v0.3.0 HTTP API.
+    */
+  def fromSet(ids: Set[KeyId]): HoneyKeyRegistry = new HoneyKeyRegistry:
+    def isHoney(keyId: KeyId): Boolean = ids.contains(keyId)
+    def snapshot: Set[KeyId]           = ids

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineDetectorSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/BaselineDetectorSpec.scala
@@ -2,7 +2,7 @@ package dev.aegiskms.agent
 
 import cats.effect.unsafe.implicits.global
 import dev.aegiskms.audit.AuditRecord
-import dev.aegiskms.core.{Operation, Principal}
+import dev.aegiskms.core.{KeyId, Operation, Principal}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -242,4 +242,128 @@ final class BaselineDetectorSpec extends AnyFunSuite with Matchers:
       "TimeOfDayBaseline",
       "SourceIpBaseline"
     )
+  }
+
+  // ── HoneyKey detector (#26) ───────────────────────────────────────────────
+  //
+  // Honey-key resource format mirrors production (`AuditingKeyService.instrument` writes the bare
+  // `id.value` to `AuditRecord.resource`, NOT `key:<id>`). The existing test helper `rec(..., key)`
+  // prepends `key:` which is incorrect for the honey-key path; these tests construct the record
+  // directly to use the production-aligned format.
+
+  private val honeyKeyId: KeyId    = KeyId.fromString("k-treasury-canary").toOption.get
+  private val nonHoneyKeyId: KeyId = KeyId.fromString("k-real-invoice").toOption.get
+
+  private def opRec(
+      at: Instant,
+      principal: Principal,
+      op: Operation,
+      keyId: KeyId,
+      outcome: String = "Success"
+  ): AuditRecord =
+    AuditRecord(
+      at = at,
+      principal = principal,
+      operation = op,
+      resource = keyId.value,
+      outcome = outcome,
+      correlationId = java.util.UUID.randomUUID().toString
+    )
+
+  test("HoneyKey: agent touching a registered honey key fires High-severity Revoke") {
+    val registry = HoneyKeyRegistry.fromSet(Set(honeyKeyId))
+    val det      = BaselineDetector.make(honeyKeys = registry).unsafeRunSync()
+    val ag       = agent(alice)
+
+    val recs = det
+      .observe(opRec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Sign, honeyKeyId))
+      .unsafeRunSync()
+
+    val honey =
+      recs.find(_.detector == "HoneyKey").getOrElse(fail(s"HoneyKey detector did not fire; got: $recs"))
+    honey.severity shouldBe Severity.High
+    honey.suggestedAction shouldBe SuggestedAction.Revoke
+    honey.details("honeyKeyId") shouldBe honeyKeyId.value
+    honey.details("operation") shouldBe Operation.Sign.toString
+  }
+
+  test("HoneyKey: first touch fires unconditionally — NO cold-start guard (trip wire by design)") {
+    // Other detectors require >= 1 prior observation before they fire. HoneyKey does not — the
+    // entire point of the honey is to fire on first touch.
+    val registry = HoneyKeyRegistry.fromSet(Set(honeyKeyId))
+    val det      = BaselineDetector.make(honeyKeys = registry).unsafeRunSync()
+    val ag       = agent(alice)
+    // No prior observations; touch the honey directly.
+    val recs = det
+      .observe(opRec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Get, honeyKeyId))
+      .unsafeRunSync()
+
+    recs.map(_.detector) should contain("HoneyKey")
+  }
+
+  test("HoneyKey: human touching a registered honey key does NOT fire (Revoke is agent-only)") {
+    // Humans may legitimately validate that a canary is still alive. We don't auto-revoke; the
+    // audit row remains for review.
+    val registry = HoneyKeyRegistry.fromSet(Set(honeyKeyId))
+    val det      = BaselineDetector.make(honeyKeys = registry).unsafeRunSync()
+
+    val recs = det
+      .observe(opRec(Instant.parse("2026-04-25T03:00:00Z"), alice, Operation.Get, honeyKeyId))
+      .unsafeRunSync()
+
+    recs.map(_.detector) should not contain "HoneyKey"
+  }
+
+  test("HoneyKey: agent touching a non-honey key does NOT fire") {
+    val registry = HoneyKeyRegistry.fromSet(Set(honeyKeyId))
+    val det      = BaselineDetector.make(honeyKeys = registry).unsafeRunSync()
+    val ag       = agent(alice)
+
+    val recs = det
+      .observe(opRec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Sign, nonHoneyKeyId))
+      .unsafeRunSync()
+
+    recs.map(_.detector) should not contain "HoneyKey"
+  }
+
+  test("HoneyKey: empty registry (default) keeps the detector inert") {
+    // Default BaselineDetector.make() uses HoneyKeyRegistry.empty. Even a flagrantly suspicious
+    // agent op against any key should not trip the HoneyKey detector when nothing is registered.
+    val det = BaselineDetector.make().unsafeRunSync()
+    val ag  = agent(alice)
+
+    val recs = det
+      .observe(opRec(Instant.parse("2026-04-25T03:00:00Z"), ag, Operation.Sign, honeyKeyId))
+      .unsafeRunSync()
+
+    recs.map(_.detector) should not contain "HoneyKey"
+  }
+
+  test("HoneyKey: Create / Locate resources (name:/pattern: prefixes) never trip the detector") {
+    // Create resources are `name:<n>/alg:.../size:...` and Locate is `pattern:...`. Neither yields
+    // a parseable KeyId, so the HoneyKey detector skips them. (You can't touch a honey key you
+    // haven't seen yet — only operations ON an existing KeyId are relevant.)
+    val registry = HoneyKeyRegistry.fromSet(Set(honeyKeyId))
+    val det      = BaselineDetector.make(honeyKeys = registry).unsafeRunSync()
+    val ag       = agent(alice)
+
+    val createRec = AuditRecord(
+      at = Instant.parse("2026-04-25T03:00:00Z"),
+      principal = ag,
+      operation = Operation.Create,
+      resource = "name:treasury-canary/alg:AES/size:256",
+      outcome = "Success",
+      correlationId = "c-create"
+    )
+    val locateRec = AuditRecord(
+      at = Instant.parse("2026-04-25T03:00:05Z"),
+      principal = ag,
+      operation = Operation.Locate,
+      resource = "pattern:treasury-*",
+      outcome = "Success",
+      correlationId = "c-locate"
+    )
+
+    det.observe(createRec).unsafeRunSync().map(_.detector) should not contain "HoneyKey"
+    det.observe(locateRec).unsafeRunSync().map(_.detector) should not contain "HoneyKey"
   }

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/HoneyKeyRegistrySpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/HoneyKeyRegistrySpec.scala
@@ -1,0 +1,39 @@
+package dev.aegiskms.agent
+
+import dev.aegiskms.core.KeyId
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Unit tests for `HoneyKeyRegistry` (#26). The SPI is small — `isHoney` + `snapshot` — but load-bearing: a
+  * regression that returns `false` for every KeyId silently disables the canary detection, which is the
+  * entire point of the feature. These tests pin the contract.
+  */
+final class HoneyKeyRegistrySpec extends AnyFunSuite with Matchers:
+
+  private val k1: KeyId = KeyId.fromString("k-canary-1").toOption.get
+  private val k2: KeyId = KeyId.fromString("k-canary-2").toOption.get
+  private val k3: KeyId = KeyId.fromString("k-real-3").toOption.get
+
+  test("empty: isHoney returns false for every KeyId; snapshot is empty") {
+    HoneyKeyRegistry.empty.isHoney(k1) shouldBe false
+    HoneyKeyRegistry.empty.isHoney(k2) shouldBe false
+    HoneyKeyRegistry.empty.snapshot shouldBe empty
+  }
+
+  test("fromSet: isHoney returns true for registered ids, false for unregistered") {
+    val reg = HoneyKeyRegistry.fromSet(Set(k1, k2))
+    reg.isHoney(k1) shouldBe true
+    reg.isHoney(k2) shouldBe true
+    reg.isHoney(k3) shouldBe false
+  }
+
+  test("fromSet: snapshot returns the exact set passed in (no reordering or duplication)") {
+    val ids = Set(k1, k2)
+    HoneyKeyRegistry.fromSet(ids).snapshot shouldBe ids
+  }
+
+  test("fromSet(Set.empty) is equivalent to empty (no honey keys registered)") {
+    val reg = HoneyKeyRegistry.fromSet(Set.empty)
+    reg.isHoney(k1) shouldBe false
+    reg.snapshot shouldBe empty
+  }

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -88,6 +88,19 @@ aegis {
     }
   }
 
+  # Honey key (canary) registry (#26). Any agent operation against a KeyId listed here fires the
+  # `HoneyKey` detector at Severity.High, which the AutoResponder.DefaultRules translate into a
+  # Revoke action — killing both the key and the agent's JWT via the wired RevocationList.
+  # Human operations against honey keys are NOT auto-revoked (operators may legitimately validate
+  # the canary is alive); they still produce an audit row for review.
+  #
+  # Comma-separated string for the env-var path; HOCON-list syntax for the file path. Empty by
+  # default — production deployments opt in explicitly.
+  security {
+    honey-keys = []
+    honey-keys = ${?AEGIS_HONEY_KEYS}
+  }
+
   policy {
     # "dev"        — DevPolicyEngine. Every Human + Service is allowed for every op; only the
     #                agent-scope recursion still gates. Suitable for the workstation demo and the

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -8,6 +8,7 @@ import dev.aegiskms.agent.{
   AutoResponder,
   BaselineDetector,
   BaselineRiskScorer,
+  HoneyKeyRegistry,
   InMemoryRecommendationSink,
   TappedAuditSink,
   ThresholdDecisionEngine
@@ -154,7 +155,12 @@ object Server extends IOApp.Simple:
       metered     = new MeteredKeyService(authorizing, metricsRegistry)
       traced      = new TracingKeyService(metered, tracer)
       recStore <- Resource.eval(InMemoryRecommendationSink.make)
-      detector <- Resource.eval(BaselineDetector.make())
+      // Honey key (canary) registry (#26). Parsed from `aegis.security.honey-keys` HOCON list
+      // (or AEGIS_HONEY_KEYS comma-separated env override). Empty by default — production
+      // deployments opt in explicitly. Threaded into BaselineDetector.make so the 6th detector
+      // can short-circuit any agent op against a marked key into a High-severity Revoke.
+      honeyKeys = buildHoneyKeyRegistry(rootConfig)
+      detector <- Resource.eval(BaselineDetector.make(honeyKeys = honeyKeys))
       // Audit sink (#19): `aegis.audit.kind=stdout` (default) writes to console; `postgres`
       // persists to the indexed `aegis_audit_events` table backing the audit-read API (#20).
       // `stdoutSink` is kept as the variable name across both modes so the existing references
@@ -638,6 +644,38 @@ object Server extends IOApp.Simple:
     * Both modes return a `Resource.eval`-friendly `IO[AgentTokenIssuer]`; the issuer itself holds no closable
     * resource, but lifting it via `IO` keeps the boot composition uniform.
     */
+  /** Parse `aegis.security.honey-keys` (#26). Accepts either a HOCON list or — when overridden via
+    * `AEGIS_HONEY_KEYS` — a comma-separated string (HOCON happily coerces a single string into a singleton
+    * list, but `,`-separated values look like one element to it; we split on `,` ourselves to handle that
+    * env-var shape).
+    *
+    * Unknown / malformed `KeyId` strings fail fast at boot rather than being silently ignored — a typo'd
+    * canary that doesn't catch the agent is the opposite of what an operator wanted.
+    */
+  private def buildHoneyKeyRegistry(config: Config): HoneyKeyRegistry =
+    import scala.jdk.CollectionConverters.*
+    val raw = config.getValue("aegis.security.honey-keys").unwrapped() match
+      case s: String             => s.split(',').toList.map(_.trim).filter(_.nonEmpty)
+      case xs: java.util.List[?] => xs.asScala.toList.map(_.toString.trim).filter(_.nonEmpty)
+      case other =>
+        throw new IllegalArgumentException(
+          s"aegis.security.honey-keys must be a list or comma-separated string, got: $other"
+        )
+    val parsed = raw.map { s =>
+      dev.aegiskms.core.KeyId.fromString(s).fold(
+        msg =>
+          throw new IllegalArgumentException(
+            s"aegis.security.honey-keys: invalid KeyId '$s': $msg"
+          ),
+        identity
+      )
+    }.toSet
+    if parsed.isEmpty then
+      logger.info("honey keys: none registered (set aegis.security.honey-keys to opt in)")
+    else
+      logger.info(s"honey keys: ${parsed.size} registered for canary auto-revoke")
+    HoneyKeyRegistry.fromSet(parsed)
+
   private def buildAgentIssuer(config: Config): IO[AgentTokenIssuer] = IO {
     config.getString("aegis.auth.kind") match
       case "hmac" =>


### PR DESCRIPTION
## Summary

Operator marks specific `KeyId`s as honey via `aegis.security.honey-keys`. Any **agent** operation against a registered key fires the 6th `BaselineDetector` heuristic — `HoneyKey` — at `Severity.High`. `AutoResponder.DefaultRules` then translate `High → Revoke`, which kills both the offending key and the agent's JWT via the wired `RevocationList`.

The "Claude goes phishing for treasury keys" trap closes its jaws on the **first touch**.

Closes #26.

This is **Batch 3 of the v0.2.0 push**. After this merges, only #27 (OPA backend) remains before the tag.

## Design

### Why a registry SPI rather than a `boolean` flag on `ManagedKey`

Marking a key honey is an **operational** decision that often happens *after* key creation (e.g. "we noticed Claude is fishing for treasury keys — let's plant a canary named `treasury-master-canary`"). A schema flag would require key rotation to mark an existing key, which is hostile to the operator workflow. The registry pattern also keeps the library tier (`aegis-core`, `aegis-persistence`) unchanged so embedders don't see a binary-compat break.

### Why agent-only

Humans may legitimately validate that a canary is still alive. The detector restricts firing to `Principal.Agent` so a human touching a honey produces an audit row for review but does NOT auto-revoke. Agents have no business touching a canary.

### Why no cold-start guard

The other five detectors require ≥ 1 prior observation before they fire (so first-time actors don't trigger noisy alerts). HoneyKey deliberately skips that — the entire point of the canary is to fire on first touch.

### Why HOCON-static (not dynamic)

Matches the `aegis.policy.role-based.*` static-config pattern. Dynamic add/remove via HTTP API is a v0.3.0 follow-up. For v0.2.0, operators set the list in HOCON or via `AEGIS_HONEY_KEYS`.

## `aegis-agent-ai` (library tier)

- **`HoneyKeyRegistry` SPI** — `isHoney(KeyId): Boolean` + `snapshot: Set[KeyId]`. Three impls:
  - `HoneyKeyRegistry.empty` — production-safe default
  - `HoneyKeyRegistry.fromSet(ids)` — static config-driven
  - Constructor default on `BaselineDetector.make` so existing embedders compile unchanged
- **`BaselineDetector` gains a 6th detector** named `"HoneyKey"`. Agent-only, fires at `Severity.High` with `SuggestedAction.Revoke` unconditionally. No cold-start guard. Skips Create / Locate audit resources (their `name:.../pattern:...` shapes don't yield a parseable `KeyId`).

## `aegis-server`

- **HOCON:** `aegis.security.honey-keys = []` (default empty). Env override: `AEGIS_HONEY_KEYS=k1,k2,...` (comma-separated for env shape, HOCON list syntax for the file).
- **`Server.buildHoneyKeyRegistry`** parses HOCON list OR env-var string into `Set[KeyId]`. **Malformed `KeyId` strings fail fast at boot** rather than being silently ignored — a typo'd canary that doesn't catch the agent is the opposite of what an operator wanted.
- Boot logs how many honey keys are registered (or "none — opt in via `aegis.security.honey-keys`").

## Test plan

- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` — formatting gate
- [x] `sbt "scalafixAll --check"` — lint gate
- [x] `sbt test` — **452 tests pass, 0 failures**
- [x] **`HoneyKeyRegistrySpec`** (4 cases) — `empty` returns false for everything, `fromSet` contains semantics, `snapshot` fidelity, `fromSet(Set.empty) ≡ empty`
- [x] **`BaselineDetectorSpec`** (+6 cases) — happy-path fire, first-touch trip wire, human-touch no-fire, non-honey no-fire, empty-registry inert, Create/Locate skip

## Docs updates

- **`ROADMAP.md`** — §v0.2.0 capability row 2.0.l flipped 💡 → ✅; AI-governance row updated
- **`docs/ARCHITECTURE.md`** — status table grew a Honey-keys row marking the 6th detector shipped
- **`CHANGELOG.md`** — `### Added` entry under `## Unreleased`

## After this merges

| Issue | Status |
|---|---|
| #26 Honey keys | ✅ this PR |
| #27 OPA backend | ⏭ Batch 4 (final v0.2.0 issue) |
| 🏁 Tag `v0.2.0` + record wedge demo | after Batch 4 |

The OPA backend will be the last new feature before the tag. Then it's `## Unreleased → ## v0.2.0 — YYYY-MM-DD`, `git tag -s v0.2.0`, push, demo recording.