### PR TITLE
feat(sdk+server): real SDK clients + production preflight; docs + issue hygiene (closes #98, closes #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to Aegis will be documented here. This project follows
 
 ## Unreleased
 
+### Added
+
+- **Real SDKs — `aegis-sdk-scala` + `aegis-sdk-java` now work (closes #98, ROADMAP 2.2.a).** Both published
+  SDK artifacts previously threw on their only entry point (`NotImplementedError` /
+  `UnsupportedOperationException`). The CLI's tested blocking client (`AegisHttpClient` + `WireFormats` +
+  `HttpPort`) moved down into `aegis-sdk-scala` under `dev.aegiskms.sdk`, gaining bearer-token auth
+  (`Authorization: Bearer <jwt>`) alongside the dev `X-Aegis-User` header. `AegisClient.https(baseUrl, token)`
+  / `AegisClient.dev(baseUrl, principal)` return a working client with full REST coverage (key lifecycle,
+  sign/verify, encrypt/decrypt, wrap/unwrap, rotate/compromise, agent issuance, audit read, advisor).
+  `aegis-sdk-java`'s `AegisClientJ` is now a thin pure-Java delegate over the new `javadsl.AegisJavaClient`:
+  `java.util` collections in, wire DTOs out, failures as one `AegisClientException`. The CLI consumes the SDK
+  client, so the wire code exists exactly once.
+
+- **Production preflight (closes #99, ROADMAP 2.2.b).** `Server.boot` step 0 cross-checks the bind address
+  against dev-grade settings (`auth.kind=dev`, `policy.kind=dev`, `crypto.kind=in-memory`,
+  `journal.kind=in-memory`). Loopback binds always pass. On a network-reachable bind,
+  `aegis.security.preflight=warn` (default) prints one unmissable banner listing each finding and its risk;
+  `enforce` (set `AEGIS_SECURITY_PREFLIGHT=enforce` — recommended for production) refuses to boot before any
+  resource is acquired.
+
+### Changed
+
+- **CLI wire DTOs moved package.** `dev.aegiskms.cli.{AegisHttpClient, WireFormats, HttpPort}` are now
+  `dev.aegiskms.sdk.*` (the CLI re-uses them from the SDK). Source-breaking only for code that imported the
+  CLI's internals — the CLI itself is unchanged on the command line.
+
 ## 0.2.1 — 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@
 
 ---
 
-> **v0.2.0 — pre-alpha.** The crypto surface is real and end-to-end (sign / verify / encrypt /
-> decrypt / wrap / unwrap / rotate / compromise) on REST + CLI, with JWT + OIDC auth, Postgres /
-> MySQL / SQLite event journals, Prometheus metrics, OpenTelemetry tracing, OpenAPI on `/docs/`,
-> and the full wedge: a baseline anomaly engine + honey-key trip wire feeding a risk scorer,
-> decision adapter, and auto-responder, plus agent-token issuance, Redis-backed JWT revocation,
-> and SIEM / Kafka / NATS audit fan-out. Multi-cloud root-of-trust (GCP / Azure / Vault), KMIP,
-> and the MCP-native server land in v0.3.0+. See [the status table](https://sharma-bhaskar.github.io/aegis-kms/about/status/)
+> **v0.2.1 — pre-alpha.** The crypto surface is real and end-to-end (sign / verify / encrypt /
+> decrypt / wrap / unwrap / rotate / compromise) on REST + CLI + SDK, with JWT + OIDC auth,
+> Postgres / MySQL / SQLite event journals, Prometheus metrics, OpenTelemetry tracing, OpenAPI on
+> `/docs/`, and the full wedge: a baseline anomaly engine + honey-key trip wire feeding a risk
+> scorer, decision adapter, and auto-responder, plus agent-token issuance, Redis-backed JWT
+> revocation, SIEM / Kafka / NATS audit fan-out, and a read-only LLM advisor (`advisor scan` /
+> `advisor explain`, with pluggable Anthropic / OpenAI / Ollama narration). Multi-cloud
+> root-of-trust (GCP / Azure / Vault), KMIP, and the MCP-native server land in v0.3.0+. See
+> [the status table](https://sharma-bhaskar.github.io/aegis-kms/about/status/)
 > for the per-capability split.
 
 ## 🤔 Why Aegis exists
@@ -154,7 +156,7 @@ embed in any JVM app; server-tier modules add the actor system, HTTP, and proces
 | `aegis-audit` | Library | `AuditSink` SPI + auditing decorator |
 | `aegis-crypto` | Library | `RootOfTrust` SPI + AWS KMS adapter |
 | `aegis-persistence` | Library | Doobie event journal (Postgres / MySQL / SQLite / in-memory) |
-| `aegis-sdk-scala` / `aegis-sdk-java` | Library | Client SDKs *(skeleton — full REST coverage in v0.3.0)* |
+| `aegis-sdk-scala` / `aegis-sdk-java` | Library | Client SDKs — full REST coverage (Scala) + pure-Java facade |
 | `aegis-http` | Server | Tapir REST + OpenAPI 3.1 |
 | `aegis-agent-ai` | Server | Anomaly engine + risk scorer + auto-responder |
 | `aegis-server` | Server | Boot wiring, Prometheus, OTel, Pekko actor |
@@ -165,7 +167,7 @@ embed in any JVM app; server-tier modules add the actor system, HTTP, and proces
 
 ## 🗺️ Status
 
-**v0.2.0 (latest, pre-alpha)** — the agent-aware wedge, end-to-end.
+**v0.2.1 (latest, pre-alpha)** — the agent-aware wedge, end-to-end, plus the LLM advisor.
 
 <details>
 <summary>Per-release breakdown</summary>
@@ -173,9 +175,11 @@ embed in any JVM app; server-tier modules add the actor system, HTTP, and proces
 <br>
 
 - **v0.1.1** — full crypto surface, observability (Prometheus + OTel), 5-detector anomaly engine.
-- **v0.2.0** *(latest)* — risk scorer, decision adapter, auto-responder, honey keys; agent-token
+- **v0.2.0** — risk scorer, decision adapter, auto-responder, honey keys; agent-token
   issuance + OIDC / JWKS; Redis JWT revocation; role-based policy engine; Postgres audit table +
   `GET /v1/audit`; SIEM / Kafka / NATS audit fan-out; MySQL + SQLite journals.
+- **v0.2.1** *(latest)* — read-only LLM advisor: deterministic `advisor scan` triage,
+  `advisor explain` agent timeline, pluggable Anthropic / OpenAI / Ollama narration.
 - **v0.3.0+** — multi-cloud root-of-trust (GCP / Azure / Vault), Helm chart, time-windowed access;
   then KMIP wire plane + MCP-native server (v0.4.0).
 
@@ -198,6 +202,10 @@ the library tier must remain Pekko-free; CHANGELOG updates land in the same PR a
 
 Please do **not** open a public issue for a security report. See [SECURITY.md](SECURITY.md) for the
 disclosure process and the deploy-time configuration matrix.
+
+Deploying for real? Set `AEGIS_SECURITY_PREFLIGHT=enforce` — the boot preflight then refuses to
+bind a network-reachable address while dev-grade settings (dev auth / dev policy, in-memory
+crypto / journal) are active, instead of just printing a warning banner.
 
 ## 📄 License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,18 +99,30 @@ Non-goals: cryptographic operations, multi-cloud RoT, KMIP, MCP, OIDC. All defer
 
 ---
 
-### v0.2.1 — LLM advisor
+### v0.2.1 — LLM advisor ✅ *shipped*
 
 **Theme:** read-only AI assistant that explains the audit log to operators.
 
 | # | Capability | Area | Status |
 |---|---|---|---|
-| 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; deterministic (LLM narration via 2.1.c later) | Wedge | 🚧 |
-| 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | 🚧 |
-| 2.1.c | Pluggable LLM provider — `LlmClient` SPI + Anthropic + OpenAI + Ollama shipped (Bedrock fast-follow) | Wedge | 🚧 |
-| 2.1.d | Prompt safety: read-only system prompt, bounded structured input, graceful LLM-failure fallback | Wedge | 🚧 |
+| 2.1.a | `aegis advisor scan` — finds unused keys, scope-creep, anomalies; deterministic (LLM narration via 2.1.c later) | Wedge | ✅ |
+| 2.1.b | `aegis advisor explain <agent-id>` — human-readable timeline of why a recommendation fired | Wedge | ✅ |
+| 2.1.c | Pluggable LLM provider — `LlmClient` SPI + Anthropic + OpenAI + Ollama shipped (Bedrock fast-follow) | Wedge | ✅ |
+| 2.1.d | Prompt safety: read-only system prompt, bounded structured input, graceful LLM-failure fallback | Wedge | ✅ |
 
 **Demo target:** "`aegis advisor scan` returns 'these 3 keys haven't been used in 60 days, these 2 agents have unusually broad scopes, there are no active anomalies.'"
+
+---
+
+### v0.2.2 — Hardening fix pass
+
+**Theme:** remove the things a first-time evaluator hits in their first ten minutes.
+
+| # | Capability | Area | Status |
+|---|---|---|---|
+| 2.2.a | Real SDKs — `aegis-sdk-scala` full REST coverage + working Java facade, replacing the `NotImplementedError` stubs (#98) | Platform | 🚧 |
+| 2.2.b | Production preflight — warn/enforce when dev-grade settings bind a non-loopback address (#99) | Platform | 🚧 |
+| 2.2.c | Issue hygiene — tracking issues for journal snapshotting (#100), agent registry (#101), kill-switch (#102), v1.0.0 rows (#103–#107) | Platform | 🚧 |
 
 ---
 
@@ -279,8 +291,8 @@ The release tables above slice the work by milestone. The tables below slice by 
 
 | Capability | Status | Tracking |
 |---|---|---|
-| Agent registry (list all live agents, parents, scopes, last activity) | 🔜 v0.3.0 | `area/ai-governance` |
-| Agent kill-switch ("revoke all agents under alice@org issued in 24h") | 🔜 v0.3.0 | `area/ai-governance area/auto-response` |
+| Agent registry (list all live agents, parents, scopes, last activity) | 🔜 v0.3.0 | #101 |
+| Agent kill-switch ("revoke all agents under alice@org issued in 24h") | 🔜 v0.3.0 | #102 |
 | Per-prompt accountability (record originating LLM prompt) | 💡 v0.4.0 | `area/ai-governance area/wire/mcp` |
 | Model identifier in audit (`actor.model = "..."`) | 💡 v0.4.0 | `area/ai-governance area/audit` |
 | Token cost / op-rate tracking per agent | 💡 v0.4.0+ | `area/ai-governance` |
@@ -323,8 +335,8 @@ The release tables above slice the work by milestone. The tables below slice by 
 
 | SDK | Status | Tracking |
 |---|---|---|
-| Scala SDK (`aegis-sdk-scala`) — full REST coverage | ⚠️ skeleton | v0.3.0 |
-| Java SDK (`aegis-sdk-java`) — full REST coverage | ⚠️ skeleton | v0.3.0 |
+| Scala SDK (`aegis-sdk-scala`) — full REST coverage | 🚧 v0.2.2 (#98) | — |
+| Java SDK (`aegis-sdk-java`) — key ops + agent issuance facade | 🚧 v0.2.2 (#98) | full audit/advisor coverage later |
 | Kotlin coroutines wrapper | 💡 | community welcome |
 | TypeScript / Node SDK | 💡 | community welcome |
 | Python SDK | 💡 | community welcome |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,16 @@ network you do not fully control must use `AEGIS_AUTH_KIND=hmac` (HS256
 JWT) or `AEGIS_AUTH_KIND=oidc` (OIDC / JWKS verification with RS256/ES256,
 shipped in v0.2.0).
 
+### Production preflight
+
+At boot, Aegis cross-checks the bind address against every dev-grade setting
+(`AEGIS_AUTH_KIND=dev`, `AEGIS_POLICY_KIND=dev`, `AEGIS_CRYPTO_KIND=in-memory`,
+`AEGIS_JOURNAL_KIND=in-memory`). Loopback binds always pass. On a
+network-reachable bind, the default mode (`AEGIS_SECURITY_PREFLIGHT=warn`)
+prints one unmissable banner listing each finding; production deployments
+should set `AEGIS_SECURITY_PREFLIGHT=enforce`, which refuses to boot instead
+(#99) — a crashed pod is cheaper than an open KMS.
+
 ### TLS termination
 
 Aegis-KMS does not yet ship its own TLS listener. Production deployments

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Cli.scala
@@ -1,6 +1,7 @@
 package dev.aegiskms.cli
 
 import dev.aegiskms.cli.Commands.CommandResult
+import dev.aegiskms.sdk.{AegisHttpClient, HttpPort}
 
 /** The `aegis` admin CLI entry point.
   *

--- a/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
+++ b/modules/aegis-cli/src/main/scala/dev/aegiskms/cli/Commands.scala
@@ -1,7 +1,8 @@
 package dev.aegiskms.cli
 
-import dev.aegiskms.cli.AegisHttpClient.{ClientError, renderError}
-import dev.aegiskms.cli.WireFormats.{
+import dev.aegiskms.sdk.AegisHttpClient
+import dev.aegiskms.sdk.AegisHttpClient.{ClientError, renderError}
+import dev.aegiskms.sdk.WireFormats.{
   AdvisorExplainResponseDto,
   AdvisorScanResponseDto,
   AuditRecordDto,

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CliSpec.scala
@@ -1,6 +1,7 @@
 package dev.aegiskms.cli
 
-import dev.aegiskms.cli.WireFormats.*
+import dev.aegiskms.sdk.WireFormats.*
+import dev.aegiskms.sdk.{AegisHttpClient, HttpPort}
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
+++ b/modules/aegis-cli/src/test/scala/dev/aegiskms/cli/CommandsSpec.scala
@@ -1,6 +1,7 @@
 package dev.aegiskms.cli
 
-import dev.aegiskms.cli.WireFormats.*
+import dev.aegiskms.sdk.WireFormats.*
+import dev.aegiskms.sdk.{AegisHttpClient, HttpPort}
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/modules/aegis-sdk-java/src/main/java/dev/aegiskms/sdk/java/AegisClientJ.java
+++ b/modules/aegis-sdk-java/src/main/java/dev/aegiskms/sdk/java/AegisClientJ.java
@@ -1,16 +1,93 @@
 package dev.aegiskms.sdk.java;
 
+import dev.aegiskms.sdk.WireFormats;
+import dev.aegiskms.sdk.javadsl.AegisJavaClient;
+
+import java.util.List;
+import java.util.Map;
+
 /**
- * Java-friendly facade over the Scala SDK. Placeholder during scaffolding;
- * real implementation will wrap {@code dev.aegiskms.sdk.AegisClient} and
- * expose a blocking / CompletableFuture API so Java users never need to
- * reason about Cats Effect.
+ * Java client for the Aegis-KMS REST surface. Thin delegate over the Scala SDK's
+ * {@code javadsl.AegisJavaClient}: {@code java.util} collections in, wire DTOs out,
+ * failures thrown as {@code dev.aegiskms.sdk.javadsl.AegisClientException}.
+ *
+ * <pre>{@code
+ * AegisClientJ client = AegisClientJ.https("https://aegis.example.com", jwt);
+ * WireFormats.ManagedKeyDto key = client.createKey("invoice-2026", "AES", 256);
+ * client.activateKey(key.id());
+ * }</pre>
  */
 public final class AegisClientJ {
-    private AegisClientJ() { }
 
+    private final AegisJavaClient delegate;
+
+    private AegisClientJ(AegisJavaClient delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Connect with a bearer JWT — the production path. */
     public static AegisClientJ https(String baseUrl, String token) {
-        throw new UnsupportedOperationException(
-            "AegisClientJ.https is not yet implemented (scaffold)");
+        return new AegisClientJ(AegisJavaClient.https(baseUrl, token));
+    }
+
+    /**
+     * Connect to a dev-mode server ({@code AEGIS_AUTH_KIND=dev}) identifying via the
+     * {@code X-Aegis-User} header. Workstation use only — dev auth performs no verification.
+     */
+    public static AegisClientJ dev(String baseUrl, String principal) {
+        return new AegisClientJ(AegisJavaClient.dev(baseUrl, principal));
+    }
+
+    public WireFormats.ManagedKeyDto createKey(String name, String algorithm, int sizeBits) {
+        return delegate.createKey(name, algorithm, sizeBits);
+    }
+
+    public WireFormats.ManagedKeyDto getKey(String id) {
+        return delegate.getKey(id);
+    }
+
+    public WireFormats.ManagedKeyDto activateKey(String id) {
+        return delegate.activateKey(id);
+    }
+
+    public void destroyKey(String id) {
+        delegate.destroyKey(id);
+    }
+
+    public WireFormats.SignResponse sign(String id, String messageBase64, String algorithm) {
+        return delegate.sign(id, messageBase64, algorithm);
+    }
+
+    public boolean verify(String id, String messageBase64, String signatureBase64, String algorithm) {
+        return delegate.verify(id, messageBase64, signatureBase64, algorithm);
+    }
+
+    public WireFormats.EncryptResponse encrypt(String id, String plaintextBase64, Map<String, String> context) {
+        return delegate.encrypt(id, plaintextBase64, context);
+    }
+
+    public WireFormats.DecryptResponse decrypt(String id, String ciphertextBase64, Map<String, String> context) {
+        return delegate.decrypt(id, ciphertextBase64, context);
+    }
+
+    public WireFormats.WrapResponse wrap(String id, String dekBase64) {
+        return delegate.wrap(id, dekBase64);
+    }
+
+    public WireFormats.UnwrapResponse unwrap(String id, String wrappedDekBase64) {
+        return delegate.unwrap(id, wrappedDekBase64);
+    }
+
+    public WireFormats.ManagedKeyDto compromiseKey(String id, String reason) {
+        return delegate.compromiseKey(id, reason);
+    }
+
+    public WireFormats.ManagedKeyDto rotateKey(String id, String policy) {
+        return delegate.rotateKey(id, policy);
+    }
+
+    /** Mint a short-lived agent JWT. {@code parent} may be null to default to the calling principal. */
+    public WireFormats.IssueAgentResponseDto issueAgent(String label, List<String> scopes, long ttlSeconds, String parent) {
+        return delegate.issueAgent(label, scopes, ttlSeconds, parent);
     }
 }

--- a/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/AegisClient.scala
+++ b/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/AegisClient.scala
@@ -1,22 +1,20 @@
 package dev.aegiskms.sdk
 
-import dev.aegiskms.core.{KeyId, KeySpec, KmsError, ManagedKey}
-
-/** Thin client over the Aegis-KMS REST surface.
+/** Entry point for the Scala SDK. Both factories return a working [[AegisHttpClient]] with full coverage of
+  * the Aegis REST surface (key lifecycle, crypto ops, agent issuance, audit read, advisor).
   *
-  * This is a placeholder during scaffolding; the real implementation will use sttp + circe and will be
-  * generated from the Tapir-authored OpenAPI spec.
+  * The client is blocking (JDK `HttpClient` underneath) and returns `Either[ClientError, A]`. Effect-system
+  * users can lift calls into their own `F[_]` with a single `blocking(...)` wrapper; we deliberately don't
+  * force a cats-effect dependency on every consumer for what is one HTTP round-trip per call.
   */
-trait AegisClient[F[_]]:
-  def keys: AegisKeysApi[F]
-
-trait AegisKeysApi[F[_]]:
-  def create(spec: KeySpec): F[Either[KmsError, ManagedKey]]
-  def get(id: KeyId): F[Either[KmsError, ManagedKey]]
-  def locate(pattern: String): F[List[ManagedKey]]
-  def revoke(id: KeyId): F[Either[KmsError, ManagedKey]]
-  def destroy(id: KeyId): F[Either[KmsError, Unit]]
-
 object AegisClient:
-  def https[F[_]](baseUrl: String, token: String): AegisClient[F] =
-    throw new NotImplementedError("AegisClient.https is not yet implemented (scaffold)")
+
+  /** Connect with a bearer JWT — the production path (`AEGIS_AUTH_KIND=hmac` or OIDC). */
+  def https(baseUrl: String, token: String): AegisHttpClient =
+    new AegisHttpClient(HttpPort.jdk(), baseUrl, principal = None, token = Some(token))
+
+  /** Connect to a dev-mode server (`AEGIS_AUTH_KIND=dev`) identifying as `principal` via the `X-Aegis-User`
+    * header. Workstation use only — dev auth performs no verification.
+    */
+  def dev(baseUrl: String, principal: String): AegisHttpClient =
+    new AegisHttpClient(HttpPort.jdk(), baseUrl, principal = Some(principal))

--- a/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/AegisHttpClient.scala
+++ b/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/AegisHttpClient.scala
@@ -1,24 +1,33 @@
-package dev.aegiskms.cli
+package dev.aegiskms.sdk
 
-import dev.aegiskms.cli.WireFormats.*
+import dev.aegiskms.sdk.WireFormats.*
 import io.circe.Decoder
 import io.circe.parser.*
 import io.circe.syntax.*
 
-/** Typed wrapper over `HttpPort` exposing the Aegis REST surface in the four shapes the CLI cares about:
-  * create / get / activate / destroy. The methods return `Either[ClientError, A]` so the CLI's command layer
-  * can map errors into exit codes without exception handling spread across every subcommand.
+/** Typed, blocking client over the Aegis REST surface. The methods return `Either[ClientError, A]` so callers
+  * can map errors into their own failure channel without exception handling spread across every call site.
+  *
+  * Authentication is either a dev-mode principal (`X-Aegis-User` header, workstation servers only) or a
+  * bearer JWT (`Authorization: Bearer …`, the production path). Use the factories on [[AegisClient]] rather
+  * than constructing this directly unless you need to inject a custom [[HttpPort]].
   *
   * Why not return `KmsErrorDto` directly? Because the failure could be a network blip, a JSON decode
   * mismatch, or the server returning HTML on a misconfigured ingress. We model those uniformly as
-  * [[ClientError]] and let the command formatter render whichever variant happened.
+  * [[AegisHttpClient.ClientError]] and let the caller render whichever variant happened.
   */
-final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[String]):
+final class AegisHttpClient(
+    http: HttpPort,
+    baseUrl: String,
+    principal: Option[String],
+    token: Option[String] = None
+):
 
   import AegisHttpClient.*
 
   private val baseHeaders: Map[String, String] =
-    principal.fold(Map.empty[String, String])(p => Map("X-Aegis-User" -> p))
+    principal.fold(Map.empty[String, String])(p => Map("X-Aegis-User" -> p)) ++
+      token.fold(Map.empty[String, String])(t => Map("Authorization" -> s"Bearer $t"))
 
   def createKey(spec: KeySpecDto): Either[ClientError, ManagedKeyDto] =
     val body = CreateKeyRequest(spec).asJson.noSpaces
@@ -140,13 +149,8 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       limit.map(v => "limit" -> v.toString),
       offset.map(v => "offset" -> v.toString)
     ).flatten
-    val qs =
-      if params.isEmpty then ""
-      else
-        params.map { case (k, v) =>
-          s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
-        }.mkString("?", "&", "")
-    val res = http.execute(HttpPort.Request("GET", url(s"/v1/audit$qs"), baseHeaders, None))
+    val res =
+      http.execute(HttpPort.Request("GET", url(s"/v1/audit${queryString(params)}"), baseHeaders, None))
     res.status match
       case 200    => decodeBody[AuditQueryResponseDto](res.body)
       case status => Left(toError(status, res.body))
@@ -166,13 +170,8 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       broadScope.map(v => "broadScope" -> v.toString),
       top.map(v => "top" -> v.toString)
     ).flatten
-    val qs =
-      if params.isEmpty then ""
-      else
-        params.map { case (k, v) =>
-          s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
-        }.mkString("?", "&", "")
-    val res = http.execute(HttpPort.Request("GET", url(s"/v1/advisor/scan$qs"), baseHeaders, None))
+    val res =
+      http.execute(HttpPort.Request("GET", url(s"/v1/advisor/scan${queryString(params)}"), baseHeaders, None))
     res.status match
       case 200    => decodeBody[AdvisorScanResponseDto](res.body)
       case status => Left(toError(status, res.body))
@@ -189,15 +188,16 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
       lookbackDays.map(v => "lookbackDays" -> v.toString),
       maxEvents.map(v => "maxEvents" -> v.toString)
     ).flatten
-    val qs =
-      if params.isEmpty then ""
-      else
-        params.map { case (k, v) =>
-          s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
-        }.mkString("?", "&", "")
     val encodedId = java.net.URLEncoder.encode(agentId, java.nio.charset.StandardCharsets.UTF_8)
     val res =
-      http.execute(HttpPort.Request("GET", url(s"/v1/advisor/explain/$encodedId$qs"), baseHeaders, None))
+      http.execute(
+        HttpPort.Request(
+          "GET",
+          url(s"/v1/advisor/explain/$encodedId${queryString(params)}"),
+          baseHeaders,
+          None
+        )
+      )
     res.status match
       case 200    => decodeBody[AdvisorExplainResponseDto](res.body)
       case status => Left(toError(status, res.body))
@@ -207,6 +207,13 @@ final class AegisHttpClient(http: HttpPort, baseUrl: String, principal: Option[S
   private def url(path: String): String =
     val base = if baseUrl.endsWith("/") then baseUrl.dropRight(1) else baseUrl
     s"$base$path"
+
+  private def queryString(params: List[(String, String)]): String =
+    if params.isEmpty then ""
+    else
+      params.map { case (k, v) =>
+        s"$k=${java.net.URLEncoder.encode(v, java.nio.charset.StandardCharsets.UTF_8)}"
+      }.mkString("?", "&", "")
 
   private def decodeBody[A](body: String)(using Decoder[A]): Either[ClientError, A] =
     decode[A](body).left.map(e => ClientError.Decode(e.getMessage, body))
@@ -226,7 +233,7 @@ object AegisHttpClient:
     case Raw(status: Int, body: String)
     case Decode(message: String, body: String)
 
-  /** Render an error for the CLI user. Single source of formatting so all commands print the same way. */
+  /** Render an error for a human. Single source of formatting so all callers print the same way. */
   def renderError(err: ClientError): String = err match
     case ClientError.Server(status, code, message) => s"server returned $status $code: $message"
     case ClientError.Raw(status, body) =>

--- a/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/HttpPort.scala
+++ b/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/HttpPort.scala
@@ -1,11 +1,11 @@
-package dev.aegiskms.cli
+package dev.aegiskms.sdk
 
 import java.net.URI
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.time.Duration
 
-/** A tiny HTTP seam used by the CLI. Two reasons it exists:
-  *   - JDK's `HttpClient` works fine for the CLI's needs but is awkward to mock; this port lets tests inject
+/** A tiny HTTP seam used by the SDK (and the `aegis` CLI on top of it). Two reasons it exists:
+  *   - JDK's `HttpClient` works fine for the SDK's needs but is awkward to mock; this port lets tests inject
   *     a hand-rolled stub that records calls and returns canned responses, with no network boot.
   *   - It pins the exact wire shape (method/url/headers/body) we depend on, so we can route requests through
   *     a different backend later (for example, an in-process route interpreter for testing).
@@ -25,7 +25,7 @@ object HttpPort:
   final case class Response(status: Int, body: String)
 
   /** Default JDK-backed implementation. Uses `HttpClient.newHttpClient()` with a per-request timeout so a
-    * misconfigured server URL doesn't hang the CLI indefinitely.
+    * misconfigured server URL doesn't hang the caller indefinitely.
     */
   def jdk(timeout: Duration = Duration.ofSeconds(15)): HttpPort = new HttpPort:
     private val client = HttpClient.newHttpClient()

--- a/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/WireFormats.scala
+++ b/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/WireFormats.scala
@@ -1,16 +1,16 @@
-package dev.aegiskms.cli
+package dev.aegiskms.sdk
 
 import io.circe.*
 import io.circe.generic.semiauto.*
 
 import java.time.Instant
 
-/** Wire DTOs the CLI exchanges with the Aegis server.
+/** Wire DTOs the SDK (and the `aegis` CLI on top of it) exchanges with the Aegis server.
   *
   * These mirror the shapes in `aegis-http`'s `JsonCodecs` but are duplicated here on purpose: depending on
-  * `aegis-http` would drag Tapir + pekko-http into the CLI, which doubles its packaged size and slows boot.
-  * The shapes are small and stable; if they ever drift, the integration tests in `aegis-http` will fail
-  * loudly because they exercise the same JSON.
+  * `aegis-http` would drag Tapir + pekko-http into every SDK consumer, which breaks the library-tier rule and
+  * doubles the CLI's packaged size. The shapes are small and stable; if they ever drift, the integration
+  * tests in `aegis-http` will fail loudly because they exercise the same JSON.
   */
 object WireFormats:
 

--- a/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/javadsl/AegisJavaClient.scala
+++ b/modules/aegis-sdk-scala/src/main/scala/dev/aegiskms/sdk/javadsl/AegisJavaClient.scala
@@ -1,0 +1,83 @@
+package dev.aegiskms.sdk.javadsl
+
+import dev.aegiskms.sdk.WireFormats.*
+import dev.aegiskms.sdk.{AegisClient, AegisHttpClient}
+
+import scala.jdk.CollectionConverters.*
+
+/** Thrown by [[AegisJavaClient]] when the server (or the wire) reports a failure. Java callers get one
+  * exception type with a rendered message instead of the Scala `Either` channel.
+  */
+final class AegisClientException(message: String) extends RuntimeException(message)
+
+/** Java-friendly facade over [[dev.aegiskms.sdk.AegisHttpClient]]: `java.util` collections in, DTOs out,
+  * failures as [[AegisClientException]]. `aegis-sdk-java`'s `AegisClientJ` delegates here so the Java
+  * artifact stays a thin pure-Java shim.
+  */
+final class AegisJavaClient private (underlying: AegisHttpClient):
+
+  def createKey(name: String, algorithm: String, sizeBits: Int): ManagedKeyDto =
+    orThrow(underlying.createKey(KeySpecDto(name, algorithm, sizeBits, "SymmetricKey")))
+
+  def getKey(id: String): ManagedKeyDto = orThrow(underlying.getKey(id))
+
+  def activateKey(id: String): ManagedKeyDto = orThrow(underlying.activateKey(id))
+
+  def destroyKey(id: String): Unit = orThrow(underlying.destroyKey(id))
+
+  def sign(id: String, messageBase64: String, algorithm: String): SignResponse =
+    orThrow(underlying.signKey(id, SignRequest(messageBase64, algorithm)))
+
+  def verify(id: String, messageBase64: String, signatureBase64: String, algorithm: String): Boolean =
+    orThrow(underlying.verifyKey(id, VerifyRequest(messageBase64, signatureBase64, algorithm))).valid
+
+  def encrypt(
+      id: String,
+      plaintextBase64: String,
+      context: java.util.Map[String, String]
+  ): EncryptResponse =
+    orThrow(underlying.encryptKey(id, EncryptRequest(plaintextBase64, context.asScala.toMap)))
+
+  def decrypt(
+      id: String,
+      ciphertextBase64: String,
+      context: java.util.Map[String, String]
+  ): DecryptResponse =
+    orThrow(underlying.decryptKey(id, DecryptRequest(ciphertextBase64, context.asScala.toMap)))
+
+  def wrap(id: String, dekBase64: String): WrapResponse =
+    orThrow(underlying.wrapKey(id, WrapRequest(dekBase64)))
+
+  def unwrap(id: String, wrappedDekBase64: String): UnwrapResponse =
+    orThrow(underlying.unwrapKey(id, UnwrapRequest(wrappedDekBase64)))
+
+  def compromiseKey(id: String, reason: String): ManagedKeyDto =
+    orThrow(underlying.compromiseKey(id, CompromiseRequest(reason)))
+
+  def rotateKey(id: String, policy: String): ManagedKeyDto =
+    orThrow(underlying.rotateKey(id, RotateRequest(policy)))
+
+  def issueAgent(
+      label: String,
+      scopes: java.util.List[String],
+      ttlSeconds: Long,
+      parent: String /* nullable */
+  ): IssueAgentResponseDto =
+    orThrow(
+      underlying.issueAgent(
+        IssueAgentRequestDto(label, scopes.asScala.toList, ttlSeconds, Option(parent))
+      )
+    )
+
+  private def orThrow[A](res: Either[AegisHttpClient.ClientError, A]): A =
+    res.fold(err => throw new AegisClientException(AegisHttpClient.renderError(err)), identity)
+
+object AegisJavaClient:
+
+  /** Connect with a bearer JWT — the production path. */
+  def https(baseUrl: String, token: String): AegisJavaClient =
+    new AegisJavaClient(AegisClient.https(baseUrl, token))
+
+  /** Connect to a dev-mode server via the `X-Aegis-User` header. Workstation use only. */
+  def dev(baseUrl: String, principal: String): AegisJavaClient =
+    new AegisJavaClient(AegisClient.dev(baseUrl, principal))

--- a/modules/aegis-sdk-scala/src/test/scala/dev/aegiskms/sdk/AegisHttpClientSpec.scala
+++ b/modules/aegis-sdk-scala/src/test/scala/dev/aegiskms/sdk/AegisHttpClientSpec.scala
@@ -1,7 +1,7 @@
-package dev.aegiskms.cli
+package dev.aegiskms.sdk
 
-import dev.aegiskms.cli.AegisHttpClient.ClientError
-import dev.aegiskms.cli.WireFormats.*
+import dev.aegiskms.sdk.AegisHttpClient.ClientError
+import dev.aegiskms.sdk.WireFormats.*
 import io.circe.syntax.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -218,6 +218,18 @@ final class AegisHttpClientSpec extends AnyFunSuite with Matchers:
     seen.get.method shouldBe "POST"
     seen.get.url shouldBe s"$baseUrl/v1/keys/${sampleKey.id}/rotate"
     seen.get.body.get should include("\"policy\":\"Manual\"")
+  }
+
+  test("a bearer token is sent as Authorization: Bearer and the dev header is omitted") {
+    var seen: Option[HttpPort.Request] = None
+    val port = new RecordingPort(req => {
+      seen = Some(req)
+      HttpPort.Response(200, sampleKey.asJson.noSpaces)
+    })
+    val client = new AegisHttpClient(port, baseUrl, principal = None, token = Some("jwt-abc"))
+    val _      = client.getKey(sampleKey.id)
+    seen.get.headers.get("Authorization") shouldBe Some("Bearer jwt-abc")
+    seen.get.headers.contains("X-Aegis-User") shouldBe false
   }
 
   // ── Stub ────────────────────────────────────────────────────────────────────

--- a/modules/aegis-server/src/main/resources/application.conf
+++ b/modules/aegis-server/src/main/resources/application.conf
@@ -99,6 +99,16 @@ aegis {
   security {
     honey-keys = []
     honey-keys = ${?AEGIS_HONEY_KEYS}
+
+    # Production preflight. At boot, Aegis cross-checks the bind address against dev-grade
+    # settings (auth.kind=dev, policy.kind=dev, crypto.kind=in-memory, journal.kind=in-memory).
+    # Loopback binds always pass. On a network-reachable bind:
+    #   "warn"    — print one unmissable banner listing the findings, then continue (default;
+    #               keeps `docker run` demos working out of the box).
+    #   "enforce" — refuse to boot. Recommended for every production deployment: a crashed pod
+    #               is cheaper than an open KMS.
+    preflight = "warn"
+    preflight = ${?AEGIS_SECURITY_PREFLIGHT}
   }
 
   # AI advisor (#28/#29). `scan` is always available (deterministic). `explain` adds an optional

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Preflight.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Preflight.scala
@@ -1,0 +1,99 @@
+package dev.aegiskms.app
+
+import cats.effect.IO
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+/** Production preflight: catches the "shipped the workstation defaults to production" failure mode.
+  *
+  * The default configuration is deliberately demo-friendly — dev auth, allow-all policy, fake crypto,
+  * non-durable journal — and binds `0.0.0.0` so the Docker image works out of the box. That combination on a
+  * network-reachable interface is exactly the misconfiguration a key-management service must not run with
+  * silently. At boot we cross-check the bind address against every dev-grade setting and either print one
+  * unmissable banner (`aegis.security.preflight=warn`, the default) or refuse to start (`enforce`).
+  *
+  * Production deployments should set `AEGIS_SECURITY_PREFLIGHT=enforce`: a crashed pod is cheaper than an
+  * open KMS. Loopback binds are always exempt — every check here is about *network-reachable* exposure.
+  */
+object Preflight:
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** One dev-grade setting that is unsafe on a network-reachable bind. */
+  final case class Finding(path: String, value: String, risk: String)
+
+  /** True for binds only reachable from the host itself. `0.0.0.0` / `::` are NOT loopback — they are the
+    * all-interfaces wildcards.
+    */
+  def isLoopback(host: String): Boolean =
+    val h = host.trim.toLowerCase
+    h == "localhost" || h == "::1" || h == "[::1]" || h.startsWith("127.")
+
+  /** Pure scan of the wire-facing config for dev-grade settings. Empty when the configuration is
+    * production-shaped; the caller decides whether findings warn or abort based on the preflight mode.
+    */
+  def findings(config: Config): List[Finding] =
+    List(
+      Option.when(config.getString("aegis.auth.kind") == "dev")(
+        Finding(
+          "aegis.auth.kind",
+          "dev",
+          "any client can impersonate any principal via the X-Aegis-User header"
+        )
+      ),
+      Option.when(config.getString("aegis.policy.kind") == "dev")(
+        Finding(
+          "aegis.policy.kind",
+          "dev",
+          "DevPolicyEngine grants every Human and Service full access to every key"
+        )
+      ),
+      Option.when(config.getString("aegis.crypto.kind") == "in-memory")(
+        Finding(
+          "aegis.crypto.kind",
+          "in-memory",
+          "deterministic-MAC dev backend — not real cryptography; never protects production data"
+        )
+      ),
+      Option.when(config.getString("aegis.persistence.journal.kind") == "in-memory")(
+        Finding(
+          "aegis.persistence.journal.kind",
+          "in-memory",
+          "key state is lost on restart — keys wrapped against this instance become unrecoverable"
+        )
+      )
+    ).flatten
+
+  /** Run the preflight as the first step of `Server.boot`. Loopback binds and clean configs pass silently;
+    * otherwise `warn` prints the banner and continues, `enforce` raises and aborts the boot. An unknown mode
+    * fails fast — consistent with every other `aegis.*.kind` selector.
+    */
+  def run(config: Config): IO[Unit] =
+    val host = config.getString("aegis.http.host")
+    val mode = config.getString("aegis.security.preflight")
+    mode match
+      case "warn" | "enforce" =>
+        val found = findings(config)
+        if isLoopback(host) || found.isEmpty then
+          IO(logger.info(s"preflight: ok (host=$host, mode=$mode, dev-grade settings: ${found.size})"))
+        else
+          val lines = found.map(f => s"  - ${f.path}=${f.value} — ${f.risk}").mkString("\n")
+          if mode == "enforce" then
+            IO.raiseError(new IllegalStateException(
+              s"preflight (enforce): refusing to bind $host with dev-grade settings:\n$lines\n" +
+                "Fix the settings above, bind a loopback address, or set AEGIS_SECURITY_PREFLIGHT=warn " +
+                "if this exposure is intentional (demos only)."
+            ))
+          else
+            IO(logger.warn(
+              s"""
+                 |╔═══════════════════════════════════════════════════════════════════════════════╗
+                 |  PREFLIGHT: binding $host with dev-grade settings — NOT SAFE FOR PRODUCTION
+                 |$lines
+                 |  Set AEGIS_SECURITY_PREFLIGHT=enforce to make this configuration refuse to boot.
+                 |╚═══════════════════════════════════════════════════════════════════════════════╝""".stripMargin
+            ))
+      case other =>
+        IO.raiseError(new IllegalArgumentException(
+          s"Unknown aegis.security.preflight=$other (expected 'warn' or 'enforce')"
+        ))

--- a/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
+++ b/modules/aegis-server/src/main/scala/dev/aegiskms/app/Server.scala
@@ -115,6 +115,11 @@ object Server extends IOApp.Simple:
     val port = rootConfig.getInt("aegis.http.port")
 
     for
+      // 0. Production preflight (#99): cross-checks the bind address against dev-grade settings
+      //    (dev auth, dev policy, in-memory crypto/journal). `warn` (default) prints a banner;
+      //    `enforce` aborts the boot before any resource is acquired.
+      _ <- Resource.eval(Preflight.run(rootConfig))
+
       // 1. Meter registry. Standard JVM binders are AutoCloseable (the JvmGcMetrics binder installs JMX
       //    listeners) so we close it on shutdown.
       metricsRegistry <- meterRegistryResource

--- a/modules/aegis-server/src/test/scala/dev/aegiskms/app/PreflightSpec.scala
+++ b/modules/aegis-server/src/test/scala/dev/aegiskms/app/PreflightSpec.scala
@@ -1,0 +1,84 @@
+package dev.aegiskms.app
+
+import cats.effect.unsafe.implicits.global
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Unit tests for the production preflight. Mirrors `PolicyEngineResourceSpec`'s shape: drive each branch of
+  * the config cross-check, including the enforce-mode abort a misconfigured production deployment must hit at
+  * boot.
+  */
+final class PreflightSpec extends AnyFunSuite with Matchers:
+
+  private def cfg(hocon: String): Config =
+    ConfigFactory.parseString(hocon).withFallback(ConfigFactory.load())
+
+  /** Every dev-grade default replaced with its production-shaped counterpart. */
+  private val hardened = """
+    aegis.auth.kind                = "hmac"
+    aegis.auth.hmac.secret         = "0123456789abcdef0123456789abcdef"
+    aegis.policy.kind              = "role-based"
+    aegis.crypto.kind              = "aws-kms"
+    aegis.persistence.journal.kind = "postgres"
+  """
+
+  test("isLoopback accepts localhost / 127.x / ::1 and rejects wildcards + public addresses") {
+    Preflight.isLoopback("localhost") shouldBe true
+    Preflight.isLoopback("127.0.0.1") shouldBe true
+    Preflight.isLoopback("127.0.1.5") shouldBe true
+    Preflight.isLoopback("::1") shouldBe true
+    Preflight.isLoopback("0.0.0.0") shouldBe false
+    Preflight.isLoopback("::") shouldBe false
+    Preflight.isLoopback("10.1.2.3") shouldBe false
+    Preflight.isLoopback("aegis.example.com") shouldBe false
+  }
+
+  test("the stock application.conf defaults produce all four dev-grade findings") {
+    val found = Preflight.findings(cfg("")).map(_.path)
+    found should contain allOf (
+      "aegis.auth.kind",
+      "aegis.policy.kind",
+      "aegis.crypto.kind",
+      "aegis.persistence.journal.kind"
+    )
+  }
+
+  test("a hardened config produces no findings") {
+    Preflight.findings(cfg(hardened)) shouldBe empty
+  }
+
+  test("warn mode (the default) lets the dev defaults boot on 0.0.0.0") {
+    noException should be thrownBy Preflight.run(cfg("")).unsafeRunSync()
+  }
+
+  test("enforce mode aborts the boot when dev-grade settings bind a non-loopback address") {
+    val ex = intercept[IllegalStateException] {
+      Preflight.run(cfg("""aegis.security.preflight = "enforce" """)).unsafeRunSync()
+    }
+    ex.getMessage should include("refusing to bind 0.0.0.0")
+    ex.getMessage should include("aegis.auth.kind=dev")
+  }
+
+  test("enforce mode passes on a loopback bind even with dev-grade settings") {
+    val hocon = """
+      aegis.security.preflight = "enforce"
+      aegis.http.host          = "127.0.0.1"
+    """
+    noException should be thrownBy Preflight.run(cfg(hocon)).unsafeRunSync()
+  }
+
+  test("enforce mode passes on 0.0.0.0 once the config is hardened") {
+    val hocon = s"""
+      aegis.security.preflight = "enforce"
+      $hardened
+    """
+    noException should be thrownBy Preflight.run(cfg(hocon)).unsafeRunSync()
+  }
+
+  test("an unknown preflight mode fails fast, matching the other aegis.*.kind selectors") {
+    val ex = intercept[IllegalArgumentException] {
+      Preflight.run(cfg("""aegis.security.preflight = "audit" """)).unsafeRunSync()
+    }
+    ex.getMessage should include("Unknown aegis.security.preflight=audit")
+  }


### PR DESCRIPTION
## What

First slice of the v0.2.2 hardening fix pass: ROADMAP 2.2.a–c.

### Real SDKs

Closes #98.

- Move the CLI's tested blocking client, `AegisHttpClient` + `WireFormats` + `HttpPort`, down into `aegis-sdk-scala` as `dev.aegiskms.sdk.*` using git renames so history is preserved. The CLI now consumes the SDK client, so the wire code exists exactly once.
- `AegisClient.https(baseUrl, token)` / `AegisClient.dev(baseUrl, principal)` now return a working client with full REST coverage instead of throwing `NotImplementedError`.
- Bearer-token auth added alongside the dev `X-Aegis-User` header.
- `aegis-sdk-java`: `AegisClientJ` is now a thin pure-Java delegate over the new `javadsl.AegisJavaClient`: `java.util` collections in, wire DTOs out, failures as one `AegisClientException`.

### Production preflight

Closes #99.

- New `Preflight` runs as step 0 of `Server.boot`: cross-checks the bind address against dev-grade settings such as dev auth, dev policy, in-memory crypto, and in-memory journal.
- Loopback binds always pass.
- Non-loopback: `aegis.security.preflight=warn`, the default, prints one banner listing each finding.
- `enforce`, via `AEGIS_SECURITY_PREFLIGHT=enforce`, refuses to boot before any resource is acquired. Recommended for production.
- 8 unit tests cover warn, enforce-abort, loopback-exempt, hardened-pass, and unknown-mode fail-fast.

### Docs + hygiene

- README: banner bumped to v0.2.1 with advisor, SDK row no longer says skeleton, v0.2.1 status bullet, and preflight pointer in Security.
- SECURITY.md: Production preflight subsection added to the deploy-time matrix.
- ROADMAP: v0.2.1 flipped to shipped; new v0.2.2 section; SDK + agent-governance rows updated with issue refs #98, #101, and #102.
- CHANGELOG: Unreleased entries for both features plus the package-move note.
- Filed tracking issues #100–#107 for snapshotting, agent registry, kill-switch, and v1.0.0 rows.
- Milestoned #72.

## Notes for review

- `dev.aegiskms.cli.{AegisHttpClient,WireFormats,HttpPort}` → `dev.aegiskms.sdk.*` is source-breaking only for code importing CLI internals. The CLI surface is unchanged.
- MiMa has no `mimaPreviousArtifacts` baseline, so the SDK redesign trips no gate. Configuring MiMa for real is folded into #104.
- Preflight defaults to `warn`, so `docker run` demos keep working out of the box.

## Testing

- `sbt test` — all modules green. Docker-assumed suites cancel as usual.
- `sbt scalafmtCheckAll scalafmtSbtCheck`
- `sbt "scalafixAll --check"`

Closes #98
Closes #99

Generated with Claude Code.