### PR TITLE
feat: pluggable LLM provider Anthropic/OpenAI/Ollama + fix flaky Docker main push (closes #30)

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -72,21 +72,33 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           SHORT_SHA="${SHA::7}"
-          # Two tags off one build — the floating ":main" pointer is what the quickstart wedge
-          # demo references; ":main-<sha>" is the immutable per-commit reference for anyone who
-          # needs reproducibility.
-          sbt \
-            -Ddocker.username="ghcr.io/${GHCR_OWNER}" \
-            "set server / Docker / dockerRepository := Some(\"ghcr.io/${GHCR_OWNER}\")" \
-            "set server / Docker / dockerUpdateLatest := false" \
-            "set server / Docker / version := \"main\"" \
-            "server / Docker / publish"
-          sbt \
-            -Ddocker.username="ghcr.io/${GHCR_OWNER}" \
-            "set server / Docker / dockerRepository := Some(\"ghcr.io/${GHCR_OWNER}\")" \
-            "set server / Docker / dockerUpdateLatest := false" \
-            "set server / Docker / version := \"main-${SHORT_SHA}\"" \
-            "server / Docker / publish"
+          # The floating ":main" pointer is what the quickstart wedge demo references; ":main-<sha>"
+          # is the immutable per-commit reference for anyone who needs reproducibility.
+          #
+          # GHCR intermittently rejects the manifest push with "unknown blob" even after every layer
+          # has uploaded — a transient registry race, NOT a build failure (the image builds + stages
+          # cleanly, and the identical Docker config pushed fine on the prior commit). Retry the
+          # publish a few times so a flaky push doesn't red-X an otherwise-good main build.
+          publish_tag() {
+            local tag="$1"
+            local attempt
+            for attempt in 1 2 3; do
+              if sbt \
+                -Ddocker.username="ghcr.io/${GHCR_OWNER}" \
+                "set server / Docker / dockerRepository := Some(\"ghcr.io/${GHCR_OWNER}\")" \
+                "set server / Docker / dockerUpdateLatest := false" \
+                "set server / Docker / version := \"${tag}\"" \
+                "server / Docker / publish"; then
+                return 0
+              fi
+              echo "::warning::docker publish of :${tag} failed (attempt ${attempt}/3); retrying in 20s"
+              sleep 20
+            done
+            echo "::error::docker publish of :${tag} failed after 3 attempts"
+            return 1
+          }
+          publish_tag "main"
+          publish_tag "main-${SHORT_SHA}"
 
       - name: Note image tags
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **Pluggable LLM provider SPI + adapters (#30, ROADMAP 2.1.c).** The `LlmClient[F]` SPI in `aegis-agent-ai`
+  now has three bundled, config-selected adapters: **Anthropic** (`POST /v1/messages`) and **OpenAI**
+  (`POST /v1/chat/completions`) for the "pair with your existing AI vendor" path, and **Ollama**
+  (`POST /api/generate`) for local/private use — audit data never leaves the host. `LlmClient.fromConfig`
+  selects by name (`none` → disabled, returns no client; unknown name fails fast). Adapters call through a
+  tiny testable `LlmHttp` seam (JDK-backed default), so each provider's request shape and response parsing are
+  unit-tested with no network or API key. The contract stays read-only — the model only ever
+  describes/recommends, never executes a crypto op. (Bedrock is the remaining fast-follow — it needs AWS
+  SigV4; the SPI is provider-shaped for it. Wired into a running feature by `advisor explain`, #29.)
+
 - **`aegis advisor scan` — read-only audit triage (closes #28, ROADMAP 2.1.a).** The first slice of the
   v0.2.1 LLM-advisor wedge, deliberately *deterministic* (no LLM, no mutation): it aggregates the audit log
   into a bounded operator summary — idle keys, broad-scope agents, active anomalies, and the riskiest agents.
@@ -28,6 +38,12 @@ All notable changes to Aegis will be documented here. This project follows
     server-tier; no Pekko added to the library tier).
 
 ### Fixed
+
+- **`Docker (main)` workflow flaked on a transient GHCR push.** The `:main` image build/push intermittently
+  red-X'd with `unknown blob` even though the image built and every layer uploaded — a registry-side manifest
+  race, not a build failure. The publish step now retries up to 3× with backoff so a flaky push no longer
+  fails an otherwise-good `main` build. (`release.yml` has the same single-shot publish and would benefit from
+  the same treatment.)
 
 - **Honey-key auto-revoke never fired (regression in #26).** Two gaps meant a honey-key touch
   produced the `HoneyKey`/High recommendation but no `Revoke` action: (1) `AutoResponder.DefaultRules`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,7 +107,7 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 |---|---|---|---|
 | 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; deterministic (LLM narration via 2.1.c later) | Wedge | 🚧 |
 | 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | 🔜 |
-| 2.1.c | Pluggable LLM provider (OpenAI / Anthropic / Bedrock / Ollama for local) | Wedge | 💡 |
+| 2.1.c | Pluggable LLM provider — `LlmClient` SPI + Anthropic + OpenAI + Ollama shipped (Bedrock fast-follow) | Wedge | 🚧 |
 | 2.1.d | Prompt safety: never executes mutations; structured output schemas; refuses arbitrary queries | Wedge | 🔜 |
 
 **Demo target:** "`aegis advisor scan` returns 'these 3 keys haven't been used in 60 days, these 2 agents have unusually broad scopes, there are no active anomalies.'"

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AnthropicLlmClient.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AnthropicLlmClient.scala
@@ -1,0 +1,57 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax.*
+
+/** Anthropic Messages API adapter (`POST {baseUrl}/v1/messages`).
+  *
+  * Cloud provider for the "pair Aegis with your existing AI vendor" pitch. Auth is the `x-api-key` header
+  * (NOT a bearer token); the `anthropic-version` header is required by the API. The system instruction maps
+  * to the request's top-level `system` field and the audit context to a single user message — the advisor
+  * never needs multi-turn. The reply text is the first `text` block of the `content` array.
+  *
+  * Defaults to the `claude-sonnet-4-6` model (a balanced choice for narration); override via `config.model`.
+  */
+final class AnthropicLlmClient(config: LlmClient.Config, http: LlmHttp) extends LlmClient[IO]:
+
+  private val baseUrl = config.baseUrl.getOrElse("https://api.anthropic.com").stripSuffix("/")
+  private val model   = config.model.getOrElse("claude-sonnet-4-6")
+
+  def plan(prompt: String, context: String): IO[String] =
+    config.apiKey match
+      case None =>
+        IO.raiseError(
+          LlmError(
+            "anthropic provider requires an API key (set aegis.advisor.llm.api-key / AEGIS_ADVISOR_LLM_API_KEY)"
+          )
+        )
+      case Some(apiKey) =>
+        val body = Json
+          .obj(
+            "model"      -> model.asJson,
+            "max_tokens" -> config.maxTokens.asJson,
+            "system"     -> prompt.asJson,
+            "messages"   -> Json.arr(Json.obj("role" -> "user".asJson, "content" -> context.asJson))
+          )
+          .noSpaces
+        val headers = Map(
+          "x-api-key"         -> apiKey,
+          "anthropic-version" -> "2023-06-01",
+          "content-type"      -> "application/json"
+        )
+        http.post(s"$baseUrl/v1/messages", headers, body).flatMap(parseReply)
+
+  private def parseReply(res: LlmHttp.Response): IO[String] =
+    if res.status != 200 then
+      IO.raiseError(LlmError(s"anthropic returned ${res.status}: ${res.body.take(300)}"))
+    else
+      IO.fromEither(
+        parse(res.body)
+          .flatMap(_.hcursor.downField("content").downArray.downField("text").as[String])
+          .left
+          .map(e =>
+            LlmError(s"could not parse anthropic response: ${e.getMessage}; body: ${res.body.take(300)}")
+          )
+      )

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/LlmClient.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/LlmClient.scala
@@ -1,13 +1,65 @@
 package dev.aegiskms.agent
 
-/** SPI for LLM providers used by the AI policy and natural-language admin features. Bundled backends:
-  * Anthropic, OpenAI, Ollama.
+import cats.effect.IO
+
+/** SPI for pluggable LLM providers (#30, ROADMAP 2.1.c).
   *
-  * The contract is deliberately narrow: Aegis-KMS only ever asks the LLM to produce a structured plan of
-  * domain commands. The LLM never signs a cryptographic operation itself.
+  * The advisor's natural-language features (`advisor explain`, #29) call `plan` to turn a structured
+  * instruction plus a block of audit context into a human-readable answer. The contract is deliberately
+  * narrow and **read-only**: Aegis-KMS only ever asks the model to *describe* or *recommend* — it never lets
+  * the model execute a cryptographic operation. That guarantee lives in the calling code, not the model.
+  *
+  * Bundled adapters: [[AnthropicLlmClient]] + [[OpenAiLlmClient]] (cloud — "pair with your existing AI
+  * vendor") and [[OllamaLlmClient]] (local — privacy-preserving, no data leaves the host). Providers are
+  * selected at boot via [[LlmClient.fromConfig]]; `provider = none` yields no client and callers skip
+  * narration entirely.
   */
 trait LlmClient[F[_]]:
+  /** Produce a completion. `prompt` is the system instruction (what to do); `context` is the data to reason
+    * over (e.g. an agent's audit timeline). Returns the model's text answer.
+    */
   def plan(prompt: String, context: String): F[String]
+
+object LlmClient:
+
+  /** Selection + connection settings for the bundled providers. Parsed from HOCON / env by `Server.boot` (it
+    * owns the Typesafe Config dependency) and handed to [[fromConfig]]; keeping it a plain case class lets
+    * the adapters and factory stay testable without a config library.
+    *
+    *   - `provider` — `none` | `anthropic` | `openai` | `ollama` (case-insensitive). Unknown values fail
+    *     fast.
+    *   - `apiKey` — required by cloud providers (Anthropic, OpenAI); ignored by Ollama.
+    *   - `baseUrl` — overrides the provider default (Anthropic `https://api.anthropic.com`, OpenAI
+    *     `https://api.openai.com`, Ollama `http://localhost:11434`). Useful for proxies, gateways, stubbing.
+    *   - `model` — provider default applies when absent.
+    *   - `maxTokens` — completion cap for cloud providers (Ollama manages its own).
+    */
+  final case class Config(
+      provider: String,
+      apiKey: Option[String] = None,
+      baseUrl: Option[String] = None,
+      model: Option[String] = None,
+      maxTokens: Int = 1024
+  )
+
+  /** Build the configured provider, or `None` when LLM features are disabled (`provider = none`/empty).
+    * Throws [[LlmError]] on an unrecognised provider name so a typo in config fails the boot rather than
+    * silently disabling narration.
+    */
+  def fromConfig(config: Config, http: LlmHttp): Option[LlmClient[IO]] =
+    config.provider.trim.toLowerCase match
+      case "" | "none" | "disabled" => None
+      case "anthropic"              => Some(new AnthropicLlmClient(config, http))
+      case "openai"                 => Some(new OpenAiLlmClient(config, http))
+      case "ollama"                 => Some(new OllamaLlmClient(config, http))
+      case other =>
+        throw LlmError(s"unknown LLM provider '$other' (expected one of: none, anthropic, openai, ollama)")
+
+/** Failure raised by an LLM adapter — a missing credential, a non-2xx provider response, or an unparseable
+  * body. Carried through `IO.raiseError` so callers can fall back (e.g. `advisor explain` degrades to the
+  * deterministic timeline when narration fails).
+  */
+final case class LlmError(message: String) extends RuntimeException(message)
 
 /** Advisory recommendation produced by the AI module. */
 final case class PolicyRecommendation(

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/LlmHttp.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/LlmHttp.scala
@@ -1,0 +1,36 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.time.Duration
+
+/** Minimal HTTP seam for the LLM provider adapters.
+  *
+  * Mirrors the CLI's `HttpPort`: a one-method port so adapters can be unit-tested with a hand-rolled stub —
+  * asserting the request shape and returning canned JSON — with no live network and no real API key. The
+  * advisor only ever issues a single bounded request/response completion, so streaming is out of scope; the
+  * JDK-backed default is sufficient and drags in no new dependency.
+  */
+trait LlmHttp:
+  def post(url: String, headers: Map[String, String], body: String): IO[LlmHttp.Response]
+
+object LlmHttp:
+
+  final case class Response(status: Int, body: String)
+
+  /** JDK `HttpClient`-backed implementation. The blocking `send` is wrapped in `IO.blocking` so it runs on
+    * the blocking pool rather than starving a compute thread on a slow model.
+    */
+  def jdk(timeout: Duration = Duration.ofSeconds(30)): LlmHttp = new LlmHttp:
+    private val client = HttpClient.newHttpClient()
+
+    def post(url: String, headers: Map[String, String], body: String): IO[Response] =
+      IO.blocking {
+        val builder = HttpRequest.newBuilder().uri(URI.create(url)).timeout(timeout)
+        headers.foreach { case (k, v) => builder.header(k, v) }
+        builder.POST(HttpRequest.BodyPublishers.ofString(body))
+        val res = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+        Response(res.statusCode(), Option(res.body()).getOrElse(""))
+      }

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/OllamaLlmClient.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/OllamaLlmClient.scala
@@ -1,0 +1,46 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax.*
+
+/** Ollama adapter (`POST {baseUrl}/api/generate`).
+  *
+  * Local provider for privacy-conscious shops: the model runs on the operator's own host (default
+  * `http://localhost:11434`) so audit data never leaves the network. No API key. The system instruction and
+  * the audit context are concatenated into the single `prompt` field, and `stream` is forced to `false` so
+  * the whole completion arrives in one JSON body (the advisor wants the full answer, not a token stream). The
+  * reply text is the `response` field.
+  *
+  * Defaults to the `llama3` model; override via `config.model`.
+  */
+final class OllamaLlmClient(config: LlmClient.Config, http: LlmHttp) extends LlmClient[IO]:
+
+  private val baseUrl = config.baseUrl.getOrElse("http://localhost:11434").stripSuffix("/")
+  private val model   = config.model.getOrElse("llama3")
+
+  def plan(prompt: String, context: String): IO[String] =
+    val body = Json
+      .obj(
+        "model"  -> model.asJson,
+        "prompt" -> s"$prompt\n\n$context".asJson,
+        "stream" -> false.asJson
+      )
+      .noSpaces
+    http
+      .post(s"$baseUrl/api/generate", Map("content-type" -> "application/json"), body)
+      .flatMap(parseReply)
+
+  private def parseReply(res: LlmHttp.Response): IO[String] =
+    if res.status != 200 then
+      IO.raiseError(LlmError(s"ollama returned ${res.status}: ${res.body.take(300)}"))
+    else
+      IO.fromEither(
+        parse(res.body)
+          .flatMap(_.hcursor.downField("response").as[String])
+          .left
+          .map(e =>
+            LlmError(s"could not parse ollama response: ${e.getMessage}; body: ${res.body.take(300)}")
+          )
+      )

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/OpenAiLlmClient.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/OpenAiLlmClient.scala
@@ -1,0 +1,60 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import io.circe.Json
+import io.circe.parser.parse
+import io.circe.syntax.*
+
+/** OpenAI Chat Completions API adapter (`POST {baseUrl}/v1/chat/completions`).
+  *
+  * Cloud provider, bearer-token auth (`Authorization: Bearer <key>`). The system instruction and audit
+  * context map to a two-message `messages` array (`system` + `user`); the advisor never needs multi-turn. The
+  * reply text is `choices[0].message.content`. The `baseUrl` override also targets OpenAI-compatible gateways
+  * (Azure OpenAI proxies, LiteLLM, vLLM's OpenAI server, etc.).
+  *
+  * Defaults to the `gpt-4o-mini` model (cheap + capable enough for narration); override via `config.model`.
+  */
+final class OpenAiLlmClient(config: LlmClient.Config, http: LlmHttp) extends LlmClient[IO]:
+
+  private val baseUrl = config.baseUrl.getOrElse("https://api.openai.com").stripSuffix("/")
+  private val model   = config.model.getOrElse("gpt-4o-mini")
+
+  def plan(prompt: String, context: String): IO[String] =
+    config.apiKey match
+      case None =>
+        IO.raiseError(
+          LlmError(
+            "openai provider requires an API key (set aegis.advisor.llm.api-key / AEGIS_ADVISOR_LLM_API_KEY)"
+          )
+        )
+      case Some(apiKey) =>
+        val body = Json
+          .obj(
+            "model"      -> model.asJson,
+            "max_tokens" -> config.maxTokens.asJson,
+            "messages" -> Json.arr(
+              Json.obj("role" -> "system".asJson, "content" -> prompt.asJson),
+              Json.obj("role" -> "user".asJson, "content"   -> context.asJson)
+            )
+          )
+          .noSpaces
+        val headers = Map(
+          "authorization" -> s"Bearer $apiKey",
+          "content-type"  -> "application/json"
+        )
+        http.post(s"$baseUrl/v1/chat/completions", headers, body).flatMap(parseReply)
+
+  private def parseReply(res: LlmHttp.Response): IO[String] =
+    if res.status != 200 then
+      IO.raiseError(LlmError(s"openai returned ${res.status}: ${res.body.take(300)}"))
+    else
+      IO.fromEither(
+        parse(res.body)
+          .flatMap(
+            _.hcursor.downField("choices").downArray.downField("message").downField("content").as[String]
+          )
+          .left
+          .map(e =>
+            LlmError(s"could not parse openai response: ${e.getMessage}; body: ${res.body.take(300)}")
+          )
+      )

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/LlmClientSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/LlmClientSpec.scala
@@ -1,0 +1,137 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.circe.parser.parse
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Tests for the pluggable LLM providers (#30).
+  *
+  * The adapters are exercised through a stub [[LlmHttp]] that captures the outbound request (so we can assert
+  * the exact wire shape each provider sends) and returns a canned body — no network, no API key. This pins
+  * the request contract and the response-parsing for Anthropic + Ollama, plus the `fromConfig` selection.
+  */
+final class LlmClientSpec extends AnyFunSuite with Matchers:
+
+  /** A stub transport that records the last request and replays a fixed response. */
+  final private class CapturingHttp(status: Int, body: String) extends LlmHttp:
+    var lastUrl: String                  = ""
+    var lastHeaders: Map[String, String] = Map.empty
+    var lastBody: String                 = ""
+    def post(url: String, headers: Map[String, String], reqBody: String): IO[LlmHttp.Response] =
+      IO {
+        lastUrl = url; lastHeaders = headers; lastBody = reqBody
+        LlmHttp.Response(status, body)
+      }
+
+  // ── Anthropic ──────────────────────────────────────────────────────────────
+
+  test("Anthropic adapter posts to /v1/messages with x-api-key + version and parses the text block") {
+    val http = new CapturingHttp(200, """{"content":[{"type":"text","text":"all quiet"}]}""")
+    val client = new AnthropicLlmClient(
+      LlmClient.Config(provider = "anthropic", apiKey = Some("sk-test"), model = Some("claude-sonnet-4-6")),
+      http
+    )
+    val out = client.plan("be terse", "agent-7a3 did 3 things").unsafeRunSync()
+    out shouldBe "all quiet"
+    http.lastUrl shouldBe "https://api.anthropic.com/v1/messages"
+    http.lastHeaders("x-api-key") shouldBe "sk-test"
+    http.lastHeaders("anthropic-version") shouldBe "2023-06-01"
+    val json = parse(http.lastBody).toOption.get.hcursor
+    json.get[String]("model").toOption shouldBe Some("claude-sonnet-4-6")
+    json.get[String]("system").toOption shouldBe Some("be terse")
+    json.downField("messages").downArray.get[String]("content").toOption shouldBe Some(
+      "agent-7a3 did 3 things"
+    )
+  }
+
+  test("Anthropic adapter without an API key fails with a clear LlmError") {
+    val client =
+      new AnthropicLlmClient(LlmClient.Config(provider = "anthropic"), new CapturingHttp(200, "{}"))
+    val err = client.plan("x", "y").attempt.unsafeRunSync()
+    err.left.toOption.get shouldBe a[LlmError]
+    err.left.toOption.get.getMessage should include("requires an API key")
+  }
+
+  test("Anthropic adapter surfaces a non-200 as an LlmError carrying the status") {
+    val http   = new CapturingHttp(429, """{"error":"overloaded"}""")
+    val client = new AnthropicLlmClient(LlmClient.Config(provider = "anthropic", apiKey = Some("k")), http)
+    val err    = client.plan("x", "y").attempt.unsafeRunSync()
+    err.left.toOption.get.getMessage should include("429")
+  }
+
+  test("Anthropic adapter honours a baseUrl override (gateway / stub)") {
+    val http = new CapturingHttp(200, """{"content":[{"type":"text","text":"ok"}]}""")
+    val client = new AnthropicLlmClient(
+      LlmClient.Config(provider = "anthropic", apiKey = Some("k"), baseUrl = Some("https://gw.internal/")),
+      http
+    )
+    client.plan("p", "c").unsafeRunSync()
+    http.lastUrl shouldBe "https://gw.internal/v1/messages"
+  }
+
+  // ── OpenAI ─────────────────────────────────────────────────────────────────
+
+  test(
+    "OpenAI adapter posts to /v1/chat/completions with bearer auth and parses choices[0].message.content"
+  ) {
+    val http = new CapturingHttp(200, """{"choices":[{"message":{"role":"assistant","content":"steady"}}]}""")
+    val client = new OpenAiLlmClient(
+      LlmClient.Config(provider = "openai", apiKey = Some("sk-oai"), model = Some("gpt-4o-mini")),
+      http
+    )
+    val out = client.plan("be brief", "agent-7a3 timeline").unsafeRunSync()
+    out shouldBe "steady"
+    http.lastUrl shouldBe "https://api.openai.com/v1/chat/completions"
+    http.lastHeaders("authorization") shouldBe "Bearer sk-oai"
+    val json = parse(http.lastBody).toOption.get.hcursor
+    json.get[String]("model").toOption shouldBe Some("gpt-4o-mini")
+    val messages = json.downField("messages")
+    messages.downN(0).get[String]("role").toOption shouldBe Some("system")
+    messages.downN(0).get[String]("content").toOption shouldBe Some("be brief")
+    messages.downN(1).get[String]("role").toOption shouldBe Some("user")
+    messages.downN(1).get[String]("content").toOption shouldBe Some("agent-7a3 timeline")
+  }
+
+  test("OpenAI adapter without an API key fails with a clear LlmError") {
+    val client = new OpenAiLlmClient(LlmClient.Config(provider = "openai"), new CapturingHttp(200, "{}"))
+    val err    = client.plan("x", "y").attempt.unsafeRunSync()
+    err.left.toOption.get.getMessage should include("requires an API key")
+  }
+
+  // ── Ollama ─────────────────────────────────────────────────────────────────
+
+  test("Ollama adapter posts to /api/generate with stream=false and parses the response field") {
+    val http   = new CapturingHttp(200, """{"response":"local answer","done":true}""")
+    val client = new OllamaLlmClient(LlmClient.Config(provider = "ollama", model = Some("llama3")), http)
+    val out    = client.plan("summarize", "events here").unsafeRunSync()
+    out shouldBe "local answer"
+    http.lastUrl shouldBe "http://localhost:11434/api/generate"
+    val json = parse(http.lastBody).toOption.get.hcursor
+    json.get[Boolean]("stream").toOption shouldBe Some(false)
+    json.get[String]("prompt").toOption.get should include("summarize")
+    json.get[String]("prompt").toOption.get should include("events here")
+  }
+
+  // ── fromConfig selection ─────────────────────────────────────────────────────
+
+  test("fromConfig returns None when the provider is none/empty/disabled") {
+    val http = new CapturingHttp(200, "{}")
+    LlmClient.fromConfig(LlmClient.Config(provider = "none"), http) shouldBe None
+    LlmClient.fromConfig(LlmClient.Config(provider = ""), http) shouldBe None
+    LlmClient.fromConfig(LlmClient.Config(provider = "DISABLED"), http) shouldBe None
+  }
+
+  test("fromConfig selects the named provider (case-insensitive) and throws on an unknown name") {
+    val http = new CapturingHttp(200, "{}")
+    LlmClient.fromConfig(LlmClient.Config(provider = "Anthropic", apiKey = Some("k")), http).get shouldBe a[
+      AnthropicLlmClient
+    ]
+    LlmClient.fromConfig(LlmClient.Config(provider = "OpenAI", apiKey = Some("k")), http).get shouldBe a[
+      OpenAiLlmClient
+    ]
+    LlmClient.fromConfig(LlmClient.Config(provider = "ollama"), http).get shouldBe a[OllamaLlmClient]
+    val ex = intercept[LlmError](LlmClient.fromConfig(LlmClient.Config(provider = "bedrock"), http))
+    ex.getMessage should include("unknown LLM provider 'bedrock'")
+  }


### PR DESCRIPTION
## What

1. **#30 — pluggable LLM provider.** `LlmClient[F]` SPI + three config-selected adapters: **Anthropic** (`/v1/messages`), **OpenAI** (`/v1/chat/completions`), **Ollama** (`/api/generate`, local/private).

`LlmClient.fromConfig` selects by name: `none` → disabled; unknown → fail fast. Adapters call through a testable `LlmHttp` seam, so request shape and response parsing are unit-tested with no network or API key.

Read-only — the model never executes a crypto op. Bedrock AWS SigV4 is the remaining fast-follow; the SPI is provider-shaped for it. Wired into a running feature by `advisor explain` (#29).

2. **Fix Docker main flake.** The `:main` push intermittently failed GHCR with `unknown blob`, a transient manifest race after the image built and all layers uploaded.

Verified: image builds and stages cleanly; identical config pushed fine on the prior commit. The publish step now retries 3× with backoff. `release.yml` has the same single-shot publish and would benefit from the same treatment in a follow-up.

## Tests

`LlmClientSpec` — 9 cases covering per-provider request shape and response parse, missing-key and non-200 errors, `fromConfig` selection, and unknown-name failure.

Full agent-ai suite 71/71; scalafmt + scalafix + `Test / compile` green. Docker image staged locally to confirm build-side health.

Closes #30