### PR TITLE
feat: advisor explain agent timeline + LLM narration (closes #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to Aegis will be documented here. This project follows
 
 ### Added
 
+- **`aegis advisor explain <agent-id>` — agent-session timeline + LLM narration (closes #29, ROADMAP
+  2.1.b/2.1.d).** The last piece of the v0.2.1 LLM-advisor wedge: assembles one agent's audit timeline
+  (chronological events, risk scores, anomaly flags + a deterministic summary) and — when an LLM provider is
+  configured (#30) — narrates it in plain language. **Read-only and safe by construction** (2.1.d): the model
+  is handed only the structured timeline under a strict read-only system prompt, the prompt is bounded by a
+  `maxEvents` cap, and any LLM failure **degrades gracefully** to the bare deterministic timeline rather than
+  erroring. With `aegis.advisor.llm.provider=none` (the default) there are no outbound calls at all.
+  - **`AdvisorService.explain`** (`aegis-agent-ai`): pages the audit log filtered to the agent, builds the
+    timeline via the pure `AdvisorExplain.timeline`, then optionally narrates via the injected `LlmClient`.
+  - **`GET /v1/advisor/explain/{agentId}`** (`aegis-http`): human-only, `501` when no advisor is wired; knobs
+    `lookbackDays` / `maxEvents`.
+  - **`aegis advisor explain <agent-id>`** (`aegis-cli`): prints the narrative (when present) followed by the
+    event timeline.
+  - **Wiring**: `Server.boot` now builds the LLM provider from `aegis.advisor.llm.*` and threads it into the
+    advisor — the integration point for #30. New `application.conf` `aegis.advisor.llm` block (provider /
+    api-key / base-url / model / max-tokens, all env-overridable; defaults to `provider=none`).
+
 - **Pluggable LLM provider SPI + adapters (#30, ROADMAP 2.1.c).** The `LlmClient[F]` SPI in `aegis-agent-ai`
   now has three bundled, config-selected adapters: **Anthropic** (`POST /v1/messages`) and **OpenAI**
   (`POST /v1/chat/completions`) for the "pair with your existing AI vendor" path, and **Ollama**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,9 +106,9 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 | # | Capability | Area | Status |
 |---|---|---|---|
 | 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; deterministic (LLM narration via 2.1.c later) | Wedge | 🚧 |
-| 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | 🔜 |
+| 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | 🚧 |
 | 2.1.c | Pluggable LLM provider — `LlmClient` SPI + Anthropic + OpenAI + Ollama shipped (Bedrock fast-follow) | Wedge | 🚧 |
-| 2.1.d | Prompt safety: never executes mutations; structured output schemas; refuses arbitrary queries | Wedge | 🔜 |
+| 2.1.d | Prompt safety: read-only system prompt, bounded structured input, graceful LLM-failure fallback | Wedge | 🚧 |
 
 **Demo target:** "`aegis advisor scan` returns 'these 3 keys haven't been used in 60 days, these 2 agents have unusually broad scopes, there are no active anomalies.'"
 

--- a/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AdvisorService.scala
+++ b/modules/aegis-agent-ai/src/main/scala/dev/aegiskms/agent/AdvisorService.scala
@@ -20,6 +20,11 @@ import java.time.{Duration, Instant}
 trait AdvisorService[F[_]]:
   def scan(request: AdvisorScan.Request): F[AdvisorScan.Report]
 
+  /** Explain one agent's session (#29, ROADMAP 2.1.b): assemble the agent's audit timeline and — when an
+    * [[LlmClient]] is configured — narrate it in plain language. Read-only; never touches `KeyService`.
+    */
+  def explain(request: AdvisorExplain.Request): F[AdvisorExplain.Report]
+
 object AdvisorService:
 
   /** Hard cap on the number of audit rows a single scan will pull into memory. A scan is an operator triage
@@ -32,36 +37,71 @@ object AdvisorService:
   /** Page size for the underlying [[AuditQuery]] paging loop — the SPI's own per-request maximum. */
   val PageSize: Int = AuditQuery.MaxLimit
 
-  /** Deterministic implementation backed by an [[AuditQuery]]. Pages through `[now - lookback, now)` up to
-    * [[MaxScan]] rows, then folds the records into a [[AdvisorScan.Report]] via [[AdvisorScan.analyze]].
+  /** Deterministic implementation backed by an [[AuditQuery]], optionally narrated by an [[LlmClient]].
+    *
+    * `scan` pages `[now - lookback, now)` and folds the records via [[AdvisorScan.analyze]] — purely
+    * deterministic, no LLM. `explain` pages the same window filtered to one agent's `actor`, builds a
+    * deterministic timeline, and — when `llm` is present — adds a natural-language narrative on top (falling
+    * back to the bare timeline if narration fails). The `llm` is `None` when
+    * `aegis.advisor.llm.provider=none`.
     */
-  def deterministic(reader: AuditQuery[IO]): AdvisorService[IO] = new AdvisorService[IO]:
-    def scan(request: AdvisorScan.Request): IO[AdvisorScan.Report] =
-      val windowEnd   = request.now
-      val windowStart = request.now.minus(request.lookback)
+  def deterministic(reader: AuditQuery[IO], llm: Option[LlmClient[IO]] = None): AdvisorService[IO] =
+    new AdvisorService[IO]:
 
-      def loop(offset: Int, acc: Vector[AuditRecord]): IO[(Vector[AuditRecord], Boolean)] =
-        if acc.sizeIs >= MaxScan then IO.pure((acc, true))
-        else
-          reader
-            .query(
-              AuditQuery.Filter(
-                since = Some(windowStart),
-                until = Some(windowEnd),
-                limit = PageSize,
-                offset = offset
-              )
-            )
-            .flatMap { page =>
+      /** Page the audit log under `filterFor(offset)` up to [[MaxScan]] rows. Returns the records plus a
+        * `truncated` flag (true iff the cap was hit with more rows available).
+        */
+      private def pageAll(filterFor: Int => AuditQuery.Filter): IO[(Vector[AuditRecord], Boolean)] =
+        def loop(offset: Int, acc: Vector[AuditRecord]): IO[(Vector[AuditRecord], Boolean)] =
+          if acc.sizeIs >= MaxScan then IO.pure((acc, true))
+          else
+            reader.query(filterFor(offset)).flatMap { page =>
               val next = acc ++ page.records
               if page.records.isEmpty then IO.pure((next, false)) // no progress; stop
               else if page.hasMore then loop(offset + page.records.size, next)
               else IO.pure((next, false)) // window exhausted
             }
+        loop(0, Vector.empty)
 
-      loop(0, Vector.empty).map { case (records, truncated) =>
-        AdvisorScan.analyze(request, windowStart, windowEnd, records.toList, truncated)
-      }
+      def scan(request: AdvisorScan.Request): IO[AdvisorScan.Report] =
+        val windowEnd   = request.now
+        val windowStart = request.now.minus(request.lookback)
+        pageAll(off =>
+          AuditQuery.Filter(
+            since = Some(windowStart),
+            until = Some(windowEnd),
+            limit = PageSize,
+            offset = off
+          )
+        )
+          .map { case (records, truncated) =>
+            AdvisorScan.analyze(request, windowStart, windowEnd, records.toList, truncated)
+          }
+
+      def explain(request: AdvisorExplain.Request): IO[AdvisorExplain.Report] =
+        val windowEnd   = request.now
+        val windowStart = request.now.minus(request.lookback)
+        pageAll(off =>
+          AuditQuery.Filter(
+            since = Some(windowStart),
+            until = Some(windowEnd),
+            actor = Some(request.agentId),
+            limit = PageSize,
+            offset = off
+          )
+        ).flatMap { case (records, truncated) =>
+          val base = AdvisorExplain.timeline(request, windowStart, windowEnd, records.toList, truncated)
+          // Narrate with the LLM when configured; degrade to the bare timeline on any failure so
+          // `explain` is never worse than the deterministic facts (prompt safety + graceful fallback).
+          llm match
+            case None                           => IO.pure(base)
+            case Some(_) if base.events.isEmpty => IO.pure(base) // nothing to narrate
+            case Some(client) =>
+              client
+                .plan(AdvisorExplain.SystemPrompt, AdvisorExplain.renderContext(base))
+                .map(text => base.copy(narrative = Some(text.trim)))
+                .handleError(_ => base)
+        }
 
 /** Request, result, and the pure analysis for an advisor scan. `analyze` is split out from the IO-bound
   * paging so the heuristics can be property-tested against synthetic records without a live audit store.
@@ -221,3 +261,125 @@ object AdvisorScan:
     lower.contains("step-up") ||
     lower.contains("denied") ||
     lower.contains("alert")
+
+/** Request, result, and the pure timeline builder for `advisor explain` (#29). The deterministic timeline is
+  * built here (testable without a live store); the optional LLM narration is added by
+  * [[AdvisorService.deterministic]] on top of this.
+  */
+object AdvisorExplain:
+
+  val DefaultLookback: Duration = Duration.ofDays(90)
+  val DefaultMaxEvents: Int     = 200
+
+  /** System instruction for the narration. Read-only by construction: the model is told to summarise the
+    * supplied facts only, never to invent, and never to suggest executing operations (ROADMAP 2.1.d).
+    */
+  val SystemPrompt: String =
+    "You are a security-operations assistant for a key-management service. Summarise the following agent " +
+      "audit timeline for a human operator in 2-4 short paragraphs: what the agent did, why any anomaly or " +
+      "recommendation fired, and what automated action (if any) was taken. Use ONLY the facts provided — do " +
+      "not invent keys, agents, or events. You are read-only: never instruct or imply that any cryptographic " +
+      "operation should be executed."
+
+  /** Explain parameters.
+    *
+    *   - `agentId` — the agent subject to explain (matched against `actor` in the audit log).
+    *   - `now` / `lookback` — window `[now - lookback, now)` over which to read the agent's activity.
+    *   - `maxEvents` — cap on the number of timeline events kept (most recent first), bounding the LLM
+    *     prompt.
+    */
+  final case class Request(
+      agentId: String,
+      now: Instant,
+      lookback: Duration = DefaultLookback,
+      maxEvents: Int = DefaultMaxEvents
+  )
+
+  /** One audit event in the agent's timeline. `riskScore` / `anomaly` are surfaced so the narrative (and the
+    * operator) can see *why* a step mattered.
+    */
+  final case class Event(
+      at: Instant,
+      operation: String,
+      resource: String,
+      outcome: String,
+      riskScore: Option[Double],
+      anomaly: Boolean
+  )
+
+  /** Deterministic roll-up of the timeline — always present, even when no LLM is configured. */
+  final case class Summary(
+      totalEvents: Int,
+      distinctOps: List[String],
+      anomalies: Int,
+      firstSeen: Option[Instant],
+      lastSeen: Option[Instant]
+  )
+
+  /** The explain result. `narrative` is `Some` only when an LLM provider is configured and the call
+    * succeeded; otherwise consumers render the deterministic `events` + `summary`.
+    */
+  final case class Report(
+      agentId: String,
+      windowStart: Instant,
+      windowEnd: Instant,
+      summary: Summary,
+      events: List[Event],
+      narrative: Option[String],
+      truncated: Boolean
+  )
+
+  /** Build the deterministic timeline + summary for an agent from its audit records (chronological). */
+  def timeline(
+      request: Request,
+      windowStart: Instant,
+      windowEnd: Instant,
+      records: List[AuditRecord],
+      truncated: Boolean
+  ): Report =
+    val chronological = records.sortBy(_.at)
+    val allEvents = chronological.map { r =>
+      Event(
+        at = r.at,
+        operation = r.operation.toString,
+        resource = r.resource,
+        outcome = r.outcome,
+        riskScore = r.context.get("risk.score").flatMap(_.toDoubleOption),
+        anomaly = AdvisorScan.isAnomalous(r.outcome)
+      )
+    }
+    // Keep the most recent `maxEvents` (then restore chronological order) so the prompt stays bounded on a
+    // very chatty agent; flag truncation so neither the operator nor the model assumes full coverage.
+    val capped    = allEvents.takeRight(request.maxEvents)
+    val wasCapped = truncated || capped.sizeIs < allEvents.size
+    val summary = Summary(
+      totalEvents = allEvents.size,
+      distinctOps = allEvents.map(_.operation).distinct.sorted,
+      anomalies = allEvents.count(_.anomaly),
+      firstSeen = allEvents.headOption.map(_.at),
+      lastSeen = allEvents.lastOption.map(_.at)
+    )
+    Report(
+      agentId = request.agentId,
+      windowStart = windowStart,
+      windowEnd = windowEnd,
+      summary = summary,
+      events = capped,
+      narrative = None,
+      truncated = wasCapped
+    )
+
+  /** Render the report as the plain-text context handed to the LLM. One line per event, plus a header so the
+    * model has the agent id and coverage. Deterministic — also reused as the CLI's human-readable timeline.
+    */
+  def renderContext(report: Report): String =
+    val header =
+      s"Agent: ${report.agentId}\nWindow: ${report.windowStart} → ${report.windowEnd}\n" +
+        s"Events: ${report.summary.totalEvents} (showing ${report.events.size}), " +
+        s"anomalies: ${report.summary.anomalies}, ops: ${report.summary.distinctOps.mkString(", ")}"
+    val lines = report.events.map { e =>
+      val risk    = e.riskScore.map(s => f" risk=$s%.2f").getOrElse("")
+      val flagged = if e.anomaly then " [ANOMALY]" else ""
+      s"- ${e.at} ${e.operation} ${e.resource} → ${e.outcome}$risk$flagged"
+    }
+    (header +: lines).mkString("\n")

--- a/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AdvisorExplainSpec.scala
+++ b/modules/aegis-agent-ai/src/test/scala/dev/aegiskms/agent/AdvisorExplainSpec.scala
@@ -1,0 +1,144 @@
+package dev.aegiskms.agent
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import dev.aegiskms.audit.{AuditQuery, AuditRecord}
+import dev.aegiskms.core.{Operation, Principal}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.time.{Duration, Instant}
+import scala.concurrent.duration.*
+
+/** Tests for `advisor explain` (#29) — the agent-session timeline + optional LLM narration.
+  *
+  * The deterministic timeline is exercised via `AdvisorExplain.timeline`; the IO path (audit paging + LLM
+  * narration + graceful fallback) goes through `AdvisorService.deterministic` with a stub `AuditQuery` and a
+  * stub `LlmClient`.
+  */
+final class AdvisorExplainSpec extends AnyFunSuite with Matchers:
+
+  private val now: Instant     = Instant.parse("2026-06-01T00:00:00Z")
+  private val alice: Principal = Principal.Human("alice@org", Set("admins"))
+
+  private def agent(subject: String): Principal.Agent =
+    Principal.Agent(subject, alice, "test", now.minus(Duration.ofDays(1)), 1.hour, Set(Operation.Get), None)
+
+  private def rec(
+      at: Instant,
+      principal: Principal,
+      op: Operation,
+      resource: String,
+      outcome: String = "Success",
+      context: Map[String, String] = Map.empty
+  ): AuditRecord =
+    AuditRecord(at, principal, op, resource, outcome, "corr", context)
+
+  private val claude = agent("claude-session-7a3")
+  private val req    = AdvisorExplain.Request(agentId = "claude-session-7a3", now = now)
+
+  private def reader(records: List[AuditRecord]): AuditQuery[IO] = new AuditQuery[IO]:
+    def query(filter: AuditQuery.Filter): IO[AuditQuery.Page] =
+      // Honour the actor filter the service sends, and the offset (single page is enough here).
+      val matched = records.filter(r => filter.actor.forall(_ == r.principal.subject))
+      IO.pure(AuditQuery.Page(
+        if filter.offset == 0 then matched else Nil,
+        AuditQuery.MaxLimit,
+        filter.offset,
+        false
+      ))
+
+  test("timeline builds chronological events, flags anomalies, and rolls up a summary") {
+    val report = AdvisorExplain.timeline(
+      req,
+      now.minus(req.lookback),
+      now,
+      List(
+        rec(
+          now.minus(Duration.ofMinutes(10)),
+          claude,
+          Operation.Get,
+          "key:invoice",
+          "Success",
+          Map("risk.score" -> "0.2")
+        ),
+        rec(
+          now.minus(Duration.ofMinutes(5)),
+          claude,
+          Operation.Sign,
+          "key:treasury",
+          "Failed code=PermissionDenied"
+        )
+      ),
+      truncated = false
+    )
+    report.events.map(_.operation) shouldBe List("Get", "Sign") // chronological
+    report.events.head.riskScore shouldBe Some(0.2)
+    report.events(1).anomaly shouldBe true
+    report.summary.totalEvents shouldBe 2
+    report.summary.anomalies shouldBe 1
+    report.summary.distinctOps shouldBe List("Get", "Sign")
+    report.narrative shouldBe None
+  }
+
+  test("explain without an LLM returns the deterministic timeline (no narrative)") {
+    val records = List(rec(now.minus(Duration.ofMinutes(1)), claude, Operation.Get, "key:invoice"))
+    val report  = AdvisorService.deterministic(reader(records), llm = None).explain(req).unsafeRunSync()
+    report.agentId shouldBe "claude-session-7a3"
+    report.events should have size 1
+    report.narrative shouldBe None
+  }
+
+  test("explain only reads the requested agent's records (actor filter)") {
+    val records = List(
+      rec(now.minus(Duration.ofMinutes(2)), claude, Operation.Get, "key:invoice"),
+      rec(now.minus(Duration.ofMinutes(1)), agent("other-agent"), Operation.Get, "key:other")
+    )
+    val report = AdvisorService.deterministic(reader(records)).explain(req).unsafeRunSync()
+    report.events should have size 1
+    report.events.head.resource shouldBe "key:invoice"
+  }
+
+  test("explain with an LLM adds the narrative and passes the read-only system prompt + timeline context") {
+    var capturedPrompt  = ""
+    var capturedContext = ""
+    val stubLlm = new LlmClient[IO]:
+      def plan(prompt: String, context: String): IO[String] =
+        capturedPrompt = prompt; capturedContext = context
+        IO.pure("  Claude read one invoice key and was denied a treasury signature.  ")
+    val records = List(
+      rec(
+        now.minus(Duration.ofMinutes(5)),
+        claude,
+        Operation.Sign,
+        "key:treasury",
+        "Failed code=PermissionDenied"
+      )
+    )
+    val report = AdvisorService.deterministic(reader(records), Some(stubLlm)).explain(req).unsafeRunSync()
+    report.narrative shouldBe Some(
+      "Claude read one invoice key and was denied a treasury signature."
+    ) // trimmed
+    capturedPrompt should include("read-only")
+    capturedContext should include("claude-session-7a3")
+    capturedContext should include("[ANOMALY]")
+  }
+
+  test("explain degrades to the bare timeline when the LLM call fails") {
+    val failingLlm = new LlmClient[IO]:
+      def plan(prompt: String, context: String): IO[String] = IO.raiseError(LlmError("provider down"))
+    val records = List(rec(now.minus(Duration.ofMinutes(1)), claude, Operation.Get, "key:invoice"))
+    val report  = AdvisorService.deterministic(reader(records), Some(failingLlm)).explain(req).unsafeRunSync()
+    report.narrative shouldBe None // fell back, did not raise
+    report.events should have size 1
+  }
+
+  test("explain skips the LLM entirely when the agent has no events") {
+    var called = false
+    val llm = new LlmClient[IO]:
+      def plan(prompt: String, context: String): IO[String] = { called = true; IO.pure("x") }
+    val report = AdvisorService.deterministic(reader(Nil), Some(llm)).explain(req).unsafeRunSync()
+    report.events shouldBe empty
+    report.narrative shouldBe None
+    called shouldBe false
+  }

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/AegisHttpClient.scala
@@ -177,6 +177,31 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       case 200    => decodeBody[AdvisorScanResponseDto](res.body)
       case status => Left(toError(status, res.body))
 
+  /** GET /v1/advisor/explain/{agentId} — read-only agent timeline, narrated when an LLM provider is
+    * configured server-side (#29). Optional knobs are sent only when overridden.
+    */
+  def advisorExplain(
+      agentId: String,
+      lookbackDays: Option[Int] = None,
+      maxEvents: Option[Int] = None
+  ): Either[ClientError, AdvisorExplainResponseDto] =
+    val params = List(
+      lookbackDays.map(v => "lookbackDays" -> v.toString),
+      maxEvents.map(v => "maxEvents" -> v.toString)
+    ).flatten
+    val qs =
+      if params.isEmpty then ""
+      else
+        params.map { case (k, v) =>
+          s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
+        }.mkString("?", "&", "")
+    val encodedId = java.net.URLEncoder.encode(agentId, java.nio.charset.StandardCharsets.UTF_8)
+    val res =
+      http.execute(HttpPort.Request("GET", url(s"/v1/advisor/explain/$encodedId$qs"), baseHeaders, None))
+    res.status match
+      case 200    => decodeBody[AdvisorExplainResponseDto](res.body)
+      case status => Left(toError(status, res.body))
+
   // ── Helpers ────────────────────────────────────────────────────────────────
 
   private def url(path: String): String =

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -62,6 +62,12 @@ object Cli:
             Commands.advisorScan(makeClient(cfg), lookback, unused, broad, top)
           case Left(msg) => CommandResult.err(s"$msg\n\n${advisorScanHelp}")
 
+      case "advisor" :: "explain" :: rest =>
+        parseAdvisorExplain(rest) match
+          case Right((agentId, lookback, maxEvents)) =>
+            Commands.advisorExplain(makeClient(cfg), agentId, lookback, maxEvents)
+          case Left(msg) => CommandResult.err(s"$msg\n\n${advisorExplainHelp}")
+
       case unknown =>
         CommandResult.err(s"unknown command: ${unknown.mkString(" ")}\n\n${help.stdout}")
 
@@ -382,6 +388,27 @@ object Cli:
       top      <- posInt("--top")
     yield (lookback, unused, broad, top)
 
+  /** Parse `aegis advisor explain <agent-id> [--lookback-days N] [--max-events N]`. The agent id is the first
+    * positional argument; the knobs are optional positive integers.
+    */
+  private[cli] def parseAdvisorExplain(
+      args: List[String]
+  ): Either[String, (String, Option[Int], Option[Int])] =
+    args match
+      case agentId :: rest if !agentId.startsWith("--") =>
+        val flags = parseFlags(rest)
+        def posInt(flag: String): Either[String, Option[Int]] =
+          flags.get(flag) match
+            case None => Right(None)
+            case Some(v) =>
+              v.toIntOption.filter(_ > 0).map(Some(_))
+                .toRight(s"advisor explain: $flag must be a positive integer (was '$v')")
+        for
+          lookback  <- posInt("--lookback-days")
+          maxEvents <- posInt("--max-events")
+        yield (agentId, lookback, maxEvents)
+      case _ => Left("advisor explain: <agent-id> is required as the first argument")
+
   /** Watch-mode loop: print one page, then poll every 2 s for new records (using the last seen `at` as the
     * new `since`). Runs indefinitely until the JVM is killed. Sleeps via `Thread.sleep` because the CLI is
     * synchronous; the rest of the codebase uses cats-effect but dragging IO/IOApp into the CLI's startup path
@@ -459,6 +486,7 @@ object Cli:
       |  aegis audit tail [--since <ISO>] [--until <ISO>] [--actor <subject>] [--key <id>]
       |                   [--op <name>] [--limit <n>] [--offset <n>] [--watch]
       |  aegis advisor scan [--lookback-days <n>] [--unused-days <n>] [--broad-scope <n>] [--top <n>]
+      |  aegis advisor explain <agent-id> [--lookback-days <n>] [--max-events <n>]
       |
       |Config: $AEGIS_CONFIG, or ~/.aegis/config.json
       |Env:    AEGIS_SERVER, AEGIS_USER override the saved config""".stripMargin
@@ -492,6 +520,15 @@ object Cli:
       |  --top <n>            Number of riskiest agents to list (default 5)
       |
       |Read-only triage; never mutates. Requires a server with aegis.audit.kind=postgres.""".stripMargin
+  private val advisorExplainHelp: String =
+    """Usage: aegis advisor explain <agent-id> [knobs]
+      |
+      |  <agent-id>           The agent subject to explain (e.g. claude-session-7a3)
+      |  --lookback-days <n>  How far back to read the agent's activity (default 90)
+      |  --max-events <n>     Cap on timeline events returned (default 200)
+      |
+      |Read-only timeline. A natural-language narrative is added when the server has an
+      |LLM provider configured (aegis.advisor.llm.provider); otherwise the timeline only.""".stripMargin
   private val keysHelp: String =
     """Usage:
       |  aegis keys create --alg <ALG> --name <NAME>

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -2,6 +2,7 @@ package dev.aegiskms.cli
 
 import dev.aegiskms.cli.AegisHttpClient.{ClientError, renderError}
 import dev.aegiskms.cli.WireFormats.{
+  AdvisorExplainResponseDto,
   AdvisorScanResponseDto,
   AuditRecordDto,
   CompromiseRequest,
@@ -334,6 +335,48 @@ object Commands:
     )
 
     List(header, unused, broad, anomalies, riskiest).mkString("\n\n")
+
+  // ── AI advisor explain (#29) ──────────────────────────────────────────────
+
+  /** `aegis advisor explain <agent-id> [--lookback-days N] [--max-events N]`
+    *
+    * Read-only timeline of one agent's session. Calls `GET /v1/advisor/explain/<agentId>`; prints the
+    * natural-language narrative (when the server has an LLM provider configured) followed by the
+    * deterministic event timeline.
+    */
+  def advisorExplain(
+      client: AegisHttpClient,
+      agentId: String,
+      lookbackDays: Option[Int],
+      maxEvents: Option[Int]
+  ): CommandResult =
+    client.advisorExplain(agentId, lookbackDays, maxEvents) match
+      case Right(report) => CommandResult.out(formatAdvisorExplain(report))
+      case Left(err)     => CommandResult.err(renderError(err), exitCodeFor(err))
+
+  private def formatAdvisorExplain(r: AdvisorExplainResponseDto): String =
+    val header =
+      s"""advisor explain — ${r.agentId}
+         |window:   ${r.windowStart} → ${r.windowEnd}
+         |events:   ${r.summary.totalEvents} (showing ${r.events.size}), anomalies: ${r.summary.anomalies}
+         |ops:      ${r.summary.distinctOps.mkString(", ")}""".stripMargin +
+        (if r.truncated then "\n          ⚠ timeline truncated; showing the most recent events" else "")
+
+    val narrativeBlock = r.narrative match
+      case Some(text) => s"\n\nNarrative:\n$text"
+      case None => "\n\n(no narrative — server has no LLM provider configured; showing the timeline only)"
+
+    val timeline =
+      if r.events.isEmpty then "\n\nTimeline:\n  (no recorded activity for this agent in the window)"
+      else
+        val lines = r.events.map { e =>
+          val risk    = e.riskScore.map(s => f" risk=$s%.2f").getOrElse("")
+          val flagged = if e.anomaly then " [ANOMALY]" else ""
+          f"  ${e.at}  ${e.operation}%-10s ${e.resource} → ${e.outcome}$risk$flagged"
+        }
+        "\n\nTimeline:\n" + lines.mkString("\n")
+
+    header + narrativeBlock + timeline
 
   /** Render a single audit record for terminal output. Multi-line; the leading field labels are
     * column-aligned so a glance picks out the actor / operation / outcome quickly.

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/WireFormats.scala
@@ -119,6 +119,44 @@ object WireFormats:
     given Encoder[AdvisorScanResponseDto] = deriveEncoder
     given Decoder[AdvisorScanResponseDto] = deriveDecoder
 
+  // ── Advisor-explain DTOs (mirrors aegis-http/JsonCodecs.AdvisorExplainResponseDto, #29) ──
+
+  final case class ExplainEventDto(
+      at: Instant,
+      operation: String,
+      resource: String,
+      outcome: String,
+      riskScore: Option[Double],
+      anomaly: Boolean
+  )
+  object ExplainEventDto:
+    given Encoder[ExplainEventDto] = deriveEncoder
+    given Decoder[ExplainEventDto] = deriveDecoder
+
+  final case class ExplainSummaryDto(
+      totalEvents: Int,
+      distinctOps: List[String],
+      anomalies: Int,
+      firstSeen: Option[Instant],
+      lastSeen: Option[Instant]
+  )
+  object ExplainSummaryDto:
+    given Encoder[ExplainSummaryDto] = deriveEncoder
+    given Decoder[ExplainSummaryDto] = deriveDecoder
+
+  final case class AdvisorExplainResponseDto(
+      agentId: String,
+      windowStart: Instant,
+      windowEnd: Instant,
+      summary: ExplainSummaryDto,
+      events: List[ExplainEventDto],
+      narrative: Option[String],
+      truncated: Boolean
+  )
+  object AdvisorExplainResponseDto:
+    given Encoder[AdvisorExplainResponseDto] = deriveEncoder
+    given Decoder[AdvisorExplainResponseDto] = deriveDecoder
+
   final case class KmsErrorDto(code: String, message: String)
   object KmsErrorDto:
     given Encoder[KmsErrorDto] = deriveEncoder

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -194,6 +194,38 @@ final class CliSpec extends AnyFunSuite with Matchers:
     r.stderr should include("--top must be a positive integer")
   }
 
+  test("'advisor explain <id>' GETs /v1/advisor/explain/<id> with the parsed knobs") {
+    val report = AdvisorExplainResponseDto(
+      agentId = "claude-session-7a3",
+      windowStart = Instant.parse("2026-03-03T00:00:00Z"),
+      windowEnd = Instant.parse("2026-06-01T00:00:00Z"),
+      summary = ExplainSummaryDto(0, Nil, 0, None, None),
+      events = Nil,
+      narrative = None,
+      truncated = false
+    )
+    var captured: Option[HttpPort.Request] = None
+    val r = Cli.run(
+      List("advisor", "explain", "claude-session-7a3", "--max-events", "50"),
+      cfg,
+      captureFactory(req => captured = Some(req), report.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 0
+    captured.get.method shouldBe "GET"
+    captured.get.url should include("/v1/advisor/explain/claude-session-7a3")
+    captured.get.url should include("maxEvents=50")
+  }
+
+  test("'advisor explain' without an agent id reports a usage error and exits 1") {
+    val r = Cli.run(
+      List("advisor", "explain"),
+      cfg,
+      fakeClientFactory(200, sampleKey.asJson.noSpaces)
+    )
+    r.exitCode shouldBe 1
+    r.stderr should include("<agent-id> is required")
+  }
+
   // ── #79: agent issue ──────────────────────────────────────────────────────
 
   test("'agent issue' missing --label reports a usage error and exits 1") {

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -142,6 +142,60 @@ final class CommandsSpec extends AnyFunSuite with Matchers:
     r.stderr should include("FeatureNotSupported")
   }
 
+  test("advisor explain prints the narrative (when present) and the event timeline") {
+    val report = AdvisorExplainResponseDto(
+      agentId = "claude-session-7a3",
+      windowStart = Instant.parse("2026-03-03T00:00:00Z"),
+      windowEnd = Instant.parse("2026-06-01T00:00:00Z"),
+      summary =
+        ExplainSummaryDto(2, List("Get", "Sign"), 1, Some(Instant.parse("2026-05-31T00:00:00Z")), None),
+      events = List(
+        ExplainEventDto(
+          Instant.parse("2026-05-31T00:00:00Z"),
+          "Get",
+          "key:invoice",
+          "Success",
+          Some(0.2),
+          false
+        ),
+        ExplainEventDto(
+          Instant.parse("2026-05-31T00:05:00Z"),
+          "Sign",
+          "key:treasury",
+          "Failed code=PermissionDenied",
+          None,
+          true
+        )
+      ),
+      narrative = Some("Claude read an invoice key, then was denied a treasury signature."),
+      truncated = false
+    )
+    val r =
+      Commands.advisorExplain(clientReturning(200, report.asJson.noSpaces), "claude-session-7a3", None, None)
+    r.exitCode shouldBe 0
+    r.stdout should include("advisor explain — claude-session-7a3")
+    r.stdout should include("Narrative:")
+    r.stdout should include("denied a treasury signature")
+    r.stdout should include("key:invoice")
+    r.stdout should include("[ANOMALY]")
+  }
+
+  test("advisor explain notes the absence of a narrative when the server has no LLM provider") {
+    val report = AdvisorExplainResponseDto(
+      agentId = "agent-x",
+      windowStart = Instant.parse("2026-03-03T00:00:00Z"),
+      windowEnd = Instant.parse("2026-06-01T00:00:00Z"),
+      summary = ExplainSummaryDto(0, Nil, 0, None, None),
+      events = Nil,
+      narrative = None,
+      truncated = false
+    )
+    val r = Commands.advisorExplain(clientReturning(200, report.asJson.noSpaces), "agent-x", None, None)
+    r.exitCode shouldBe 0
+    r.stdout should include("no narrative")
+    r.stdout should include("no recorded activity")
+  }
+
   test("keys sign prints the base64 signature and algorithm on success") {
     val responseBody = SignResponse("c2lnLWJ5dGVz", "RsaPssSha256").asJson.noSpaces
     val client       = clientReturning(200, responseBody)

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/Endpoints.scala
@@ -398,6 +398,31 @@ object Endpoints:
           "a human principal; service and agent principals are refused with 403."
       )
 
+  /** `GET /v1/advisor/explain/{agentId}` — read-only, human-readable timeline of one agent's session.
+    * Deterministic timeline always; a natural-language `narrative` is added when an LLM provider is
+    * configured (and the call succeeds). Human-principals only; `501` when no advisor/audit sink is wired.
+    *
+    * Query parameters (optional):
+    *   - `lookbackDays` — how far back to read the agent's activity (default 90).
+    *   - `maxEvents` — cap on timeline events kept, bounding the response + LLM prompt (default 200).
+    */
+  val advisorExplain: PublicEndpoint[
+    (Option[String], Option[String], Option[String], String, Option[Int], Option[Int]),
+    (StatusCode, KmsErrorDto),
+    AdvisorExplainResponseDto,
+    Any
+  ] =
+    advisorBase.get
+      .in("explain" / path[String]("agentId"))
+      .in(query[Option[Int]]("lookbackDays").description("Audit look-back window in days; defaults to 90"))
+      .in(query[Option[Int]]("maxEvents").description("Max timeline events to return; defaults to 200"))
+      .out(jsonBody[AdvisorExplainResponseDto])
+      .summary("Explain an agent's session as a human-readable timeline")
+      .description(
+        "Assembles the named agent's audit timeline and, when an LLM provider is configured, narrates it in " +
+          "plain language. Read-only — never mutates. Caller must be a human principal (service/agent → 403)."
+      )
+
   /** All endpoint definitions. Used by the OpenAPI generator and tests. */
   val all: List[AnyEndpoint] =
     List(
@@ -415,5 +440,6 @@ object Endpoints:
       rotateKey,
       issueAgent,
       queryAudit,
-      advisorScan
+      advisorScan,
+      advisorExplain
     )

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/HttpRoutes.scala
@@ -2,7 +2,7 @@ package dev.aegiskms.http
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import dev.aegiskms.agent.{AdvisorScan, AdvisorService}
+import dev.aegiskms.agent.{AdvisorExplain, AdvisorScan, AdvisorService}
 import dev.aegiskms.audit.{AuditQuery, AuditRecord, AuditSink, RequestContext}
 import dev.aegiskms.core.*
 import dev.aegiskms.http.JsonCodecs.*
@@ -475,6 +475,47 @@ final class HttpRoutes(
             ))
     }
 
+  /** `GET /v1/advisor/explain/{agentId}` — read-only agent-session timeline, narrated when an LLM provider is
+    * configured. Same access model as the other advisor/audit endpoints: human-only, 501 when unwired.
+    */
+  private val advisorExplainSE: ServerEndpoint[Any, Future] =
+    Endpoints.advisorExplain.serverLogic {
+      case (auth, devHdr, clientIp, agentId, lookbackDays, maxEvents) =>
+        principalOf(auth, devHdr) match
+          case Left(e) => Future.successful(Left(e))
+          case Right(_: Principal.Human) =>
+            advisor match
+              case None =>
+                Future.successful(Left(
+                  StatusCode.NotImplemented -> KmsErrorDto.of(
+                    ErrorCode.FeatureNotSupported,
+                    "advisor explain is not enabled on this server (set aegis.audit.kind=postgres)"
+                  )
+                ))
+              case Some(svc) =>
+                val explain =
+                  for
+                    now <- IO.realTimeInstant
+                    report <- svc.explain(
+                      AdvisorExplain.Request(
+                        agentId = agentId,
+                        now = now,
+                        lookback = lookbackDays.filter(_ > 0).map(d => java.time.Duration.ofDays(d.toLong))
+                          .getOrElse(AdvisorExplain.DefaultLookback),
+                        maxEvents = maxEvents.filter(_ > 0).getOrElse(AdvisorExplain.DefaultMaxEvents)
+                      )
+                    )
+                  yield AdvisorExplainResponseDto.fromCore(report)
+                runIO(clientIp)(explain).map(Right(_))
+          case Right(_) =>
+            Future.successful(Left(
+              StatusCode.Forbidden -> KmsErrorDto.of(
+                ErrorCode.PermissionDenied,
+                "advisor explain is restricted to human principals"
+              )
+            ))
+    }
+
   /** Write one `AuditRecord` per `/v1/agents/issue` call — success OR failure — so operators have a forensic
     * trail of every agent credential ever minted. The audit row captures the caller (the human who issued),
     * the requested scopes + ttl + label (so reviewers can answer "what does this agent have access to"), and
@@ -575,7 +616,8 @@ final class HttpRoutes(
       rotateSE,
       issueAgentSE,
       queryAuditSE,
-      advisorScanSE
+      advisorScanSE,
+      advisorExplainSE
     )
 
   /** Render the live endpoint set as an OpenAPI 3.1 document. The build-time guarantee here is the same one

--- a/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
+++ b/modules/aegis-http/src/main/scala/dev/aegiskms/http/JsonCodecs.scala
@@ -325,3 +325,65 @@ object JsonCodecs:
 
     given Encoder[AdvisorScanResponseDto] = deriveEncoder
     given Decoder[AdvisorScanResponseDto] = deriveDecoder
+
+  // ── Advisor-explain DTOs (#29) ────────────────────────────────────────────
+
+  /** One audit event in an agent's timeline (wire mirror of `AdvisorExplain.Event`). */
+  final case class ExplainEventDto(
+      at: Instant,
+      operation: String,
+      resource: String,
+      outcome: String,
+      riskScore: Option[Double],
+      anomaly: Boolean
+  )
+  object ExplainEventDto:
+    given Encoder[ExplainEventDto] = deriveEncoder
+    given Decoder[ExplainEventDto] = deriveDecoder
+
+  /** Deterministic roll-up of an agent's timeline (wire mirror of `AdvisorExplain.Summary`). */
+  final case class ExplainSummaryDto(
+      totalEvents: Int,
+      distinctOps: List[String],
+      anomalies: Int,
+      firstSeen: Option[Instant],
+      lastSeen: Option[Instant]
+  )
+  object ExplainSummaryDto:
+    given Encoder[ExplainSummaryDto] = deriveEncoder
+    given Decoder[ExplainSummaryDto] = deriveDecoder
+
+  /** Wire response for `GET /v1/advisor/explain/{agentId}`. `narrative` is present only when an LLM provider
+    * is configured and the call succeeded; otherwise clients render `events` + `summary`.
+    */
+  final case class AdvisorExplainResponseDto(
+      agentId: String,
+      windowStart: Instant,
+      windowEnd: Instant,
+      summary: ExplainSummaryDto,
+      events: List[ExplainEventDto],
+      narrative: Option[String],
+      truncated: Boolean
+  )
+  object AdvisorExplainResponseDto:
+    def fromCore(r: dev.aegiskms.agent.AdvisorExplain.Report): AdvisorExplainResponseDto =
+      AdvisorExplainResponseDto(
+        agentId = r.agentId,
+        windowStart = r.windowStart,
+        windowEnd = r.windowEnd,
+        summary = ExplainSummaryDto(
+          totalEvents = r.summary.totalEvents,
+          distinctOps = r.summary.distinctOps,
+          anomalies = r.summary.anomalies,
+          firstSeen = r.summary.firstSeen,
+          lastSeen = r.summary.lastSeen
+        ),
+        events = r.events.map(e =>
+          ExplainEventDto(e.at, e.operation, e.resource, e.outcome, e.riskScore, e.anomaly)
+        ),
+        narrative = r.narrative,
+        truncated = r.truncated
+      )
+
+    given Encoder[AdvisorExplainResponseDto] = deriveEncoder
+    given Decoder[AdvisorExplainResponseDto] = deriveDecoder

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -101,6 +101,27 @@ aegis {
     honey-keys = ${?AEGIS_HONEY_KEYS}
   }
 
+  # AI advisor (#28/#29). `scan` is always available (deterministic). `explain` adds an optional
+  # natural-language narrative when an LLM provider is configured below. `provider = none` (default)
+  # keeps everything deterministic — no outbound LLM calls, no API key required.
+  advisor {
+    llm {
+      # none | anthropic | openai | ollama
+      provider  = "none"
+      provider  = ${?AEGIS_ADVISOR_LLM_PROVIDER}
+      # Required for anthropic / openai; ignored by ollama.
+      api-key   = ""
+      api-key   = ${?AEGIS_ADVISOR_LLM_API_KEY}
+      # Optional override of the provider's default endpoint (proxies / gateways / local ollama).
+      base-url  = ""
+      base-url  = ${?AEGIS_ADVISOR_LLM_BASE_URL}
+      # Optional model override; each provider has a sensible default.
+      model     = ""
+      model     = ${?AEGIS_ADVISOR_LLM_MODEL}
+      max-tokens = 1024
+    }
+  }
+
   policy {
     # "dev"        — DevPolicyEngine. Every Human + Service is allowed for every op; only the
     #                agent-scope recursion still gates. Suitable for the workstation demo and the

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -11,6 +11,8 @@ import dev.aegiskms.agent.{
   BaselineRiskScorer,
   HoneyKeyRegistry,
   InMemoryRecommendationSink,
+  LlmClient,
+  LlmHttp,
   TappedAuditSink,
   ThresholdDecisionEngine
 }
@@ -236,6 +238,10 @@ object Server extends IOApp.Simple:
         case q: AuditQuery[IO @unchecked] => Some(q)
         case _                            => None
 
+      // Advisor LLM provider (#30): selected from `aegis.advisor.llm.*` (provider=none disables narration).
+      // `advisor explain` (#29) uses it; `advisor scan` is deterministic and ignores it.
+      llmClient = buildLlmClient(rootConfig)
+
       // 5. HTTP binding. Acquire = bind; release = unbind with the configured grace period (5s) so
       //    in-flight requests finish before the socket closes.
       appRoute =
@@ -255,7 +261,7 @@ object Server extends IOApp.Simple:
             Some(stdoutSink),
             auditReader,
             reqContext,
-            auditReader.map(AdvisorService.deterministic)
+            auditReader.map(r => AdvisorService.deterministic(r, llmClient))
           ).routes,
           MetricsRoutes.route(metricsRegistry)
         )
@@ -682,6 +688,34 @@ object Server extends IOApp.Simple:
     else
       logger.info(s"honey keys: ${parsed.size} registered for canary auto-revoke")
     HoneyKeyRegistry.fromSet(parsed)
+
+  /** Build the advisor's LLM provider from `aegis.advisor.llm.*`, or `None` when `provider=none`/absent. The
+    * provider only narrates `advisor explain` (#29); `advisor scan` is deterministic and never calls it. A
+    * bad provider name throws from `LlmClient.fromConfig`, failing the boot rather than silently disabling.
+    */
+  private def buildLlmClient(config: Config): Option[LlmClient[IO]] =
+    def str(path: String): Option[String] =
+      if config.hasPath(path) then Some(config.getString(path).trim).filter(_.nonEmpty) else None
+    val llmConfig = LlmClient.Config(
+      provider = str("aegis.advisor.llm.provider").getOrElse("none"),
+      apiKey = str("aegis.advisor.llm.api-key"),
+      baseUrl = str("aegis.advisor.llm.base-url"),
+      model = str("aegis.advisor.llm.model"),
+      maxTokens = if config.hasPath("aegis.advisor.llm.max-tokens") then
+        config.getInt("aegis.advisor.llm.max-tokens")
+      else 1024
+    )
+    val client = LlmClient.fromConfig(llmConfig, LlmHttp.jdk())
+    client match
+      case Some(_) =>
+        logger.info(
+          s"advisor LLM: provider=${llmConfig.provider}, model=${llmConfig.model.getOrElse("(provider default)")}"
+        )
+      case None =>
+        logger.info(
+          "advisor LLM: disabled (set aegis.advisor.llm.provider=anthropic|openai|ollama to enable narration)"
+        )
+    client
 
   private def buildAgentIssuer(config: Config): IO[AgentTokenIssuer] = IO {
     config.getString("aegis.auth.kind") match

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/ServerWiringSpec.scala
@@ -16,8 +16,8 @@ final class ServerWiringSpec extends AnyFunSuite with Matchers:
     given IORuntime = IORuntime.global
     val svc         = KeyService.inMemory.unsafeRunSync()
     val routes      = HttpRoutes(svc)
-    // 15 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
+    // 16 endpoints: 12 keys (create, get, activate, destroy, sign, verify, encrypt, decrypt,
     // wrap, unwrap, compromise, rotate) + agents/issue (#18) + audit/query (#20) + advisor/scan
-    // (#28). Bump this when a new top-level REST surface lands.
-    routes.serverEndpoints.size shouldBe 15
+    // (#28) + advisor/explain (#29). Bump this when a new top-level REST surface lands.
+    routes.serverEndpoints.size shouldBe 16
   }


### PR DESCRIPTION
## What

The final piece of the v0.2.1 LLM-advisor wedge: ROADMAP 2.1.b + 2.1.d.

`aegis advisor explain <agent-id>` assembles one agent's audit timeline: chronological events, risk scores, anomaly flags, and a deterministic summary. When an LLM provider is configured via #30, it also narrates the timeline in plain language.

**Read-only and safe by construction:** the model gets only the structured timeline under a strict read-only system prompt. The prompt is bounded by `maxEvents`, and any LLM failure degrades gracefully to the bare deterministic timeline rather than erroring.

With `aegis.advisor.llm.provider=none`, which is the default, there are zero outbound calls.

## Changes

- **agent-ai**: `AdvisorService.explain` + pure `AdvisorExplain.timeline`.
- **http**: `GET /v1/advisor/explain/{agentId}` with human-only access, `501` when unwired, and knobs for `lookbackDays` / `maxEvents`.
- **cli**: `aegis advisor explain <agent-id>` with narrative when present, plus timeline.
- **server**: `Server.boot` builds the LLM provider from the new `aegis.advisor.llm.*` config block and threads it into the advisor, completing the integration point for #30.

## Tests

- `AdvisorExplainSpec`: 6 cases covering deterministic timeline, actor filter, LLM narration via stub, graceful fallback, and no-events skip.
- CLI `CommandsSpec` / `CliSpec` cases.
- `ServerWiringSpec` endpoint count updated from 15 to 16.
- agentAi 77 / http 61 / cli 102 / server-wiring green.
- scalafmt + scalafix + `Test / compile` clean.

Closes #29