### PR TITLE
feat: deterministic advisor scan audit triage (closes #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to Aegis will be documented here. This project follows
 
 ## Unreleased
 
+### Added
+
+- **`aegis advisor scan` — read-only audit triage (closes #28, ROADMAP 2.1.a).** The first slice of the
+  v0.2.1 LLM-advisor wedge, deliberately *deterministic* (no LLM, no mutation): it aggregates the audit log
+  into a bounded operator summary — idle keys, broad-scope agents, active anomalies, and the riskiest agents.
+  Keeping the analysis deterministic means the headline demo runs in CI with no API key and the numbers are
+  reproducible. The pluggable `LlmClient` (#30) layers natural-language narration over these same facts later.
+  - **`AdvisorService[F]` SPI + `AdvisorScan` analyzer** (`aegis-agent-ai`): the heuristics live in a pure
+    `AdvisorScan.analyze` (property-testable against synthetic records); `AdvisorService.deterministic` pages
+    the audit log via the existing `AuditQuery` SPI up to a 50k-row cap and marks the report `truncated` when
+    the window exceeds it (no silent under-reporting).
+  - **`GET /v1/advisor/scan`** (`aegis-http`): human-principals-only (Service/Agent get 403), `501` when the
+    server has no queryable audit sink (audit kind ≠ postgres) — same access model as `GET /v1/audit`. Tuning
+    knobs `lookbackDays` / `unusedDays` / `broadScope` / `top` fall back to defaults (90 / 30 / 5 / 5).
+  - **`aegis advisor scan`** (`aegis-cli`): replaces the long-standing stub; flags `--lookback-days`,
+    `--unused-days`, `--broad-scope`, `--top`; sectioned terminal output that prints "none" for empty
+    findings.
+  - **Wiring**: `Server.boot` builds the advisor over the same `AuditQuery` that backs the audit-read
+    endpoint, so it's available exactly when audit-read is. `aegis-http` now depends on `aegis-agent-ai` (both
+    server-tier; no Pekko added to the library tier).
+
 ### Fixed
 
 - **Honey-key auto-revoke never fired (regression in #26).** Two gaps meant a honey-key touch

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 
 | # | Capability | Area | Status |
 |---|---|---|---|
-| 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; bounded prompt set | Wedge | 🔜 |
+| 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; deterministic (LLM narration via 2.1.c later) | Wedge | 🚧 |
 | 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | 🔜 |
 | 2.1.c | Pluggable LLM provider (OpenAI / Anthropic / Bedrock / Ollama for local) | Wedge | 💡 |
 | 2.1.d | Prompt safety: never executes mutations; structured output schemas; refuses arbitrary queries | Wedge | 🔜 |

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val kmip = (project in file("modules/aegis-kmip"))
   )
 
 lazy val http = (project in file("modules/aegis-http"))
-  .dependsOn(core, crypto, iam, audit)
+  .dependsOn(core, crypto, iam, audit, agentAi)
   .settings(
     commonSettings,
     name := "aegis-http",

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AdvisorService.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AdvisorService.scala
@@ -1,0 +1,223 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import dev.aegiskms.audit.{AuditQuery, AuditRecord}
+import dev.aegiskms.core.Principal
+
+import java.time.{Duration, Instant}
+
+/** Read-only AI-advisor scan over the audit log (#28, ROADMAP 2.1.a).
+  *
+  * The v0.2.1 advisor is deliberately *deterministic*: it answers a bounded set of operator questions ("which
+  * keys are idle", "which agents have unusually broad operation usage", "are there active anomalies", "who
+  * are the riskiest agents") by aggregating the audit log — no LLM call, no mutation. The pluggable
+  * [[LlmClient]] (#30) is layered on later for natural-language *narration* of these same facts (`advisor
+  * explain`, #29); keeping the analysis deterministic means the headline demo runs in CI with no API key and
+  * the numbers are reproducible and auditable.
+  *
+  * The contract is strictly read-only: `scan` reads via [[AuditQuery]] and never touches `KeyService`.
+  */
+trait AdvisorService[F[_]]:
+  def scan(request: AdvisorScan.Request): F[AdvisorScan.Report]
+
+object AdvisorService:
+
+  /** Hard cap on the number of audit rows a single scan will pull into memory. A scan is an operator triage
+    * action, not a bulk export; 50k rows is plenty to characterise a window. When the window holds more than
+    * this, the report is marked `truncated = true` so the operator knows the analysis is over a partial
+    * window rather than silently under-reporting (e.g. an idle key that only appears past the cap).
+    */
+  val MaxScan: Int = 50_000
+
+  /** Page size for the underlying [[AuditQuery]] paging loop — the SPI's own per-request maximum. */
+  val PageSize: Int = AuditQuery.MaxLimit
+
+  /** Deterministic implementation backed by an [[AuditQuery]]. Pages through `[now - lookback, now)` up to
+    * [[MaxScan]] rows, then folds the records into a [[AdvisorScan.Report]] via [[AdvisorScan.analyze]].
+    */
+  def deterministic(reader: AuditQuery[IO]): AdvisorService[IO] = new AdvisorService[IO]:
+    def scan(request: AdvisorScan.Request): IO[AdvisorScan.Report] =
+      val windowEnd   = request.now
+      val windowStart = request.now.minus(request.lookback)
+
+      def loop(offset: Int, acc: Vector[AuditRecord]): IO[(Vector[AuditRecord], Boolean)] =
+        if acc.sizeIs >= MaxScan then IO.pure((acc, true))
+        else
+          reader
+            .query(
+              AuditQuery.Filter(
+                since = Some(windowStart),
+                until = Some(windowEnd),
+                limit = PageSize,
+                offset = offset
+              )
+            )
+            .flatMap { page =>
+              val next = acc ++ page.records
+              if page.records.isEmpty then IO.pure((next, false)) // no progress; stop
+              else if page.hasMore then loop(offset + page.records.size, next)
+              else IO.pure((next, false)) // window exhausted
+            }
+
+      loop(0, Vector.empty).map { case (records, truncated) =>
+        AdvisorScan.analyze(request, windowStart, windowEnd, records.toList, truncated)
+      }
+
+/** Request, result, and the pure analysis for an advisor scan. `analyze` is split out from the IO-bound
+  * paging so the heuristics can be property-tested against synthetic records without a live audit store.
+  */
+object AdvisorScan:
+
+  val DefaultLookback: Duration       = Duration.ofDays(90)
+  val DefaultUnusedAfter: Duration    = Duration.ofDays(30)
+  val DefaultBroadScopeThreshold: Int = 5
+  val DefaultTopRiskiest: Int         = 5
+
+  /** Scan parameters.
+    *
+    *   - `now` — the reference instant; the window is `[now - lookback, now)` and "idle for" is measured from
+    *     `now`. Passed in (rather than read from the clock here) so the analysis stays pure and testable.
+    *   - `lookback` — how far back to read the audit log. Must exceed `unusedAfter` for idle-key detection to
+    *     see anything (a key whose last activity predates the window can't be observed).
+    *   - `unusedAfter` — a key with no audit activity newer than `now - unusedAfter` is flagged "unused".
+    *   - `broadScopeThreshold` — an agent using at least this many *distinct* operations is flagged "broad
+    *     scope".
+    *   - `topRiskiest` — number of agents to return in the riskiest ranking.
+    */
+  final case class Request(
+      now: Instant,
+      lookback: Duration = DefaultLookback,
+      unusedAfter: Duration = DefaultUnusedAfter,
+      broadScopeThreshold: Int = DefaultBroadScopeThreshold,
+      topRiskiest: Int = DefaultTopRiskiest
+  )
+
+  /** A key with no audit activity newer than the cutoff. `idleDays` is whole days between `lastSeen` and
+    * `now`.
+    */
+  final case class UnusedKey(keyId: String, lastSeen: Instant, idleDays: Long)
+
+  /** An agent whose distinct-operation count met the broad-scope threshold; `operations` is the sorted set of
+    * distinct KMIP operation names it invoked in the window.
+    */
+  final case class BroadScopeAgent(agent: String, operations: List[String])
+
+  /** A single blocked / flagged operation surfaced as an active anomaly. */
+  final case class ActiveAnomaly(at: Instant, actor: String, operation: String, outcome: String)
+
+  /** An agent ranked by a transparent risk proxy. `score` combines failed-op weight, operation breadth, and
+    * the maximum `risk.score` the scorer stamped on the agent's records (`failedOps`/`distinctOps` are
+    * surfaced so the number is explainable rather than opaque).
+    */
+  final case class RiskyAgent(agent: String, score: Double, failedOps: Int, distinctOps: Int)
+
+  /** The full scan result. `scannedRecords` + `truncated` describe the coverage so a thin report can be told
+    * apart from a quiet window.
+    */
+  final case class Report(
+      windowStart: Instant,
+      windowEnd: Instant,
+      scannedRecords: Int,
+      truncated: Boolean,
+      unusedKeys: List[UnusedKey],
+      broadScopeAgents: List[BroadScopeAgent],
+      activeAnomalies: List[ActiveAnomaly],
+      riskiestAgents: List[RiskyAgent]
+  )
+
+  /** Fold a window of audit records into a [[Report]]. Pure; all heuristics live here.
+    *
+    *   - **Unused keys** — group `key:<id>` resources, take the latest `at` per key, flag those older than
+    *     `now - unusedAfter`. Sorted most-idle first.
+    *   - **Broad-scope agents** — over `Principal.Agent` records, agents whose distinct-operation count is
+    *     `>= broadScopeThreshold`. Sorted widest first.
+    *   - **Active anomalies** — records whose `outcome` signals a block / flag (see [[isAnomalous]]). Most
+    *     recent first.
+    *   - **Riskiest agents** — `failedOps * 2 + distinctOps + maxRiskScore * 10`, top `topRiskiest`.
+    */
+  def analyze(
+      request: Request,
+      windowStart: Instant,
+      windowEnd: Instant,
+      records: List[AuditRecord],
+      truncated: Boolean
+  ): Report =
+    val cutoff = request.now.minus(request.unusedAfter)
+
+    val latestByKey: Map[String, Instant] =
+      records.iterator
+        .filter(_.resource.startsWith("key:"))
+        .map(r => r.resource.stripPrefix("key:") -> r.at)
+        .toList
+        .groupMapReduce(_._1)(_._2)((a, b) => if a.isAfter(b) then a else b)
+
+    val unusedKeys =
+      latestByKey.iterator.collect {
+        case (keyId, lastSeen) if lastSeen.isBefore(cutoff) =>
+          UnusedKey(keyId, lastSeen, Duration.between(lastSeen, request.now).toDays)
+      }.toList
+        .sortBy(k => (-k.idleDays, k.keyId))
+
+    val agentRecords = records.filter(_.principal.isInstanceOf[Principal.Agent])
+
+    val opsByAgent: Map[String, List[String]] =
+      agentRecords
+        .groupMap(_.principal.subject)(_.operation.toString)
+        .map((subject, ops) => subject -> ops.distinct.sorted)
+
+    val broadScopeAgents =
+      opsByAgent.iterator.collect {
+        case (agent, ops) if ops.sizeIs >= request.broadScopeThreshold => BroadScopeAgent(agent, ops)
+      }.toList
+        .sortBy(a => (-a.operations.size, a.agent))
+
+    val activeAnomalies =
+      records.iterator
+        .filter(r => isAnomalous(r.outcome))
+        .map(r => ActiveAnomaly(r.at, r.principal.subject, r.operation.toString, r.outcome))
+        .toList
+        .sortBy(_.at)(using Ordering[Instant].reverse)
+
+    val riskiestAgents =
+      agentRecords
+        .groupBy(_.principal.subject)
+        .iterator
+        .map { (agent, rs) =>
+          val failed   = rs.count(_.outcome.startsWith("Failed"))
+          val distinct = rs.map(_.operation.toString).distinct.size
+          val maxRisk =
+            rs.flatMap(_.context.get("risk.score")).flatMap(_.toDoubleOption).maxOption.getOrElse(0.0)
+          RiskyAgent(
+            agent,
+            score = failed * 2.0 + distinct + maxRisk * 10.0,
+            failedOps = failed,
+            distinctOps = distinct
+          )
+        }
+        .toList
+        .sortBy(a => (-a.score, a.agent))
+        .take(request.topRiskiest)
+
+    Report(
+      windowStart = windowStart,
+      windowEnd = windowEnd,
+      scannedRecords = records.size,
+      truncated = truncated,
+      unusedKeys = unusedKeys,
+      broadScopeAgents = broadScopeAgents,
+      activeAnomalies = activeAnomalies,
+      riskiestAgents = riskiestAgents
+    )
+
+  /** Whether an audit `outcome` reads as an active anomaly: a failed operation, or an outcome that names a
+    * detector / decision-engine flag (anomaly, step-up, denial, alert). Conservative by design — a legit
+    * success never matches.
+    */
+  def isAnomalous(outcome: String): Boolean =
+    val lower = outcome.toLowerCase
+    outcome.startsWith("Failed") ||
+    lower.contains("anomaly") ||
+    lower.contains("stepup") ||
+    lower.contains("step-up") ||
+    lower.contains("denied") ||
+    lower.contains("alert")

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AdvisorServiceSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AdvisorServiceSpec.scala
@@ -1,0 +1,151 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.audit.{AuditQuery, AuditRecord}
+import dev.aegiskms.core.{Operation, Principal}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.{Duration, Instant}
+import scala.concurrent.duration.*
+
+/** Tests for the deterministic `advisor scan` analysis (#28).
+  *
+  * The heuristics live in the pure `AdvisorScan.analyze`, so most assertions drive it directly with synthetic
+  * records. One test exercises the IO paging path through a stub `AuditQuery` to confirm the loop assembles a
+  * multi-page window and surfaces the `truncated` flag.
+  */
+final class AdvisorServiceSpec extends AnyFunSuite with Matchers:
+
+  private val now: Instant     = Instant.parse("2026-06-01T00:00:00Z")
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def agent(subject: String): Principal.Agent =
+    Principal.Agent(
+      subject = subject,
+      operator = alice,
+      purpose = "test",
+      issuedAt = now.minus(Duration.ofDays(1)),
+      ttl = 1.hour,
+      allowedOps = Set(Operation.Get),
+      parent = None
+    )
+
+  private def rec(
+      at: Instant,
+      principal: Principal,
+      op: Operation,
+      resource: String,
+      outcome: String = "Success",
+      context: Map[String, String] = Map.empty
+  ): AuditRecord =
+    AuditRecord(at, principal, op, resource, outcome, "corr", context)
+
+  private val req = AdvisorScan.Request(now = now, lookback = Duration.ofDays(90))
+
+  private def analyze(records: List[AuditRecord], truncated: Boolean = false): AdvisorScan.Report =
+    AdvisorScan.analyze(req, now.minus(req.lookback), now, records, truncated)
+
+  test("a key whose last activity predates the unused-after cutoff is flagged, idle days computed from now") {
+    val lastSeen = now.minus(Duration.ofDays(45))
+    val report = analyze(
+      List(
+        rec(now.minus(Duration.ofDays(60)), alice, Operation.Create, "key:stale"),
+        rec(lastSeen, alice, Operation.Get, "key:stale"), // newest activity for the key
+        rec(now.minus(Duration.ofDays(2)), alice, Operation.Get, "key:fresh")
+      )
+    )
+    report.unusedKeys.map(_.keyId) shouldBe List("stale")
+    report.unusedKeys.head.lastSeen shouldBe lastSeen
+    report.unusedKeys.head.idleDays shouldBe 45L
+  }
+
+  test("a key used within the cutoff is not flagged unused") {
+    val report = analyze(List(rec(now.minus(Duration.ofDays(3)), alice, Operation.Sign, "key:active")))
+    report.unusedKeys shouldBe empty
+  }
+
+  test("broad-scope agents are those whose distinct-op count meets the threshold") {
+    val wide   = agent("agent-wide")
+    val narrow = agent("agent-narrow")
+    val ops    = List(Operation.Get, Operation.Sign, Operation.Encrypt, Operation.Decrypt, Operation.Wrap)
+    val records =
+      ops.map(o => rec(now.minus(Duration.ofHours(1)), wide, o, "key:k1")) ++
+        List(rec(now, narrow, Operation.Get, "key:k2"), rec(now, narrow, Operation.Sign, "key:k2"))
+    val report = analyze(records) // default broadScopeThreshold = 5
+    report.broadScopeAgents.map(_.agent) shouldBe List("agent-wide")
+    report.broadScopeAgents.head.operations shouldBe ops.map(_.toString).sorted
+  }
+
+  test("human principals never count toward broad-scope or riskiest agents") {
+    val records =
+      List(
+        Operation.Get,
+        Operation.Sign,
+        Operation.Encrypt,
+        Operation.Decrypt,
+        Operation.Wrap,
+        Operation.Rotate
+      )
+        .map(o => rec(now, alice, o, "key:k"))
+    val report = analyze(records)
+    report.broadScopeAgents shouldBe empty
+    report.riskiestAgents shouldBe empty
+  }
+
+  test("active anomalies pick up failed / flagged outcomes, newest first; clean window reports none") {
+    val a     = agent("agent-x")
+    val clean = analyze(List(rec(now, a, Operation.Get, "key:k", "Success")))
+    clean.activeAnomalies shouldBe empty
+
+    val flagged = analyze(
+      List(
+        rec(now.minus(Duration.ofMinutes(10)), a, Operation.Sign, "key:k", "Failed code=PermissionDenied"),
+        rec(now.minus(Duration.ofMinutes(5)), a, Operation.Get, "key:k", "AnomalyAlert(scope)"),
+        rec(now.minus(Duration.ofMinutes(1)), a, Operation.Get, "key:k", "Success")
+      )
+    )
+    flagged.activeAnomalies.map(_.outcome) shouldBe List(
+      "AnomalyAlert(scope)",
+      "Failed code=PermissionDenied"
+    )
+  }
+
+  test("riskiest agents rank by failed-ops + breadth + max risk.score, capped at topRiskiest") {
+    val risky = agent("agent-risky")
+    val calm  = agent("agent-calm")
+    val records = List(
+      rec(now, risky, Operation.Sign, "key:k", "Failed code=PermissionDenied", Map("risk.score" -> "0.9")),
+      rec(now, risky, Operation.Get, "key:k", "Success", Map("risk.score" -> "0.4")),
+      rec(now, calm, Operation.Get, "key:k", "Success", Map("risk.score" -> "0.1"))
+    )
+    val report = analyze(records).copy() // explicit; default topRiskiest = 5
+    report.riskiestAgents.head.agent shouldBe "agent-risky"
+    report.riskiestAgents.head.failedOps shouldBe 1
+    report.riskiestAgents.map(_.agent) should contain theSameElementsAs List("agent-risky", "agent-calm")
+  }
+
+  test("deterministic service pages through multiple audit pages and reports coverage") {
+    // Stub reader returns two pages of 1 record then signals exhaustion.
+    val page1 = AuditQuery.Page(
+      List(rec(now.minus(Duration.ofDays(50)), alice, Operation.Get, "key:stale")),
+      1000,
+      0,
+      true
+    )
+    val page2 = AuditQuery.Page(
+      List(rec(now.minus(Duration.ofDays(1)), alice, Operation.Get, "key:fresh")),
+      1000,
+      1,
+      false
+    )
+    val reader = new AuditQuery[IO]:
+      def query(filter: AuditQuery.Filter): IO[AuditQuery.Page] =
+        IO.pure(if filter.offset == 0 then page1 else page2)
+
+    val report = AdvisorService.deterministic(reader).scan(req).unsafeRunSync()
+    report.scannedRecords shouldBe 2
+    report.truncated shouldBe false
+    report.unusedKeys.map(_.keyId) shouldBe List("stale")
+  }

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -151,6 +151,32 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[AuditQueryResponseDto](res.body)
       case status => Left(toError(status, res.body))
 
+  /** GET /v1/advisor/scan — deterministic read-only triage over the recent audit window (#28). Each tuning
+    * knob is sent only when the caller overrides the default, so the server's defaults apply otherwise.
+    */
+  def advisorScan(
+      lookbackDays: Option[Int] = None,
+      unusedDays: Option[Int] = None,
+      broadScope: Option[Int] = None,
+      top: Option[Int] = None
+  ): Either[ClientError, AdvisorScanResponseDto] =
+    val params = List(
+      lookbackDays.map(v => "lookbackDays" -> v.toString),
+      unusedDays.map(v => "unusedDays" -> v.toString),
+      broadScope.map(v => "broadScope" -> v.toString),
+      top.map(v => "top" -> v.toString)
+    ).flatten
+    val qs =
+      if params.isEmpty then ""
+      else
+        params.map { case (k, v) =>
+          s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
+        }.mkString("?", "&", "")
+    val res = http.execute(HttpPort.Request("GET", url(s"/v1/advisor/scan$qs"), baseHeaders, None))
+    res.status match
+      case 200    => decodeBody[AdvisorScanResponseDto](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -56,7 +56,11 @@ object Cli:
               )
           case Left(msg) => CommandResult.err(s"$msg\n\n${auditTailHelp}")
 
-      case "advisor" :: "scan" :: _ => Commands.advisorScan
+      case "advisor" :: "scan" :: rest =>
+        parseAdvisorScan(rest) match
+          case Right((lookback, unused, broad, top)) =>
+            Commands.advisorScan(makeClient(cfg), lookback, unused, broad, top)
+          case Left(msg) => CommandResult.err(s"$msg\n\n${advisorScanHelp}")
 
       case unknown =>
         CommandResult.err(s"unknown command: ${unknown.mkString(" ")}\n\n${help.stdout}")
@@ -357,6 +361,27 @@ object Cli:
             .toRight(s"audit tail: --offset must be a non-negative integer (was '$v')")
     yield AuditTailFilter(since, until, actor, key, op, l, o, watch)
 
+  /** Parse `aegis advisor scan [--lookback-days N] [--unused-days N] [--broad-scope N] [--top N]`. Each knob
+    * is optional and must parse as a positive integer if provided; absent knobs let the server defaults
+    * apply.
+    */
+  private[cli] def parseAdvisorScan(
+      args: List[String]
+  ): Either[String, (Option[Int], Option[Int], Option[Int], Option[Int])] =
+    val flags = parseFlags(args)
+    def posInt(flag: String): Either[String, Option[Int]] =
+      flags.get(flag) match
+        case None => Right(None)
+        case Some(v) =>
+          v.toIntOption.filter(_ > 0).map(Some(_))
+            .toRight(s"advisor scan: $flag must be a positive integer (was '$v')")
+    for
+      lookback <- posInt("--lookback-days")
+      unused   <- posInt("--unused-days")
+      broad    <- posInt("--broad-scope")
+      top      <- posInt("--top")
+    yield (lookback, unused, broad, top)
+
   /** Watch-mode loop: print one page, then poll every 2 s for new records (using the last seen `at` as the
     * new `since`). Runs indefinitely until the JVM is killed. Sleeps via `Thread.sleep` because the CLI is
     * synchronous; the rest of the codebase uses cats-effect but dragging IO/IOApp into the CLI's startup path
@@ -433,7 +458,7 @@ object Cli:
       |  aegis agent issue --label <text> --scopes Op,Op,… --ttl <seconds> [--parent <subject>]
       |  aegis audit tail [--since <ISO>] [--until <ISO>] [--actor <subject>] [--key <id>]
       |                   [--op <name>] [--limit <n>] [--offset <n>] [--watch]
-      |  aegis advisor scan       (planned — PR W4)
+      |  aegis advisor scan [--lookback-days <n>] [--unused-days <n>] [--broad-scope <n>] [--top <n>]
       |
       |Config: $AEGIS_CONFIG, or ~/.aegis/config.json
       |Env:    AEGIS_SERVER, AEGIS_USER override the saved config""".stripMargin
@@ -458,6 +483,15 @@ object Cli:
       |  --limit <n>     Page size; default 100, max 1000
       |  --offset <n>    Starting row offset; default 0
       |  --watch         Poll every 2 s for new records (tail -f UX)""".stripMargin
+  private val advisorScanHelp: String =
+    """Usage: aegis advisor scan [knobs]
+      |
+      |  --lookback-days <n>  How far back to read the audit log (default 90)
+      |  --unused-days <n>    Flag keys idle at least this many days (default 30)
+      |  --broad-scope <n>    Flag agents using ≥ this many distinct ops (default 5)
+      |  --top <n>            Number of riskiest agents to list (default 5)
+      |
+      |Read-only triage; never mutates. Requires a server with aegis.audit.kind=postgres.""".stripMargin
   private val keysHelp: String =
     """Usage:
       |  aegis keys create --alg <ALG> --name <NAME>

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -2,6 +2,7 @@ package dev.aegiskms.cli
 
 import dev.aegiskms.cli.AegisHttpClient.{ClientError, renderError}
 import dev.aegiskms.cli.WireFormats.{
+  AdvisorScanResponseDto,
   AuditRecordDto,
   CompromiseRequest,
   DecryptRequest,
@@ -280,14 +281,59 @@ object Commands:
           CommandResult.out(body + footer)
       case Left(err) => CommandResult.err(renderError(err), exitCodeFor(err))
 
-  // ── Placeholder for AI advisor (W4, deferred) ─────────────────────────────
+  // ── AI advisor scan (#28) ─────────────────────────────────────────────────
 
-  /** `aegis advisor scan` — runs the LLM advisor against recent audit data. Awaits PR W4. */
-  def advisorScan: CommandResult =
-    CommandResult.err(
-      "advisor scan: not yet wired up — the LLM advisor ships in PR W4.",
-      code = 2
+  /** `aegis advisor scan [--lookback-days N] [--unused-days N] [--broad-scope N] [--top N]`
+    *
+    * Deterministic, read-only triage of recent audit activity: idle keys, broad-scope agents, active
+    * anomalies, and the riskiest agents. Calls `GET /v1/advisor/scan`; all tuning knobs are optional and fall
+    * back to server defaults (lookback 90d, unused 30d, broad-scope 5 ops, top 5 agents).
+    */
+  def advisorScan(
+      client: AegisHttpClient,
+      lookbackDays: Option[Int],
+      unusedDays: Option[Int],
+      broadScope: Option[Int],
+      top: Option[Int]
+  ): CommandResult =
+    client.advisorScan(lookbackDays, unusedDays, broadScope, top) match
+      case Right(report) => CommandResult.out(formatAdvisorReport(report))
+      case Left(err)     => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  /** Render an advisor-scan report as a sectioned terminal summary. Each section prints its findings or an
+    * explicit "none", so a clean window reads as "no findings" rather than an ambiguous blank.
+    */
+  private def formatAdvisorReport(r: AdvisorScanResponseDto): String =
+    def section(title: String, lines: List[String]): String =
+      val body = if lines.isEmpty then "  none" else lines.map("  • " + _).mkString("\n")
+      s"$title\n$body"
+
+    val header =
+      s"advisor scan — window ${r.windowStart} → ${r.windowEnd} (${r.scannedRecords} record(s) scanned)" +
+        (if r.truncated then
+           s"\n  ⚠ partial window: hit the ${r.scannedRecords}-record scan cap; findings may be incomplete"
+         else "")
+
+    val unused = section(
+      "Unused keys:",
+      r.unusedKeys.map(k => f"${k.keyId}%-28s idle ${k.idleDays}d (last seen ${k.lastSeen})")
     )
+    val broad = section(
+      "Broad-scope agents:",
+      r.broadScopeAgents.map(a => f"${a.agent}%-28s ${a.operations.mkString(", ")}")
+    )
+    val anomalies = section(
+      "Active anomalies:",
+      r.activeAnomalies.map(a => f"${a.at}  ${a.actor}%-20s ${a.operation}%-10s ${a.outcome}")
+    )
+    val riskiest = section(
+      "Riskiest agents:",
+      r.riskiestAgents.map(a =>
+        f"${a.agent}%-28s score ${a.score}%.1f (failed ${a.failedOps}, distinct ops ${a.distinctOps})"
+      )
+    )
+
+    List(header, unused, broad, anomalies, riskiest).mkString("\n\n")
 
   /** Render a single audit record for terminal output. Multi-line; the leading field labels are
     * column-aligned so a glance picks out the actor / operation / outcome quickly.

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -83,6 +83,42 @@ object WireFormats:
     given Encoder[AuditQueryResponseDto] = deriveEncoder
     given Decoder[AuditQueryResponseDto] = deriveDecoder
 
+  // ── Advisor-scan DTOs (mirrors aegis-http/JsonCodecs.AdvisorScanResponseDto, #28) ──
+
+  final case class UnusedKeyDto(keyId: String, lastSeen: Instant, idleDays: Long)
+  object UnusedKeyDto:
+    given Encoder[UnusedKeyDto] = deriveEncoder
+    given Decoder[UnusedKeyDto] = deriveDecoder
+
+  final case class BroadScopeAgentDto(agent: String, operations: List[String])
+  object BroadScopeAgentDto:
+    given Encoder[BroadScopeAgentDto] = deriveEncoder
+    given Decoder[BroadScopeAgentDto] = deriveDecoder
+
+  final case class ActiveAnomalyDto(at: Instant, actor: String, operation: String, outcome: String)
+  object ActiveAnomalyDto:
+    given Encoder[ActiveAnomalyDto] = deriveEncoder
+    given Decoder[ActiveAnomalyDto] = deriveDecoder
+
+  final case class RiskyAgentDto(agent: String, score: Double, failedOps: Int, distinctOps: Int)
+  object RiskyAgentDto:
+    given Encoder[RiskyAgentDto] = deriveEncoder
+    given Decoder[RiskyAgentDto] = deriveDecoder
+
+  final case class AdvisorScanResponseDto(
+      windowStart: Instant,
+      windowEnd: Instant,
+      scannedRecords: Int,
+      truncated: Boolean,
+      unusedKeys: List[UnusedKeyDto],
+      broadScopeAgents: List[BroadScopeAgentDto],
+      activeAnomalies: List[ActiveAnomalyDto],
+      riskiestAgents: List[RiskyAgentDto]
+  )
+  object AdvisorScanResponseDto:
+    given Encoder[AdvisorScanResponseDto] = deriveEncoder
+    given Decoder[AdvisorScanResponseDto] = deriveDecoder
+
   final case class KmsErrorDto(code: String, message: String)
   object KmsErrorDto:
     given Encoder[KmsErrorDto] = deriveEncoder

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -160,11 +160,38 @@ final class CliSpec extends AnyFunSuite with Matchers:
     r.stderr should include("aegis keys create")
   }
 
-  test("'advisor scan' is still a placeholder and surfaces a clear non-zero exit") {
-    // The only remaining stub in the CLI surface — `agent issue` and `audit tail` are wired up
-    // in #79; `advisor scan` waits for the AI advisor (PR W4).
-    val factory = fakeClientFactory(200, sampleKey.asJson.noSpaces)
-    Cli.run(List("advisor", "scan"), cfg, factory).exitCode should not be 0
+  test("'advisor scan' with knobs GETs /v1/advisor/scan carrying the parsed query params") {
+    val report = AdvisorScanResponseDto(
+      windowStart = Instant.parse("2026-03-03T00:00:00Z"),
+      windowEnd = Instant.parse("2026-06-01T00:00:00Z"),
+      scannedRecords = 0,
+      truncated = false,
+      unusedKeys = Nil,
+      broadScopeAgents = Nil,
+      activeAnomalies = Nil,
+      riskiestAgents = Nil
+    )
+    var captured: Option[HttpPort.Request] = None
+    val r = Cli.run(
+      List("advisor", "scan", "--unused-days", "60", "--top", "3"),
+      cfg,
+      captureFactory(req => captured = Some(req), report.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "GET"
+    captured.get.url should include("/v1/advisor/scan")
+    captured.get.url should include("unusedDays=60")
+    captured.get.url should include("top=3")
+  }
+
+  test("'advisor scan' with a non-numeric knob reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("advisor", "scan", "--top", "lots"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("--top must be a positive integer")
   }
 
   // ── #79: agent issue ──────────────────────────────────────────────────────

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -109,10 +109,37 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     r.stderr should include("boom")
   }
 
-  test("advisor scan is still a placeholder and exits non-zero with a clear message") {
-    // `agent issue` and `audit tail` are real in #79; only `advisor scan` (PR W4) remains a stub.
-    Commands.advisorScan.exitCode should not be 0
-    Commands.advisorScan.stderr should include("PR W4")
+  test("advisor scan renders each section, printing 'none' for empty findings") {
+    val report = AdvisorScanResponseDto(
+      windowStart = Instant.parse("2026-03-03T00:00:00Z"),
+      windowEnd = Instant.parse("2026-06-01T00:00:00Z"),
+      scannedRecords = 1234,
+      truncated = false,
+      unusedKeys = List(UnusedKeyDto("key:stale", Instant.parse("2026-04-02T00:00:00Z"), 60)),
+      broadScopeAgents =
+        List(BroadScopeAgentDto("agent-7a3", List("Decrypt", "Encrypt", "Get", "Sign", "Wrap"))),
+      activeAnomalies = Nil,
+      riskiestAgents = List(RiskyAgentDto("agent-7a3", 12.0, 1, 5))
+    )
+    val client = clientReturning(200, report.asJson.noSpaces)
+    val r      = Commands.advisorScan(client, None, None, None, None)
+    r.exitCode shouldBe 0
+    r.stdout should include("1234 record(s) scanned")
+    r.stdout should include("key:stale")
+    r.stdout should include("idle 60d")
+    r.stdout should include("agent-7a3")
+    r.stdout should include("Decrypt, Encrypt, Get, Sign, Wrap")
+    r.stdout should include("Active anomalies:\n  none")
+    r.stdout should include("score 12.0")
+  }
+
+  test("advisor scan surfaces a 501 (not wired) as a non-zero exit with the server reason") {
+    val errBody =
+      KmsErrorDto("FeatureNotSupported", "advisor scan is not enabled on this server").asJson.noSpaces
+    val client = clientReturning(501, errBody)
+    val r      = Commands.advisorScan(client, None, None, None, None)
+    r.exitCode should not be 0
+    r.stderr should include("FeatureNotSupported")
   }
 
   test("keys sign prints the base64 signature and algorithm on success") {

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -351,6 +351,53 @@ object Endpoints:
           "human principal — service and agent principals are refused with 403."
       )
 
+  // ── Advisor scan (#28) ────────────────────────────────────────────────────
+
+  /** Common base for the read-only advisor surface under `/v1/advisor`, same auth + error contract as the
+    * rest of the REST plane, distinct OpenAPI tag.
+    */
+  private val advisorBase =
+    endpoint
+      .in("v1" / "advisor")
+      .in(authHeader)
+      .in(devUserHeader)
+      .in(sourceIpInput)
+      .errorOut(statusCode and jsonBody[KmsErrorDto].description("Failure detail"))
+      .tag("advisor")
+
+  /** `GET /v1/advisor/scan` — read-only triage over the recent audit window. Deterministic: no LLM, no
+    * mutation. Only `Principal.Human` callers are permitted (Service + Agent return 403), and the endpoint
+    * returns 501 when the server has no queryable audit sink (audit kind ≠ postgres), mirroring `GET
+    * /v1/audit`.
+    *
+    * Query parameters (all optional, sensible defaults):
+    *   - `lookbackDays` — how far back to read the audit log (default 90).
+    *   - `unusedDays` — a key idle for at least this many days is flagged unused (default 30).
+    *   - `broadScope` — distinct-operation count at/above which an agent is flagged broad-scope (default 5).
+    *   - `top` — number of agents in the riskiest ranking (default 5).
+    */
+  val advisorScan: PublicEndpoint[
+    (Option[String], Option[String], Option[String], Option[Int], Option[Int], Option[Int], Option[Int]),
+    (StatusCode, KmsErrorDto),
+    AdvisorScanResponseDto,
+    Any
+  ] =
+    advisorBase.get
+      .in("scan")
+      .in(query[Option[Int]]("lookbackDays").description("Audit look-back window in days; defaults to 90"))
+      .in(query[Option[Int]]("unusedDays").description("Idle-days threshold for unused keys; defaults to 30"))
+      .in(query[Option[Int]]("broadScope").description(
+        "Distinct-op count flagging a broad-scope agent; default 5"
+      ))
+      .in(query[Option[Int]]("top").description("Number of riskiest agents to return; defaults to 5"))
+      .out(jsonBody[AdvisorScanResponseDto])
+      .summary("Read-only advisor scan of recent audit activity")
+      .description(
+        "Aggregates the audit log into a triage summary: unused keys, broad-scope agents, active " +
+          "anomalies, and the riskiest agents. Deterministic and read-only — never mutates. Caller must be " +
+          "a human principal; service and agent principals are refused with 403."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -367,5 +414,6 @@ object Endpoints:
       compromiseKey,
       rotateKey,
       issueAgent,
-      queryAudit
+      queryAudit,
+      advisorScan
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -2,6 +2,7 @@ package dev.aegiskms.http
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import dev.aegiskms.agent.{AdvisorScan, AdvisorService}
 import dev.aegiskms.audit.{AuditQuery, AuditRecord, AuditSink, RequestContext}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
@@ -53,7 +54,12 @@ final class HttpRoutes(
       * Defaults to [[RequestContext.empty]] so existing tests that construct `HttpRoutes` without the IOLocal
       * compile unchanged — the production wiring in `Server.boot` swaps in the real one.
       */
-    requestContext: RequestContext = RequestContext.empty
+    requestContext: RequestContext = RequestContext.empty,
+    /** Optional advisor backing the `GET /v1/advisor/scan` endpoint. Wired by `Server.boot` over the same
+      * `AuditQuery` that backs the audit-read endpoint — so it's present exactly when `auditReader` is. When
+      * `None`, `GET /v1/advisor/scan` returns `501 FeatureNotSupported`.
+      */
+    advisor: Option[AdvisorService[IO]] = None
 )(using runtime: IORuntime):
 
   private given ExecutionContext = runtime.compute
@@ -423,6 +429,52 @@ final class HttpRoutes(
                 ))
     }
 
+  /** `GET /v1/advisor/scan` — deterministic, read-only triage over the audit window. Same access model as
+    * `/v1/audit`: human principals only (Service + Agent return 403), and 501 when no advisor is wired (audit
+    * kind ≠ postgres). Negative/zero query params fall back to the advisor defaults rather than erroring — a
+    * scan with a nonsensical window is better served by sane defaults than a 400.
+    */
+  private val advisorScanSE: ServerEndpoint[Any, Future] =
+    Endpoints.advisorScan.serverLogic {
+      case (auth, devHdr, clientIp, lookbackDays, unusedDays, broadScope, top) =>
+        principalOf(auth, devHdr) match
+          case Left(e) => Future.successful(Left(e))
+          case Right(_: Principal.Human) =>
+            advisor match
+              case None =>
+                Future.successful(Left(
+                  StatusCode.NotImplemented -> KmsErrorDto.of(
+                    ErrorCode.FeatureNotSupported,
+                    "advisor scan is not enabled on this server (set aegis.audit.kind=postgres)"
+                  )
+                ))
+              case Some(svc) =>
+                val scan =
+                  for
+                    now <- IO.realTimeInstant
+                    report <- svc.scan(
+                      AdvisorScan.Request(
+                        now = now,
+                        lookback = lookbackDays.filter(_ > 0).map(d => java.time.Duration.ofDays(d.toLong))
+                          .getOrElse(AdvisorScan.DefaultLookback),
+                        unusedAfter = unusedDays.filter(_ > 0).map(d => java.time.Duration.ofDays(d.toLong))
+                          .getOrElse(AdvisorScan.DefaultUnusedAfter),
+                        broadScopeThreshold =
+                          broadScope.filter(_ > 0).getOrElse(AdvisorScan.DefaultBroadScopeThreshold),
+                        topRiskiest = top.filter(_ > 0).getOrElse(AdvisorScan.DefaultTopRiskiest)
+                      )
+                    )
+                  yield AdvisorScanResponseDto.fromCore(report)
+                runIO(clientIp)(scan).map(Right(_))
+          case Right(_) =>
+            Future.successful(Left(
+              StatusCode.Forbidden -> KmsErrorDto.of(
+                ErrorCode.PermissionDenied,
+                "advisor scan is restricted to human principals"
+              )
+            ))
+    }
+
   /** Write one `AuditRecord` per `/v1/agents/issue` call — success OR failure — so operators have a forensic
     * trail of every agent credential ever minted. The audit row captures the caller (the human who issued),
     * the requested scopes + ttl + label (so reviewers can answer "what does this agent have access to"), and
@@ -522,7 +574,8 @@ final class HttpRoutes(
       compromiseSE,
       rotateSE,
       issueAgentSE,
-      queryAuditSE
+      queryAuditSE,
+      advisorScanSE
     )
 
   /** Render the live endpoint set as an OpenAPI 3.1 document. The build-time guarantee here is the same one

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -269,3 +269,59 @@ object JsonCodecs:
   object AuditQueryResponseDto:
     given Encoder[AuditQueryResponseDto] = deriveEncoder
     given Decoder[AuditQueryResponseDto] = deriveDecoder
+
+  // ── Advisor-scan DTOs (#28) ───────────────────────────────────────────────
+
+  /** Wire mirror of `AdvisorScan.UnusedKey`. */
+  final case class UnusedKeyDto(keyId: String, lastSeen: Instant, idleDays: Long)
+  object UnusedKeyDto:
+    given Encoder[UnusedKeyDto] = deriveEncoder
+    given Decoder[UnusedKeyDto] = deriveDecoder
+
+  /** Wire mirror of `AdvisorScan.BroadScopeAgent`. */
+  final case class BroadScopeAgentDto(agent: String, operations: List[String])
+  object BroadScopeAgentDto:
+    given Encoder[BroadScopeAgentDto] = deriveEncoder
+    given Decoder[BroadScopeAgentDto] = deriveDecoder
+
+  /** Wire mirror of `AdvisorScan.ActiveAnomaly`. */
+  final case class ActiveAnomalyDto(at: Instant, actor: String, operation: String, outcome: String)
+  object ActiveAnomalyDto:
+    given Encoder[ActiveAnomalyDto] = deriveEncoder
+    given Decoder[ActiveAnomalyDto] = deriveDecoder
+
+  /** Wire mirror of `AdvisorScan.RiskyAgent`. */
+  final case class RiskyAgentDto(agent: String, score: Double, failedOps: Int, distinctOps: Int)
+  object RiskyAgentDto:
+    given Encoder[RiskyAgentDto] = deriveEncoder
+    given Decoder[RiskyAgentDto] = deriveDecoder
+
+  /** Wire response for `GET /v1/advisor/scan`. A read-only triage summary over the audit window:
+    * `scannedRecords` + `truncated` describe coverage, the four lists are the findings.
+    */
+  final case class AdvisorScanResponseDto(
+      windowStart: Instant,
+      windowEnd: Instant,
+      scannedRecords: Int,
+      truncated: Boolean,
+      unusedKeys: List[UnusedKeyDto],
+      broadScopeAgents: List[BroadScopeAgentDto],
+      activeAnomalies: List[ActiveAnomalyDto],
+      riskiestAgents: List[RiskyAgentDto]
+  )
+  object AdvisorScanResponseDto:
+    def fromCore(r: dev.aegiskms.agent.AdvisorScan.Report): AdvisorScanResponseDto =
+      AdvisorScanResponseDto(
+        windowStart = r.windowStart,
+        windowEnd = r.windowEnd,
+        scannedRecords = r.scannedRecords,
+        truncated = r.truncated,
+        unusedKeys = r.unusedKeys.map(k => UnusedKeyDto(k.keyId, k.lastSeen, k.idleDays)),
+        broadScopeAgents = r.broadScopeAgents.map(a => BroadScopeAgentDto(a.agent, a.operations)),
+        activeAnomalies = r.activeAnomalies.map(a => ActiveAnomalyDto(a.at, a.actor, a.operation, a.outcome)),
+        riskiestAgents =
+          r.riskiestAgents.map(a => RiskyAgentDto(a.agent, a.score, a.failedOps, a.distinctOps))
+      )
+
+    given Encoder[AdvisorScanResponseDto] = deriveEncoder
+    given Decoder[AdvisorScanResponseDto] = deriveDecoder

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, IOApp, IOLocal, Resource}
 import cats.syntax.all.*
 import com.typesafe.config.{Config, ConfigFactory}
 import dev.aegiskms.agent.{
+  AdvisorService,
   AutoResponder,
   BaselineDetector,
   BaselineRiskScorer,
@@ -228,6 +229,13 @@ object Server extends IOApp.Simple:
       // with proper OIDC + JWKS rotation.
       agentIssuer <- Resource.eval(buildAgentIssuer(rootConfig))
 
+      // Audit-read capability (#20) + advisor scan (#28) both ride on the `AuditQuery` SPI, which only the
+      // *primary* postgres sink satisfies. Match on `primarySink`, not `stdoutSink`, because the latter may
+      // be wrapped in a `FanOutAuditSink` for the webhook fan-out (#21) that doesn't carry the capability.
+      auditReader = primarySink match
+        case q: AuditQuery[IO @unchecked] => Some(q)
+        case _                            => None
+
       // 5. HTTP binding. Acquire = bind; release = unbind with the configured grace period (5s) so
       //    in-flight requests finish before the socket closes.
       appRoute =
@@ -245,10 +253,9 @@ object Server extends IOApp.Simple:
             resolver,
             Some(agentIssuer),
             Some(stdoutSink),
-            primarySink match
-              case q: AuditQuery[IO @unchecked] => Some(q)
-              case _                            => None,
-            reqContext
+            auditReader,
+            reqContext,
+            auditReader.map(AdvisorService.deterministic)
           ).routes,
           MetricsRoutes.route(metricsRegistry)
         )

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,8 +16,8 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 14 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
-    // wrap, unwrap, compromise, rotate) + agents/issue (#18) + audit/query (#20). Bump this
-    // when a new top-level REST surface lands.
-    routes.serverEndpoints.size shouldBe 14
+    // 15 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // wrap, unwrap, compromise, rotate) + agents/issue (#18) + audit/query (#20) + advisor/scan
+    // (#28). Bump this when a new top-level REST surface lands.
+    routes.serverEndpoints.size shouldBe 15
   }


### PR DESCRIPTION
## What

First slice of the v0.2.1 LLM-advisor wedge (ROADMAP 2.1.a): a **deterministic, read-only** `aegis advisor scan` that aggregates the audit log into an operator triage summary — idle keys, broad-scope agents, active anomalies, and the riskiest agents.

No LLM, no mutation; the headline demo runs in CI with no API key. LLM narration layers on later via #30 (`advisor explain`, #29).

## Changes

- **agent-ai**: `AdvisorService[F]` SPI + pure `AdvisorScan.analyze` + `deterministic` impl that pages `AuditQuery` up to a 50k-row cap and marks `truncated` rather than silently under-reporting.
- **http**: `GET /v1/advisor/scan` Tapir endpoint + DTOs + handler. Human-principals only: Service/Agent → 403. Returns `501` when audit kind is not postgres, same access model as `GET /v1/audit`. Knobs: `lookbackDays`, `unusedDays`, `broadScope`, `top`.
- **cli**: replaces the long-standing `advisor scan` stub with the real command, flags, and sectioned output.
- **wiring**: `Server.boot` builds the advisor over the same `AuditQuery` that backs audit-read. `aegis-http` now depends on `aegis-agent-ai`; both are server-tier, with no Pekko added to the library tier.

## Tests

- New `AdvisorServiceSpec` with 7 cases: heuristics + paging.
- Updated CLI `CommandsSpec` / `CliSpec` replacing the stub assertions.
- Updated `ServerWiringSpec` endpoint count 14 → 15.
- scalafmt + scalafix + full `Test / compile` + agentAi/http/cli/server tests all green.

Closes #28